### PR TITLE
PANTHER GO cross-references

### DIFF
--- a/lib/Match.groovy
+++ b/lib/Match.groovy
@@ -668,6 +668,7 @@ class TreeGrafter implements Serializable {
     String subfamilyName
     String subfamilyDescription
     String proteinClass
+    List<GoXRefs> goXRefs = []
 
     TreeGrafter(String ancestralNodeID) {
         this.ancestralNodeID = ancestralNodeID
@@ -683,7 +684,12 @@ class TreeGrafter implements Serializable {
         tg.subfamilyName = data.subfamilyName
         tg.subfamilyDescription = data.subfamilyDescription
         tg.proteinClass = data.proteinClass
+        tg.goXRefs = data.goXRefs.collect { GoXRefs.fromMap(it) }
         return tg
+    }
+
+    void addGoXRefs(GoXRefs go) {
+        this.goXRefs.add(go)
     }
 }
 

--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -319,12 +319,13 @@ def writeMobiDBlite(Map match, JsonGenerator jsonWriter) {
 def writePANTHER(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
         "signature"   : match.signature,
-        "model-ac"    : match.modelAccession,
+        "model-ac"    : match.treegrafter.subfamilyAccession ?: match.modelAccession,
         "name"        : match.treegrafter.subfamilyDescription,
         "evalue"      : match.evalue,
         "score"       : match.score,
         "proteinClass": match.treegrafter.proteinClass,
         "graftPoint"  : match.treegrafter.graftPoint,
+        "goXRefs"     : match.treegrafter.goXRefs,
         "locations"   : match.locations.collect { loc ->
             [
                 "start"             : loc.start,

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -202,7 +202,20 @@ def addMatchNode(String proteinMd5, Map match, def xml) {
             )
         }
 
-        xml."model-ac"(memberDB == "panther" ? match.treegrafter.subfamilyAccession : match.modelAccession)
+        if (memberDB == "panther") {
+            xml."model-ac"(match.treegrafter.subfamilyAccession ?: match.modelAccession)
+            match.treegrafter.goXRefs.each { goXref ->
+                xml."go-xref"(
+                    category: goXref.category,
+                    db: goXref.databaseName,
+                    id: goXref.id,
+                    name: goXref.name
+                )
+            }
+        } else {
+            xml."model-ac"(match.modelAccession)
+        }
+
         addLocationNodes(memberDB, proteinMd5, match, xml)
     }
 }


### PR DESCRIPTION
Report PANTHER/TreeGrafter GO cross-references, like InterProScan 5.

(You need to run InterProScan 6 with `--goterms`)