### PR TITLE
Match CDD sites in output

### DIFF
--- a/interproscan/modules/output/json/main.nf
+++ b/interproscan/modules/output/json/main.nf
@@ -134,11 +134,8 @@ process WRITE_JSON_OUTPUT {
                         }
                         if (memberDB == "CDD") {
                             locationResult["sites"] = location.sites?.collect { site ->
-                                site.remove("label")
-                                site.remove("group")
-                                site.remove("hmmStart")
-                                site.remove("hmmEnd")
-                                return site
+                                cddSite = new Site(site.description, site.siteLocations)
+                                return Site.asMap(cddSite, memberDB)
                             } ?: []
                         }
                         matchResult["locations"].add(locationResult)

--- a/lib/Match.groovy
+++ b/lib/Match.groovy
@@ -730,11 +730,11 @@ class Site implements Serializable {
         this.numLocations = siteLocations.size()
 
         for (SiteLocation loc: siteLocations) {
-            if (loc.start == -1 || loc.start < this.start) {
+            if (this.start == -1 || loc.start < this.start) {
                 this.start = loc.start
             }
 
-            if (loc.end == -1 || loc.end > this.end) {
+            if (this.end == -1 || loc.end > this.end) {
                 this.end = loc.end
             }
         }
@@ -771,17 +771,19 @@ class Site implements Serializable {
         return siteLocations
     }
 
-    static Map asMap(Site site) {
+    static Map asMap(Site site, String memberDB = null) {
         if (!site) { return [:] }
         Map siteMap = [
-            "description"   : site.description,
-            "numLocations"  : site.numLocations ?: null,
-            "siteLocations" : site.siteLocations.collect { SiteLocation.asMap(it) }
+                "description"   : site.description,
+                "numLocations"  : site.numLocations ?: null,
+                "siteLocations" : site.siteLocations.collect { SiteLocation.asMap(it) }
         ]
-        if (site.label) {    siteMap["label"]    = site.label }
-        if (site.group) {    siteMap["group"]    = site.group }
-        if (site.hmmStart) { siteMap["hmmStart"] = site.hmmStart }
-        if (site.hmmEnd) {   siteMap["hmmEnd"]   = site.hmmEnd }
+        if (memberDB != "CDD") {
+            if (site.label) { siteMap["label"] = site.label }
+            if (site.group) { siteMap["group"] = site.group }
+            if (site.hmmStart) { siteMap["hmmStart"] = site.hmmStart }
+            if (site.hmmEnd) { siteMap["hmmEnd"] = site.hmmEnd }
+        }
         return siteMap
     }
 


### PR DESCRIPTION
This PR fixes the issue sites not appearing in the final output, and fixes an additional bug:
```
ERROR ~ Error executing process > 'WRITE_JSON_OUTPUT'

Caused by:
  Error occured when writing Json file match-patch/test_prot.fa.ips6.json -- java.lang.Exception: Error parsing JSON file /home/ehobbs/Projects/InterProScan6/work/38/a6c2f0318aaddbd8de4098badf1795/matches_with_representative.json -- groovy.lang.MissingMethodException: No signature of method: Site.remove() is applicable for argument types: (String) values: [label]
  Possible solutions: clone(), getAt(java.lang.String)
  null
  groovy.lang.MissingMethodException: No signature of method: Site.remove() is applicable for argument types: (String) values: [label]
  Possible solutions: clone(), getAt(java.lang.String) -- Check script './interproscan/modules/output/json/main.nf' at line: 44
```

It's not an elegant fix but it is simplified on the `stnd-seq-storage` branch during the refactorising of the JSON and XML writers