### PR TITLE
Validate value following non-boolean options

### DIFF
--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -133,7 +133,14 @@ class InterProScan {
 
             // Convert to kebab-case
             def kebabParamName = this.camelToKebab(paramName)
-            if (!allowedParams.contains(kebabParamName.toLowerCase())) {
+            if (allowedParams.contains(kebabParamName.toLowerCase())) {
+                def paramObj = this.PARAMS.find { it.name.toLowerCase() == kebabParamName.toLowerCase() }
+                assert paramObj != null
+                if (paramObj?.metavar != null && !(paramValue instanceof String)) {
+                    log.error "'--${paramObj.name} ${paramObj.metavar}' is mandatory and cannot be empty."
+                    System.exit(1)
+                }
+            } else {
                 log.warn "Unrecognised option: '--${paramName}'. Try '--help' for more information."
             }
         }


### PR DESCRIPTION
Tiny PR that add a validation for options that expects a value following them, e.g. `--input <expected-value>`.

If an option is used without a value, e.g. `--input` in `--input --applications cdd,pfam`, it resolves to `true` which isn't what we want. In the case of `--input`, InterProScan crashes because the value of `param.input` (`true`) is passed to

https://github.com/ebi-pf-team/interproscan6/blob/6c465277b5e0650bc04baea79664cb1b9732986c/lib/InterProScan.groovy#L153-L156

which expects a `String`, not a `boolean`.