### PR TITLE
Fix maxWorkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Explanation of parameters:
 * `--datadir data`: use `data` as the directory for storing all required databases; created automatically if needed
 * `--interpro latest`: fetch the most recent InterPro release
 * `--download`: download any missing metadata and database files
+* `--maxWorkers` - Maximum number of workers available for the `InterProScan` when running locally
+
+> [!IMPORTANT]
+> *--maxWorkers* only applies when using the `local` profile (i.e. `-profile local`), it does **_not_** apply when running on a cluster.
+> IPS6 will always use a minimum or 2 CPUs, with at least 1 dedicated to the main workflow and 1 to run
+> processes (exception for PRINTS member, which require 2 CPUs to run processes).
 
 After completion, you’ll find three output files in your working directory:
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Explanation of parameters:
 * `--datadir data`: use `data` as the directory for storing all required databases; created automatically if needed
 * `--interpro latest`: fetch the most recent InterPro release
 * `--download`: download any missing metadata and database files
-* `--maxWorkers` - Maximum number of workers available for the `InterProScan` when running locally
+* `--max-workers` - Maximum number of workers available for the `InterProScan` when running locally
 
 > [!IMPORTANT]
-> *--maxWorkers* only applies when using the `local` profile (i.e. `-profile local`), it does **_not_** apply when running on a cluster.
+> *--max-workers* only applies when using the `local` profile (i.e. `-profile local`), it does **_not_** apply when running on a cluster.
 > IPS6 will always use a minimum or 2 CPUs, with at least 1 dedicated to the main workflow and 1 to run
 > processes (exception for PRINTS member, which require 2 CPUs to run processes).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Explanation of parameters:
 * `--datadir data`: use `data` as the directory for storing all required databases; created automatically if needed
 * `--interpro latest`: fetch the most recent InterPro release
 * `--download`: download any missing metadata and database files
-* `--max-workers` - Maximum number of workers available for the `InterProScan` when running locally
+* `--max-workers`: Maximum number of workers available for the `InterProScan` when running locally
 
 > [!IMPORTANT]
 > *--max-workers* only applies when using the `local` profile (i.e. `-profile local`), it does **_not_** apply when running on a cluster.

--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -2,9 +2,9 @@ executor {
     name = 'local'
     exitReadTimeout = '5 min'
     submitRateLimit = '1/1sec'
-    // if (params.maxWorkers != null) {
-    //     maxWorkers = params.maxWorkers
-    // }
+    if (params.maxWorkers != null) {
+         cpus = params.maxWorkers
+    }
 }
 
 process {


### PR DESCRIPTION
Max workers working to local now (the parameter we need to change is [cpu](https://www.nextflow.io/docs/latest/executor.html#local) )

How to test:
`nextflow run main.nf --offline --input /hps/nobackup/agb/interpro/lcf/interproscan6/3000.fasta -with-trace -with-report -with-timeline -profile singularity --datadir /hps/nobackup/agb/interpro/lcf/data -work-dir /hps/nobackup/agb/interpro/lcf/work --formats json --outdir /hps/nobackup/agb/interpro/lcf/ --batchSize 500 --maxWorkers 1 --applications cdd,antifam,coils`

My tests:
/hps/nobackup/agb/interpro/lcf/interproscan6/timeline-20250506-43336620.html (--maxWorkers 1)
/hps/nobackup/agb/interpro/lcf/interproscan6/timeline-20250506-43038005.html (--maxWorkers 16)


