### PR TITLE
Use accession of parent

### DIFF
--- a/interproscan/modules/sfld/main.nf
+++ b/interproscan/modules/sfld/main.nf
@@ -131,7 +131,7 @@ process PARSE_SFLD {
                 def promotedMatches = parents
                     .findAll { it != match.modelAccession }
                     .collect {
-                        Signature signature = new Signature(match.modelAccession, library)
+                        Signature signature = new Signature(it, library)
                         Match promotedMatch = new Match(it, match.evalue, match.score, match.bias, signature)
                         promotedMatch.addLocation(match.locations[0].clone())
                         return promotedMatch


### PR DESCRIPTION
Minor fix for SFLD where the accession of the _parent_ is used when propagating matches instead of the accession of the child (if creating a new match for the parent, both the model accession and the signature accession should be the one of the parent).