### PR TITLE
Increase SEARCH_FUNFAM process time

### DIFF
--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -32,4 +32,7 @@ process {
         memory = { 12.GB * task.attempt }
         time = { 6.hour * task.attempt }
     }
+    withName: 'SEARCH_FUNFAM' {
+        time = { 6.hour * task.attempt }
+    }
 }

--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -30,6 +30,6 @@ process {
     withLabel:'large' {
         cpus = { 1 * task.attempt }
         memory = { 12.GB * task.attempt }
-        time = { 4.hour * task.attempt }
+        time = { 6.hour * task.attempt }
     }
 }

--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -30,7 +30,7 @@ process {
     withLabel:'large' {
         cpus = { 1 * task.attempt }
         memory = { 12.GB * task.attempt }
-        time = { 6.hour * task.attempt }
+        time = { 4.hour * task.attempt }
     }
     withName: 'SEARCH_FUNFAM' {
         time = { 6.hour * task.attempt }

--- a/modules/cath/funfam/main.nf
+++ b/modules/cath/funfam/main.nf
@@ -39,7 +39,7 @@ process PREPARE_FUNFAM {
 }
 
 process SEARCH_FUNFAM {
-    label 'medium', 'ips6_container'
+    label 'large', 'ips6_container'
 
     input:
     tuple val(meta), path(fasta), val(supfams)

--- a/modules/cath/funfam/main.nf
+++ b/modules/cath/funfam/main.nf
@@ -39,7 +39,7 @@ process PREPARE_FUNFAM {
 }
 
 process SEARCH_FUNFAM {
-    label 'large', 'ips6_container'
+    label 'medium', 'ips6_container'
 
     input:
     tuple val(meta), path(fasta), val(supfams)


### PR DESCRIPTION
Now we can run SwissProt fasta locally without time failure. Max duration for SEARCH_FUNFAM was 3h 17m (report on /hps/nobackup/agb/interpro/lcf/interproscan6/report-20250509-40608154.html)