### PR TITLE
Add seqs with no matches to the JSON and XML output

### DIFF
--- a/modules/no_matches/main.nf
+++ b/modules/no_matches/main.nf
@@ -1,0 +1,33 @@
+import com.fasterxml.jackson.databind.ObjectMapper
+import groovy.json.JsonOutput
+
+process REPORT_NO_MATCHES {
+    executor 'local'
+
+    input:
+    tuple val(meta), val(member_matches)
+    tuple val(meta), val(fasta)
+
+    output:
+    tuple val(meta), path("no_matches.json")
+
+    exec:
+    def seqsWithMatches = [] as Set
+    member_matches.each { matchesPath ->
+        def matchesFileMap = new ObjectMapper().readValue(new File(matchesPath.toString()), Map)
+        matchesFileMap.each { String seqMd5, Map matches ->
+            seqsWithMatches.add(seqMd5)
+        }
+    }
+
+    Map<String, String> sequences = FastaFile.parse(fasta.toString())  // [md5: sequence]
+    String outputFilePath = task.workDir.resolve("no_matches.json")
+    def noMatches = [:]
+    sequences.each { String seqMd5, String seq ->
+        if (!seqsWithMatches.contains(seqMd5)) {
+            noMatches[seqMd5] = [:]
+        }
+    }
+    def json = JsonOutput.toJson(noMatches)
+    new File(outputFilePath.toString()).write(json)
+}

--- a/subworkflows/scan/main.nf
+++ b/subworkflows/scan/main.nf
@@ -1,23 +1,24 @@
-include { ANTIFAM          } from "../antifam"
-include { CATH             } from "../cath"
-include { CDD              } from "../cdd"
-include { COILS            } from "../coils"
-include { DEEPTMHMM        } from "../deeptmhmm"
-include { HAMAP            } from "../hamap"
-include { MOBIDBLITE       } from "../mobidblite"
-include { NCBIFAM          } from "../ncbifam"
-include { PANTHER          } from "../panther"
-include { PFAM             } from "../pfam"
-include { PHOBIUS          } from "../phobius"
-include { PIRSF            } from "../pirsf"
-include { PIRSR            } from "../pirsr"
-include { PRINTS           } from "../prints"
-include { PROSITE_PATTERNS } from "../prosite/patterns"
-include { PROSITE_PROFILES } from "../prosite/profiles"
-include { SFLD             } from "../sfld"
-include { SIGNALP          } from "../signalp"
-include { SMART            } from "../smart"
-include { SUPERFAMILY      } from "../superfamily"
+include { ANTIFAM           } from "../antifam"
+include { CATH              } from "../cath"
+include { CDD               } from "../cdd"
+include { COILS             } from "../coils"
+include { DEEPTMHMM         } from "../deeptmhmm"
+include { HAMAP             } from "../hamap"
+include { MOBIDBLITE        } from "../mobidblite"
+include { NCBIFAM           } from "../ncbifam"
+include { PANTHER           } from "../panther"
+include { PFAM              } from "../pfam"
+include { PHOBIUS           } from "../phobius"
+include { PIRSF             } from "../pirsf"
+include { PIRSR             } from "../pirsr"
+include { PRINTS            } from "../prints"
+include { PROSITE_PATTERNS  } from "../prosite/patterns"
+include { PROSITE_PROFILES  } from "../prosite/profiles"
+include { SFLD              } from "../sfld"
+include { SIGNALP           } from "../signalp"
+include { SMART             } from "../smart"
+include { SUPERFAMILY       } from "../superfamily"
+include { REPORT_NO_MATCHES } from "../../modules/no_matches"
 
 workflow SCAN_SEQUENCES {
     take:
@@ -127,7 +128,7 @@ workflow SCAN_SEQUENCES {
 
         results = results.mix(PFAM.out)
     }
-    
+
     if (applications.contains("phobius")) {
         PHOBIUS(
             ch_seqs,
@@ -136,7 +137,7 @@ workflow SCAN_SEQUENCES {
         results = results.mix(PHOBIUS.out)
     }
 
-    if (applications.contains("pirsf")) {   
+    if (applications.contains("pirsf")) {
         PIRSF(
             ch_seqs,
             db_releases.pirsf.dirpath,
@@ -247,6 +248,12 @@ workflow SCAN_SEQUENCES {
         .groupTuple()
         .set { grouped_results }
 
+    grouped_results.mix(REPORT_NO_MATCHES(grouped_results, ch_seqs))
+        .groupTuple()
+        .set { all_grouped_results }
+
+    all_grouped_results.view()
+
     emit:
-    grouped_results
+    all_grouped_results
 }

--- a/subworkflows/scan/main.nf
+++ b/subworkflows/scan/main.nf
@@ -248,12 +248,14 @@ workflow SCAN_SEQUENCES {
         .groupTuple()
         .set { grouped_results }
 
-    grouped_results.mix(REPORT_NO_MATCHES(grouped_results, ch_seqs))
-        .groupTuple()
-        .set { all_grouped_results }
+    ch_no_matches = REPORT_NO_MATCHES(grouped_results, ch_seqs)
 
-    all_grouped_results.view()
+    merged_results = grouped_results
+        .join(ch_no_matches)
+        .map { batch_idx, paths_list, no_match_path ->
+            [batch_idx, paths_list + [no_match_path]]
+        }
 
     emit:
-    all_grouped_results
+    merged_results
 }


### PR DESCRIPTION
At the moment IPS6 only reports sequences that have matches in all three output files. This PR adds reporting sequences without matches to the JSON and XML files:
```json
{
"sequence" : "MSSIPSVEVDSSDHVAKNTKTTCPYCGVGCGVSVNVQQKSQGPVVQVEGDAEHPSNFGRLCIKGSRLADTLGLETRVLQPMMGRKADRVVTTWDAAINKIADKFQSCIDQYGRDSIAFYVSGQLLTEDYYVVNKFVKGYLGTANIDTNSRLCMSSAVAGHKRSFGEDIVPASYEDFEHADMVVLVGSNTAWCHPVLYQRIMQAKSQNPDMFVVVIDPRFTSTCEQADLHLPILPGQDVALFNGLFQYLYQNGHADQAFVEAYTEGLQDVLASSHPEADIEYVAKRSGISLDKLQQFFEKFAQTEKVITLFSMGVNQSSQGVNKANSIINCHLLTGKIGKLGAAPFSMTGQPNAMGGREVGGLANMLAAHMDLDNPLHQKVVQTFWDSPFIATQAGLKAVDLFRAVEAGKIKAIWIMATNPVVSLPDADQVKRALEKCELVVVSDICADTDTTAYADILLPALGWGEKDGTVTNSERRISRQRAFLPAPGEAKADWWSVSQVAKKLGFNGFDFANASDIFNEHAALSAQDNADMGMREESNNFRYFNLKGLMNLSTAEYDALQPVQWPVWDKNQDAKAVQQLFGKGQFSHKNAKAKLIPTVAIDPVHAVSEDYPLILNTGRIRDQWHTMTRTGLSPNLTSHRAEPFCEIHPSDALKFGVRDQGLVEVRSKWGCCVLRVTFSSGVRRGQIFAPIHWTEQVASDARIGKVVNPEVDAISGEPEFKHTPVIIQPFYTTWQGVLYIREGYDSHIQESLHHCAWWTKVKMVKTNRYELADRQTFHDTQKNLKSFLPFADETFEWLSIEDISSQLSHSVILKDGIVIASLYIAPPDLLPDRDWVASLFKRERLSALHRKALLAGMPMAATNNDGPLVCSCFKVGKNKIIDVIKTQNITHEKQVTACLKAGGNCGSCLPEIRGLIKACQQEVEV",
"md5" : "0008FBEF8899F159525153FD741BE931",
"matches" : [ ],
"xref" : [ {
  "name" : "tr|A0A009H3H9|A0A009H3H9_9GAMM OX=1310608",
  "id" : "tr|A0A009H3H9|A0A009H3H9_9GAMM"
} ]
},
```
I also double checked it when running with multiple batches to make sure the `no_matches.json` was assigned to the correct batch tuple.

It also works when there are no matches, I tested this with the attached fasta and AntiFam: 
[antifam-no-matches.zip](https://github.com/user-attachments/files/19956296/antifam-no-matches.zip)
