### PR TITLE
Improve performance

### DIFF
--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -28,7 +28,7 @@ process {
         time = { 3.hour * task.attempt }
     }
     withLabel:'large' {
-        cpus = 1
+        cpus = { 1 * task.attempt }
         memory = { 12.GB * task.attempt }
         time = { 4.hour * task.attempt }
     }

--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -28,7 +28,7 @@ process {
         time = { 3.hour * task.attempt }
     }
     withLabel:'large' {
-        cpus = { 2 * task.attempt }
+        cpus = 1
         memory = { 12.GB * task.attempt }
         time = { 4.hour * task.attempt }
     }

--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -4,6 +4,7 @@ import HierarchyEntry
 
 process RUN_PRINTS {
     label 'large'
+    cpus 1
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -4,7 +4,6 @@ import HierarchyEntry
 
 process RUN_PRINTS {
     label 'large'
-    cpus 1
 
     input:
     tuple val(meta), path(fasta)

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ params {
     signalpGPU            = false
     interpro              = "latest"
     download              = false
-    batchSize             = 15000
+    batchSize             = 5000
     maxWorkers            = null
     matchesApiUrl         = "https://www.ebi.ac.uk/interpro/matches/api"
     matchesApiChunkSize   = 100


### PR DESCRIPTION
Changing default batchSize to one (keep the memory consumption reasonable and avoid time retries - see [this doc](https://docs.google.com/spreadsheets/d/1ieGANRzIDFtDuo37rg-qVd0-fCnJ-o_p-N0zS2mc1vY/edit?gid=1679019293#gid=1679019293))

Adding `cpus 1` to RUN_PRINTS process due to the high memory consume of this process. 
PS: despite the `label large` on RUN_PRINTS process, in Nextflow when the resource is defined directly in the process, [it have priority](https://www.nextflow.io/docs/latest/config.html#process-configuration) over those in the configuration file, so the number of cpus for this process will be always 1.