### PR TITLE
Patch result propagation

### DIFF
--- a/interproscan/modules/hamap/main.nf
+++ b/interproscan/modules/hamap/main.nf
@@ -126,13 +126,8 @@ process PARSE_HAMAP {
         Double score = Double.parseDouble(fields[7])
         String alignment = fields[9]
 
-        if (matches.containsKey(sequenceId)) {
-            match = matches[sequenceId]
-        } else {
-            match = new Match(modelAccession)
-            matches.computeIfAbsent(sequenceId, { [:] })
-            matches[sequenceId][modelAccession] = match
-        }
+        match = matches.computeIfAbsent(sequenceId, { [:] })[modelAccession] ?: new Match(modelAccession)
+        matches[sequenceId][modelAccession] = match
 
         Location location = new Location(start, end, score, alignment)
         match.addLocation(location)

--- a/interproscan/modules/sfld/main.nf
+++ b/interproscan/modules/sfld/main.nf
@@ -53,14 +53,14 @@ process PARSE_SFLD {
     val hierarchy_db
 
     output:
-    tuple val(meta), val("sfld.json")
+    tuple val(meta), path("sfld.json")
 
     exec:
     def outputFilePath = task.workDir.resolve("sfld.json")
     def sequences = parseOutput(postprocess_out.toString())
     def hierarchy = parseHierarchy(hierarchy_db.toString())
 
-    sequences = sequences.collectEntries { seqId, matches -> 
+    sequences = sequences.collectEntries { seqId, matches ->
         // Flatten matches (one location per match)
         matches = matches.collectMany { key, match ->
             return match.locations.collect { location ->
@@ -95,13 +95,13 @@ process PARSE_SFLD {
 
                         if (!(l1.start > l2.end || l2.start > l1.end)) {
                             // Matches overlap
-                            
+
                             def otherParents = hierarchy.get(otherMatch.modelAccession)
                             if (otherParents != null && otherParents.contains(match.modelAccession)) {
                                 // Current match overlaps a more specific match: we want to keep the most specific
                                 overlaps = true
                                 break
-                            }    
+                            }
                         }
                     }
 
@@ -162,7 +162,7 @@ process PARSE_SFLD {
                 }
             }
         }
-        
+
         if (selectedMatches.size() > 0) {
             /*
             KEEP THIS BLOCK
@@ -283,7 +283,7 @@ Map<String, Match> parseBlock(Reader reader) {
             Match match = domains.get(modelAccession)
             if (match != null) {
                 Site site = new Site(description, residues)
-                match.addSite(site)                        
+                match.addSite(site)
             }
         }
     }

--- a/interproscan/modules/superfamily/main.nf
+++ b/interproscan/modules/superfamily/main.nf
@@ -50,7 +50,7 @@ process PARSE_SUPERFAMILY {
         String modelId = fields[0]
         String superfamilyAccession = fields[1]
         assert !model2sf.containsKey(modelId)
-        model2sf[modelId] = "SFF${superfamilyAccession}"
+        model2sf[modelId] = "SSF${superfamilyAccession}"
     }
 
     def matches = [:].withDefault { [:] }
@@ -80,7 +80,7 @@ process PARSE_SUPERFAMILY {
                 assert regions.size() >= 1
 
                 // Sort by start/end
-                regions = regions.sort { a, b -> 
+                regions = regions.sort { a, b ->
                     a[0] <=> b[0] ?: a[1] <=> b[1]
                 }
 
@@ -100,7 +100,7 @@ process PARSE_SUPERFAMILY {
                         }
                         fragments.add(new LocationFragment(fragStart, fragEnd, dcStatus))
                     }
-                    
+
                 } else {
                     def (fragStart, fragEnd) = regions[0]
                     fragments.add(new LocationFragment(fragStart, fragEnd, "CONTINUOUS"))

--- a/interproscan/modules/xrefs/main.nf
+++ b/interproscan/modules/xrefs/main.nf
@@ -149,7 +149,17 @@ process XREFS {
                 return [(rawModelAccession): matchObject]
             }]
         }
-        aggregatedMatches.putAll(matches.collect())
+        matches.each { seqId, seqMatches ->
+            if (aggregatedMatches.containsKey(seqId)) {
+                seqMatches.each { rawModelAccession, matchObject ->
+                    if (!aggregatedMatches[seqId].containsKey(rawModelAccession)) {
+                        aggregatedMatches[seqId][rawModelAccession] = matchObject
+                    }
+                }
+            } else {
+                aggregatedMatches[seqId] = seqMatches
+            }
+        }
     }
     def outputFilePath = task.workDir.resolve("matches2xrefs.json")
     def json = JsonOutput.toJson(aggregatedMatches)

--- a/lib/Match.groovy
+++ b/lib/Match.groovy
@@ -57,6 +57,8 @@ class Match implements Serializable {
         match.included = data.included
         match.locations = data.locations.collect { Location.fromMap(it) }
         match.treegrafter = TreeGrafter.fromMap(data.treegrafter)
+        match.signalp = SignalP.fromMap(data.signalp)
+        match.graphScan = data.graphScan
         return match
     }
 
@@ -315,7 +317,7 @@ class Location implements Serializable {
         LocationFragment fragment = new LocationFragment(start, end, "CONTINUOUS")
         this.fragments = [fragment]
     }
-  
+
      Location(int start, int end, Double score, String targetAlignment) { // Used for Hamap, PrositeProfiles
         this.start = start
         this.end = end
@@ -387,13 +389,15 @@ class Location implements Serializable {
         loc.sequenceFeature = data.sequenceFeature
         loc.level = data.level
         loc.cigarAlignment = data.cigarAlignment
+        loc.pvalue = data.pvalue
+        loc.motifNumber = data.motifNumber
         return loc
     }
-      
+
     @Override
     public int hashCode() {
-        return Objects.hash(start, end, hmmStart, hmmEnd, hmmLength, hmmBounds, 
-                            envelopeStart, envelopeEnd, evalue, score, bias, 
+        return Objects.hash(start, end, hmmStart, hmmEnd, hmmLength, hmmBounds,
+                            envelopeStart, envelopeEnd, evalue, score, bias,
                             queryAlignment, targetAlignment, fragments, sites)
     }
 


### PR DESCRIPTION
Some fixes important to write output:
- Adding some (signalp and prints) fields to `fromMap` on Match object (to not lose these informations when create object on xrefs)
- Superfamily acc SSF not SFF (important to get correctly the xrefs info)
- Removing Hamap duplicated mapping verification
- Changing SFLD input json to `path`
- (Most important one) On xrefs the operator putAll was overwriting matches when we have more than one memberDB matches to the same sequence (so, for each sequence, only the matches from the last memberDB processed remained), now we are adding all the matches correctly.