### PR TITLE
Fix diff in reg tests

### DIFF
--- a/tests/regression_tests/test_matches.py
+++ b/tests/regression_tests/test_matches.py
@@ -18,7 +18,7 @@ def main():
     with open(args.observed, "r") as fh:
         observed = flattern_dict(json.load(fh))
 
-    diff = difflib.ndiff(expected, observed)
+    diff = difflib.ndiff(sorted(expected), sorted(observed))
     for line in diff:
         if line.startswith(("-", "+", " ")):  # skip summary lines such as "?    ^^^^  -    ^^  ^ ^"
             try:


### PR DESCRIPTION
When not sorted we have results as:
e.g.:

```
> BA6191E60D52AA485969DD92928859EB      ANF00260        2       72
...
< BA6191E60D52AA485969DD92928859EB      ANF00260        2       72
```

When sorted we have the correct report:
`- BA6191E60D52AA485969DD92928859EB      ANF00260        2       72`


