### PR TITLE
[FIX] Adding intermediate case to MLS fail retries

### DIFF
--- a/interproscan.nf
+++ b/interproscan.nf
@@ -77,6 +77,12 @@ workflow {
         parsed_matches = SEQUENCE_PRECALC.out.parsed_matches
     }
 
+    if (parsed_matches.collect() == null) {
+            // cases in which the lookup check ran successfully but lookup matches not
+            disable_precalc = true
+            log.info "ERROR: unable to connect to match lookup service. Max retries reached. Running analysis locally..."
+        }
+
     analysis_result = Channel.empty()
     if (disable_precalc || sequences_to_analyse) {
         log.info "Running sequence analysis"

--- a/interproscan/subworkflows/sequence_precalc/main.nf
+++ b/interproscan/subworkflows/sequence_precalc/main.nf
@@ -13,7 +13,13 @@ workflow SEQUENCE_PRECALC {
     LOOKUP_MATCHES(LOOKUP_CHECK.out, applications, is_test)
     LOOKUP_NO_MATCHES(LOOKUP_CHECK.out)
 
+    if (LOOKUP_MATCHES.out.isEmpty()) {
+        parsed_matches = null
+    } else {
+        parsed_matches = LOOKUP_MATCHES.out
+    }
+
     emit:
     sequences_to_analyse = LOOKUP_NO_MATCHES.out
-    parsed_matches = LOOKUP_MATCHES.out
+    parsed_matches
 }


### PR DESCRIPTION
Now considering all possible faults and with the correct sequence running -with-timeline o/

PS: I put back the if condition (the one I thought was unnecessary) and adding a null return on parsed_matches to make sure the case is this one when happens