### PR TITLE
Skip matches without locations

### DIFF
--- a/lib/HMMER2.groovy
+++ b/lib/HMMER2.groovy
@@ -125,6 +125,14 @@ class HMMER2 {
             }                
         }
 
+        // Remove matches without locations, 
+        hits.entrySet().removeIf { Map.Entry<String,Map<String,Match>> targetEntry ->
+            targetEntry.value.entrySet().removeIf { Map.Entry<String,Match> matchEntry ->
+                matchEntry.value.locations.isEmpty()
+            }
+            targetEntry.value.isEmpty()
+        }
+
         return hits
     }
 

--- a/lib/HMMER3.groovy
+++ b/lib/HMMER3.groovy
@@ -202,6 +202,14 @@ class HMMER3 {
             }                
         }
 
+        // Remove matches without locations, 
+        hits.entrySet().removeIf { Map.Entry<String,Map<String,Match>> targetEntry ->
+            targetEntry.value.entrySet().removeIf { Map.Entry<String,Match> matchEntry ->
+                matchEntry.value.locations.isEmpty()
+            }
+            targetEntry.value.isEmpty()
+        }
+
         return hits
     }
 


### PR DESCRIPTION
This PR ensures that no matches without locations are returned by `HMMER2.parseOutput()` and `HMMER3.parseOutput()`.

Example for [Q6ZN19](https://www.uniprot.org/uniprotkb/Q6ZN19/entry):

```
Query:       rubre_like_arch  [M=34]
Accession:   NF033497.1
Description: rubrerythrin-like domain
Scores for complete sequences (score includes all domains):
   --- full sequence ---   --- best 1 domain ---    -#dom-
    E-value  score  bias    E-value  score  bias    exp  N  Sequence                         Description
    ------- ------ -----    ------- ------ -----   ---- --  --------                         -----------
    2.6e-09   47.9  77.8      1e+04    7.6   0.1   19.9  0  BC24DF9DE045BAF54F367532AE28FD75  


Domain annotation for each sequence (and alignments):
>> BC24DF9DE045BAF54F367532AE28FD75  
   [No individual domains that satisfy reporting thresholds (although complete target did)]
```

Two NCBIFAM matches are found, but without individual domains.