### PR TITLE
Add output format validation

### DIFF
--- a/interproscan/subworkflows/init/main.nf
+++ b/interproscan/subworkflows/init/main.nf
@@ -45,7 +45,7 @@ workflow INIT_PIPELINE {
     }
 
     // Check valid output file formats were provided
-    error = InterProScan.validateFormats(params.formats)
+    (formats, error) = InterProScan.validateFormats(params.formats)
     if (error) {
         log.error error
         exit 1
@@ -80,5 +80,6 @@ workflow INIT_PIPELINE {
     datadir      // str: path to data directory
     apps         // list: list of application to
     outdir       // str: path to output directory
+    formats      // set<String>: output file formats
     signalpMode  // str: Models to be used with SignalP
 }

--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -259,10 +259,10 @@ class InterProScan {
         return errorMsg ? "Could not find the following XREF data files\n${errorMsg.join('\n')}" : null
     }
 
-    static String validateFormats(String userFormats) {
+    static Set<String> validateFormats(String userFormats) {
         Set<String> formats = userFormats.toUpperCase().split(',') as Set
         def invalidFormats = formats - VALID_FORMATS
-        return invalidFormats ? "Invalid output file format provided:\n${invalidFormats.join('\n')}" : null
+        return invalidFormats ? [null, "Invalid output file format provided:\n${invalidFormats.join('\n')}"] : [formats, null]
     }
 
     static List<String> validateSignalpMode(String signalpMode) {

--- a/main.nf
+++ b/main.nf
@@ -30,6 +30,7 @@ workflow {
     fasta_file      = Channel.fromPath(INIT_PIPELINE.out.fasta.val)
     data_dir        = INIT_PIPELINE.out.datadir.val
     outut_dir       = INIT_PIPELINE.out.outdir.val
+    formats         = INIT_PIPELINE.out.formats.val
     apps            = INIT_PIPELINE.out.apps.val
     signalpMode     = INIT_PIPELINE.out.signalpMode.val
 
@@ -115,10 +116,6 @@ workflow {
 
     REPRESENTATIVE_DOMAINS(AGGREGATE_ALL_MATCHES.out)
 
-    Channel.from(params.formats.toLowerCase().split(','))
-    .set { ch_format }
-
-    def formats = params.formats.toUpperCase().split(',') as Set
     def fileName = params.input.split('/').last()
     def outFileName = "${params.outdir}/${fileName}"
     if (formats.contains("JSON")) {


### PR DESCRIPTION
Adds a validation check to the user provided output file formats (`--formats`), and if an invalid format is provided, this is flagged to user and IPS6 terminates instead of running and producing no outputs (as is the current operation on the `main` branch).