### PR TITLE
TSV-PRO report

### DIFF
--- a/scripts/output/write_results.py
+++ b/scripts/output/write_results.py
@@ -102,8 +102,12 @@ def tsv_pro_output(seq_matches: dict, output_path: str):
                 except ValueError:
                     version_major = match['version']
                     version_minor = "0"
-                evalue = match["evalue"]
-                score = match["score"]
+                try:  # cdd does not have evalue and score on this level
+                    evalue = match["evalue"]
+                    score = match["score"]
+                except KeyError:
+                    evalue = "-"
+                    score = "-"
 
                 if 'model-ac' in match:
                     model_ac = match['model-ac']


### PR DESCRIPTION
How to test (e.g.):
`nextflow run interproscan.nf --input files_test/mini_test.fasta --applications ncbifam,antifam,sfld,cdd,panther --formats tsv-pro --disable_precalc`

`nextflow run interproscan.nf --input files_test/mini_test.fasta --applications ncbifam,antifam,sfld,cdd,panther --formats tsv-pro`