### PR TITLE
Refactor invalid characters check

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ nextflow run ebi-pf-team/interproscan6 \
 > [!WARNING]  
 > DeepTMHMM 1.0 and SignalP 6.0 predictions are not yet available in the [Matches API](https://www.ebi.ac.uk/interpro/matches/api/). The pre-calculated matches lookup needs to be disabled with `--offline`.
 
+> [!WARNING]  
+> Phobius does not support certain non-standard or ambiguous residues. Any sequence containing pyrrolysine (one-letter code `O`), Asx (Asp/Asn ambiguity, `B`), Glx (Glu/Gln ambiguity, `Z`) or Xle (Leu/Ile ambiguity, `J`) will be skipped by Phobius but will continue to be processed normally by all other applications.
+
 > [!NOTE]  
 > Running both `signalp_euk` and `signalp_prok` will execute SignalP twice, once with eukaryotic post-processing and once without. Choose the mode best suited to your dataset.
 

--- a/conf/applications.config
+++ b/conf/applications.config
@@ -2,7 +2,6 @@ params {
     appsConfig {
         antifam {
             name = "AntiFam"
-            invalid_chars = "-"
             dir = "antifam"
             hmm = "AntiFam.hmm"
             has_data = true
@@ -10,7 +9,6 @@ params {
         cathgene3d {
             name = "CATH-Gene3D"
             aliases = ["gene3d"]
-            invalid_chars = "-."
             dir = "cath/gene3d"
             hmm = "gene3d_main.hmm"
             model2sfs = "model_to_family_map.tsv"
@@ -20,7 +18,6 @@ params {
         cathfunfam {
             name = "CATH-FunFam"
             aliases = ["funfam"]
-            invalid_chars = "-."
             dir = "cath/funfam"
             chunkSize = 1000
             has_data = true
@@ -43,7 +40,6 @@ params {
         }
         hamap {
             name = "HAMAP"
-            invalid_chars = "-."
             dir = "hamap"
             hmm = "hamap.hmm.lib"
             profiles = "profiles"
@@ -55,14 +51,12 @@ params {
         }
         ncbifam {
             name = "NCBIFAM"
-            invalid_chars = "-"
             dir = "ncbifam"
             hmm = "ncbifam.hmm"
             has_data = true
         }
         panther {
             name = "PANTHER"
-            invalid_chars = "-"
             dir = "panther"
             hmm = "famhmm/binHmm"
             msf = "Tree_MSF"
@@ -71,13 +65,11 @@ params {
         }
         phobius {
             name = "Phobius"
-            invalid_chars = "-*.OXUZJ"
             dir = ""
             has_data = false
         }
         pfam {
             name = "Pfam"
-            invalid_chars = "-"
             dir = "pfam"
             hmm = "pfam_a.hmm"
             seed = "pfam_a.seed"
@@ -87,7 +79,6 @@ params {
         }
         pirsf {
             name = "PIRSF"
-            invalid_chars = "-"
             dir = "pirsf"
             hmm = "sf_hmm_all"
             dat = "pirsf.dat"
@@ -95,7 +86,6 @@ params {
         }
         pirsr {
             name = "PIRSR"
-            invalid_chars = "-."
             dir = "pirsr"
             hmm = "sr_hmm_all"
             rules = "sr_uru.json"
@@ -117,7 +107,6 @@ params {
         }
         prositeprofiles {
             name = "PROSITE profiles"
-            invalid_chars = "-."
             dir = "prosite"
             profiles = "prosite_profiles"
             skip_flagged_profiles = "skip_flagged_profiles.txt"
@@ -125,7 +114,6 @@ params {
         }
         sfld {
             name = "SFLD"
-            invalid_chars = "-."
             dir = "sfld"
             hmm = "sfld.hmm"
             hierarchy = "sfld_hierarchy.txt"
@@ -142,7 +130,6 @@ params {
         }
         superfamily {
             name = "SUPERFAMILY"
-            invalid_chars = "-"
             dir = "superfamily"
             hmm = "hmmlib_1.75"
             selfhits = "self_hits.tab"

--- a/lib/FastaFile.groovy
+++ b/lib/FastaFile.groovy
@@ -2,7 +2,7 @@
 class FastaFile {
     // DNA, RNA, gaps
     static final String NUCLEIC_ALPHABET = "ACGTUN\\.\\s-"
-    // 20 standard AAs, Sec, Pyl, any/unknown, Asx, Glx, Xle, gaps
+    // 20 standard AAs, Sec, Pyl, any/unknown, Asx, Glx, Xle
     static final String PROTEIN_ALPHABET = "ACDEFGHIKLMNPQRSTVWYUOXBZJ\\s"
 
     static Map<String, String> parse(String fastaFilePath) {

--- a/lib/FastaFile.groovy
+++ b/lib/FastaFile.groovy
@@ -1,3 +1,4 @@
+
 class FastaFile {
     // DNA, RNA, gaps
     static final String NUCLEIC_ALPHABET = "ACGTUN\\.\\s-"
@@ -7,22 +8,108 @@ class FastaFile {
     static Map<String, String> parse(String fastaFilePath) {
         def sequences = [:]
         def md5 = null
-        StringBuilder currentSequence = null
+        StringBuilder builder = null
 
         new File(fastaFilePath).eachLine { line ->
             if (line.startsWith(">")) {
-                if (currentSequence) {
-                    sequences[md5] = currentSequence.toString()
+                if (builder) {
+                    sequences[md5] = builder.toString()
                 }
                 md5 = line.substring(1).trim()
-                currentSequence = new StringBuilder()
+                builder = new StringBuilder()
             } else {
-                currentSequence.append(line.replaceAll("\\s+", ""))
+                builder.append(line.replaceAll("\\s+", ""))
             }
         }
-        if (currentSequence) {
-            sequences[md5] = currentSequence.toString()
+        if (builder) {
+            sequences[md5] = builder.toString()
         }
         return sequences
+    }
+
+    static String validate(String fastaFilePath, boolean isNucleic) {
+        String allowed = isNucleic ? NUCLEIC_ALPHABET : PROTEIN_ALPHABET
+        def pattern = ~"^[${allowed}]+\$"
+        BufferedReader reader = new BufferedReader(new FileReader(fastaFilePath))
+        String seqId
+        String line
+
+        try {
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith(">")) {
+                    seqId = line.substring(1).trim()
+                } else {
+                    String seq = line.replaceAll("\\s+", "")
+                    if (seq.isEmpty()) {
+                        continue
+                    } else if (!pattern.matcher(seq).matches()) {
+                        return seqId
+                    }
+                }
+            }
+        } finally {
+            reader.close()
+        }
+
+        return null
+    }
+
+    static void write(String inputFasta,
+                      String outputFasta,
+                      String extraForbidden,
+                      Map<Character,Character> substitutions) {
+        Set<Character> baseAllowed = PROTEIN_ALPHABET.toList() as Set
+        Set<Character> forbid = extraForbidden.toList() as Set
+
+        new File(inputFasta).withReader { reader ->
+            new File(outputFasta).withWriter { writer ->
+                String header = null
+                StringBuilder builder = new StringBuilder()
+
+                reader.eachLine { line ->
+                    if (line.startsWith(">")) {
+                        if (header) {
+                            processEntry(header, builder, baseAllowed, forbid, substitutions, writer)
+                        }
+                        header = line.trim()
+                        builder = new StringBuilder()
+                    } else {
+                        builder.append(line.replaceAll("\\s+", ""))
+                    }
+                }
+                if (header) {
+                    processEntry(header, builder, baseAllowed, forbid, substitutions, writer)
+                }
+            }
+        }
+    }
+
+    private static void processEntry(String header,
+                                     StringBuilder inSeq,
+                                     Set<Character> baseAllowed,
+                                     Set<Character> forbid,
+                                     Map<Character,Character> substitutions,
+                                     Writer writer) {
+        StringBuilder outSeq = new StringBuilder()
+        boolean ok = true
+
+        inSeq.toString().each { ch ->
+            // substitute if needed
+            if (substitutions.containsKey(ch)) {
+                ch = substitutions[ch]
+            }
+            // check forbidden or outside base alphabet
+            if (forbid.contains(ch) || !baseAllowed.contains(ch)) {
+                ok = false
+                return
+            }
+            outSeq.append(ch)
+        }
+
+        if (ok) {
+            writer.writeLine(header)
+            outSeq.toString()
+                  .eachMatch(/.{1,60}/) { writer.writeLine(it) }
+        }
     }
 }

--- a/lib/FastaFile.groovy
+++ b/lib/FastaFile.groovy
@@ -2,7 +2,7 @@ class FastaFile {
     // DNA, RNA, gaps
     static final String NUCLEIC_ALPHABET = "ACGTUN\\.\\s-"
     // 20 standard AAs, Sec, Pyl, any/unknown, Asx, Glx, Xle, gaps
-    static final String PROTEIN_ALPHABET = "ACDEFGHIKLMNPQRSTVWYUOXBZJ\\.\\s-"
+    static final String PROTEIN_ALPHABET = "ACDEFGHIKLMNPQRSTVWYUOXBZJ\\s"
 
     static Map<String, String> parse(String fastaFilePath) {
         def sequences = [:]

--- a/lib/FastaFile.groovy
+++ b/lib/FastaFile.groovy
@@ -7,20 +7,21 @@ class FastaFile {
     static Map<String, String> parse(String fastaFilePath) {
         def sequences = [:]
         def md5 = null
-        def currentSequence = null
+        StringBuilder currentSequence = null
+
         new File(fastaFilePath).eachLine { line ->
             if (line.startsWith(">")) {
                 if (currentSequence) {
-                    sequences[md5] = currentSequence
+                    sequences[md5] = currentSequence.toString()
                 }
                 md5 = line.substring(1).trim()
-                currentSequence = ""
+                currentSequence = new StringBuilder()
             } else {
-                currentSequence += line.trim()
+                currentSequence.append(line.replaceAll("\\s+", ""))
             }
         }
         if (currentSequence) {
-            sequences[md5] = currentSequence
+            sequences[md5] = currentSequence.toString()
         }
         return sequences
     }

--- a/modules/phobius/main.nf
+++ b/modules/phobius/main.nf
@@ -1,5 +1,22 @@
 import groovy.json.JsonOutput
 
+process WRITE_FASTA {
+    input:
+    tuple val(meta), val(fasta)
+
+    output:
+    tuple val(meta), path("sequences.fasta")
+
+    exec:
+    def outputFilePath = task.workDir.resolve("sequences.fasta")
+    FastaFile.write(
+        fasta.toString(),
+        outputFilePath.toString(),
+        "BJOZ",
+        ["O": "K"]
+    )
+}
+
 process SEARCH_PHOBIUS {
     label       'small'
     stageInMode 'copy'

--- a/modules/phobius/main.nf
+++ b/modules/phobius/main.nf
@@ -13,7 +13,7 @@ process WRITE_FASTA {
         fasta.toString(),
         outputFilePath.toString(),
         "BJOZ",
-        ["O": "K"]
+        [:]
     )
 }
 

--- a/modules/prepare_sequences/main.nf
+++ b/modules/prepare_sequences/main.nf
@@ -1,97 +1,18 @@
 process VALIDATE_FASTA {
     // check the formating of the intput FASTA, i.e. look for illegal characters
     executor      'local'
-    label         'ips6_container'
     errorStrategy 'terminate'
 
     input:
-    path fasta
+    val fasta
     val isNucleic
-    val appsToRun
-    val appsConfig
 
     output:
-    path fasta
-    path "invalid_char_summary"
+    val fasta
+    val seq_id
 
-    script:
-    def commands = ""
-    def checkFile = "invalid_char_check"
-
-    // General illegal character check
-    def alphabet = isNucleic ? FastaFile.NUCLEIC_ALPHABET : FastaFile.PROTEIN_ALPHABET
-    def alphabetName = isNucleic ? "nucleic acid" : "protein"
-    commands += "echo 'Check: General: Tolerated characters: $alphabet' >> $checkFile\n"
-    commands += "grep -vi '^>' $fasta | grep -Eni '[^$alphabet]' >> $checkFile || true\n"
-
-    // Member database illegal specific character checks
-    appsToRun.each { app ->
-        def forbiddenChars = appsConfig[app]?.invalid_chars ?: []
-        forbiddenChars.each { forbiddenChar ->
-            forbiddenChar = forbiddenChar.toString()
-            commands += "echo 'Check: $app $forbiddenChar' >> $checkFile\n"
-            commands += "grep -Eni '^[^>].*[$forbiddenChar${forbiddenChar.toLowerCase()}]' $fasta >> $checkFile || true\n"
-        }
-    }
-
-    """
-    # Run inside the script block to ensure it is run inside the ips6 container which contains grep
-    ${commands}
-
-    touch invalid_char_summary
-
-    # Check if the file has only the "Check" lines (i.e., no grep results, meaning no invalid characters)
-    line_count=\$(wc -l < $checkFile)
-    check_line_count=\$(grep -c "^Check:" $checkFile)
-
-    if [ "\$line_count" -eq "\$check_line_count" ]; then
-        echo "No invalid chars"
-        # Only contains the initial Check lines, no errors found
-        # Do nothing
-        :
-    else
-        echo "Parsing $checkFile"
-        # Build a summary of the invalid characters that were found
-        current_app=""
-        current_char=""
-
-        while IFS= read -r line; do
-            if [[ \$line == Check:* ]]; then
-                # Extract app info - for general check or specific app check
-                if [[ \$line == *"Tolerated characters:"* ]]; then
-                    current_app="general"
-                    current_char=""
-                else
-                    # For app-specific checks like "Check: antifam -"
-                    current_app=\$(echo "\$line" | awk '{print \$2}')
-                    current_char=\$(echo "\$line" | awk '{print \$3}')
-                fi
-
-                # Reset line number collection for new check
-                line_nums=""
-            elif [[ \$line =~ ^[0-9]+: ]]; then
-                # Extract line number from grep output
-                line_num=\$(echo "\$line" | grep -o '^[0-9]*')
-
-                # Append to line numbers for this check
-                if [ -z "\$line_nums" ]; then
-                    line_nums="\$line_num"
-                else
-                    line_nums="\$line_nums, \$line_num"
-                fi
-
-                # Write to summary when we have line numbers
-                if [ -n "\$current_app" ] && [ -n "\$line_nums" ]; then
-                    if [ -n "\$current_char" ]; then
-                        echo "\$current_app forbidden character '\$current_char' found on lines: \$line_nums" >> invalid_char_summary
-                    else
-                        echo "\$current_app forbidden character(s) found on lines: \$line_nums" >> invalid_char_summary
-                    fi
-                fi
-            fi
-        done < $checkFile
-    fi
-    """
+    exec:
+    seq_id = FastaFile.validate(fasta.toString(), isNucleic)
 }
 
 process LOAD_SEQUENCES {

--- a/subworkflows/phobius/main.nf
+++ b/subworkflows/phobius/main.nf
@@ -1,4 +1,4 @@
-include { SEARCH_PHOBIUS; PARSE_PHOBIUS } from  "../../modules/phobius"
+include { WRITE_FASTA; SEARCH_PHOBIUS; PARSE_PHOBIUS } from  "../../modules/phobius"
 
 workflow PHOBIUS {
     take:
@@ -6,8 +6,10 @@ workflow PHOBIUS {
     phobius_dir
 
     main:
+    WRITE_FASTA(ch_seqs)
+
     SEARCH_PHOBIUS(
-        ch_seqs,
+        WRITE_FASTA.out,
         phobius_dir
     )
 


### PR DESCRIPTION
This PR simplifies the input FASTA validation step by replacing the separate invalid‐character lists in each application with a single, generalised alphabet. Since most InterProScan applications do not allow hyphens (`-`) or periods (`.`) as gap symbols, this PR rejects any protein FASTA that has special characters. The validation is done in Groovy and runs reasonably fast (0.6 secs for ~20k sequences).

Phobius is a thorn in the side. It doesn't support some rare (e.g. pyrrolysine) or ambiguous (e.g. Xle: leucine/isoleucine ambiguity) amino acids. This PR adds a Phobius‐specific pre-processing step: any pyrrolysine residue is converted to lysine, and if any other unsupported amino acid is encountered, the entire sequence is omitted for Phobius.

**Example**

This test uses three sequences:

- `A0A001`: the original sequence of [A0A001](https://www.uniprot.org/uniprotkb/A0A001/entry)
- `A0A001_PYL`: sequence with one lysine replaced with a pyrrolysine, which would make Phobius fail
- `A0A001_EXTRA_XLE`: sequence with on extra Xle (`J`), which would make Phobius fail

<details>
<summary>A0A001-test.faa</summary>

```fasta
>A0A001
MLRGSARTYWTLTGLWVLLRAGTLVVGLLFQRLFDALGAGGGVWLIIALVAAIEAGRLFL
QFGVMINRLEPRVQYGTTARLRHALLGSALRGSEVTARTSPGESLRTVGEDVDETGFFVA
WAPTNLAHWLFVAASVTVMMRIDAVVTGALLALLVLLTLVTALAHSRFLRHRRATRAASG
EVAGALREMVGAVGAVQAAAAEPQVAAHVAGLNGARAEAAVREELYAVVQRTVIGNPAPI
GVGVVLLLVAGRMDEGTFSVGDLALFAFYLQILTEALGSIGMLSVRLQRVSVALGRITNN
LGCRLRRSLERASPPIASDAPGGTGEGAAAPDAGPEPAPPLRELAVRGLTARHPGAGHGI
EDVDLVVERHTVTVVTGRVGSGKSTLVRAVLGLLPHERGTVLWNGEPIADPASFLVAPRC
GYTPQVPCLFSGTVRENVLLGRDGAAFDEAVRLAVAEPDLAAMQDGPDTVVGPRGLRLSG
GQIQRVAIARMLVGDPELVVLDDVSSALDPETEHLLWERLLDGTRTVLAVSHRPALLRAA
DRVVVLEGGRVEASGTFEEVMAVSAEMGRIWTGAGPGGGDAGPAPQSPPAG
>A0A001_PYL
MLRGSARTYWTLTGLWVLLRAGTLVVGLLFQRLFDALGAGGGVWLIIALVAAIEAGRLFL
QFGVMINRLEPRVQYGTTARLRHALLGSALRGSEVTARTSPGESLRTVGEDVDETGFFVA
WAPTNLAHWLFVAASVTVMMRIDAVVTGALLALLVLLTLVTALAHSRFLRHRRATRAASG
EVAGALREMVGAVGAVQAAAAEPQVAAHVAGLNGARAEAAVREELYAVVQRTVIGNPAPI
GVGVVLLLVAGRMDEGTFSVGDLALFAFYLQILTEALGSIGMLSVRLQRVSVALGRITNN
LGCRLRRSLERASPPIASDAPGGTGEGAAAPDAGPEPAPPLRELAVRGLTARHPGAGHGI
EDVDLVVERHTVTVVTGRVGSGOSTLVRAVLGLLPHERGTVLWNGEPIADPASFLVAPRC
GYTPQVPCLFSGTVRENVLLGRDGAAFDEAVRLAVAEPDLAAMQDGPDTVVGPRGLRLSG
GQIQRVAIARMLVGDPELVVLDDVSSALDPETEHLLWERLLDGTRTVLAVSHRPALLRAA
DRVVVLEGGRVEASGTFEEVMAVSAEMGRIWTGAGPGGGDAGPAPQSPPAG
>A0A001_EXTRA_XLE
MLRGSARTYWTLTGLWVLLRAGTLVVGLLFQRLFDALGAGGGVWLIIALVAAIEAGRLFL
QFGVMINRLEPRVQYGTTARLRHALLGSALRGSEVTARTSPGESLRTVGEDVDETGFFVA
WAPTNLAHWLFVAASVTVMMRIDAVVTGALLALLVLLTLVTALAHSRFLRHRRATRAASG
EVAGALREMVGAVGAVQAAAAEPQVAAHVAGLNGARAEAAVREELYAVVQRTVIGNPAPI
GVGVVLLLVAGRMDEGTFSVGDLALFAFYLQILTEALGSIGMLSVRLQRVSVALGRITNN
LGCRLRRSLERASPPIASDAPGGTGEGAAAPDAGPEPAPPLRELAVRGLTARHPGAGHGI
EDVDLVVERHTVTVVTGRVGSGKSTLVRAVLGLLPHERGTVLWNGEPIADPASFLVAPRC
GYTPQVPCLFSGTVRENVLLGRDGAAFDEAVRLAVAEPDLAAMQDGPDTVVGPRGLRLSG
GQIQRVAIARMLVGDPELVVLDDVSSALDPETEHLLWERLLDGTRTVLAVSHRPALLRAA
DRVVVLEGGRVEASGTFEEVMAVSAEMGRIWTGAGPGGGDAGPAPQSPPAGJ
```
</details>

```sh
nextflow run ebi-pf-team/interproscan6 \
    -r 4ff5597 \
    -c licensed.conf \
    -profile docker \
    --input A0A001-test.faa \
    --datadir data \
    --interpro 105.0 \
    --applications phobius,pfam \
    --offline
```

What happens:

- `A0A001`: Pfam and Phobius matches reported
- `A0A001_PYL`: pyrrolysine replaced by lysine, so Phobius doesn't crash: Pfam and Phobius matches reported
- `A0A001_EXTRA_XLE`: skipped by Phobius, but Pfam matches reported