### PR TITLE
Add PIRSR version

### DIFF
--- a/modules/xrefs/main.nf
+++ b/modules/xrefs/main.nf
@@ -49,6 +49,8 @@ process XREFS {
                     def version = (match.signature.signatureLibraryRelease.version == "null") ? null : match.signature.signatureLibraryRelease.version
                     if (!version && signatureInfo != null) {
                         match.signature.signatureLibraryRelease.version = databaseInfo[signatureInfo["database"]]
+                    } else if (match.signature.signatureLibraryRelease.library == "PIRSR") {
+                        match.signature.signatureLibraryRelease.version = databaseInfo["PIRSR"]
                     }
 
                     // Handle PANTHER data


### PR DESCRIPTION
This is a tiny PR to add the version to PIRSR matches. Since PIRSR doesn't have proper _signatures_, the lookup in `entries.json` returns nothing during the `XREFS` step, which led the PIRSR matches to lack the version.