### PR TITLE
Fix PANTHER when only one sequence is used

### DIFF
--- a/interproscan/modules/panther/main.nf
+++ b/interproscan/modules/panther/main.nf
@@ -29,7 +29,7 @@ process PREPARE_TREEGRAFTER {
 
     output:
     tuple val(meta), path("panther.json"),                             emit: json
-    tuple val(meta), val(sequenceIds), val(familyIds), path(fastas),   emit: fasta
+    tuple val(meta), val(sequenceIds), val(familyIds), val(fastas),    emit: fasta
     
     exec:
     def hmmerMatches = HMMER3.parseOutput(hmmseach_out.toString(), "PANTHER")
@@ -138,7 +138,7 @@ process RUN_TREEGRAFTER {
     label 'small', 'ips6_container'
     
     input:
-    tuple val(meta), val(sequenceIds), val(familyIds), path(fastas)
+    tuple val(meta), val(sequenceIds), val(familyIds), val(fastas)
     path msf_dir
 
     output:


### PR DESCRIPTION
The `path()` operator returns a list of `Path` objects if it matches multiple files, and one single `Path` object if only one is found. If only one sequence is processed, only one PANTHER family can be reported (because we always select the best family so even two families hit the sequence, we only keep the one with the best hit), so `path()` will evaluate to a single Path object. 

However, the output of `PREPARE_TREEGRAFTER` and the input of `RUN_TREEGRAFTER` are expected to include an array of sequence IDs, an array of PANTHER families, and and array of FASTA files.

This PR uses `val()` instead of `path()` to guarantee we always have a list of file paths.

To reproduce the issue, try running PANTHER with an input file containing only one sequence (using the `main` branch).