### PR TITLE
Update resource requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.DS_Store
 .idea/
 .nextflow*
+.vscode/
 *__pycache__*
 tests/integration_tests/test_outputs/current_output.json
 tests/integration_tests/test_outputs/current_output.tsv-pro

--- a/README.md
+++ b/README.md
@@ -37,17 +37,14 @@ nextflow run ebi-pf-team/interproscan6 \
 Explanation of parameters:
 
 * `-profile test,docker`:
-  * `test`: use an included example FASTA file
-  * `docker`: execute tasks in Docker containers
-* `--datadir data`: use `data` as the directory for storing all required databases; created automatically if needed
-* `--interpro latest`: fetch the most recent InterPro release
-* `--download`: download any missing metadata and database files
-* `--max-workers`: Maximum number of workers available for the `InterProScan` when running locally
+  * `test`: Use an included example FASTA file.
+  * `docker`: Execute tasks in Docker containers.
+* `--datadir data`: Specify `data` as the directory for storing all required InterPro and member database files. The directory is created automatically if it doesn't exist.
+* `--interpro latest`: Use the most recent InterPro release.
+* `--download`: Download any missing metadata and database files into the specified `--datadir`
 
-> [!IMPORTANT]
-> *--max-workers* only applies when using the `local` profile (i.e. `-profile local`), it does **_not_** apply when running on a cluster.
-> IPS6 will always use a minimum or 2 CPUs, with at least 1 dedicated to the main workflow and 1 to run
-> processes (exception for PRINTS member, which require 2 CPUs to run processes).
+> [!TIP]
+> To use a specific version of InterPro, use the release number, e.g. `--interpro 105.0`.
 
 After completion, you’ll find three output files in your working directory:
 
@@ -65,7 +62,6 @@ To annotate your own sequences FASTA file, omit the `test` profile and specify `
 nextflow run ebi-pf-team/interproscan6 \
   -profile docker \
   --datadir data \
-  --interpro latest \
   --input /path/to/sequences.fasta
 ```
 
@@ -75,7 +71,6 @@ For nucleotide sequences, add `--nucleic`:
 nextflow run ebi-pf-team/interproscan6 \
   -profile docker \
   --datadir data \
-  --interpro latest \
   --input /path/to/sequences.fna \
   --nucleic
 ```
@@ -88,11 +83,10 @@ To run only certain analyses (for example, Pfam and MobiDB‑lite):
 nextflow run ebi-pf-team/interproscan6 \
   -profile test,docker \
   --datadir data \
-  --interpro latest \
   --applications Pfam,MobiDB-lite
 ```
 
-Analyses are case‑insensitive and ignore hyphens, so `MobiDB-lite` and `mobidblite` both work.
+Analyses are case‑insensitive and ignore hyphens, so both `MobiDB-lite` and `mobidblite` work.
 
 The available analyses are:
 

--- a/conf/applications.config
+++ b/conf/applications.config
@@ -19,7 +19,6 @@ params {
             name = "CATH-FunFam"
             aliases = ["funfam"]
             dir = "cath/funfam"
-            chunkSize = 1000
             has_data = true
         }        
         cdd {

--- a/conf/applications.config
+++ b/conf/applications.config
@@ -19,7 +19,7 @@ params {
             name = "CATH-FunFam"
             aliases = ["funfam"]
             dir = "cath/funfam"
-            chunkSize = 1000
+            chunkSize = 100
             has_data = true
         }        
         cdd {

--- a/conf/applications.config
+++ b/conf/applications.config
@@ -19,7 +19,7 @@ params {
             name = "CATH-FunFam"
             aliases = ["funfam"]
             dir = "cath/funfam"
-            chunkSize = 100
+            chunkSize = 1000
             has_data = true
         }        
         cdd {

--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -3,7 +3,7 @@ executor {
     exitReadTimeout = '5 min'
     submitRateLimit = '1/1sec'
     if (params.maxWorkers != null) {
-         cpus = params.maxWorkers
+        cpus = params.maxWorkers
     }
 }
 
@@ -12,24 +12,39 @@ process {
     maxRetries      = 3
     errorStrategy   = { task.exitStatus in ((130..145) + 104 + 1 + 9 + 97 + 0) ? "retry" : "finish" }
     // afterScript     = 'sleep 60'  // to avoid fail when using storeDir for missing output
-    withLabel:'tiny' {
-        cpus = { 1 * task.attempt }
+    withLabel: 'mini' {
+        cpus   = { 1    * task.attempt }
+        memory = { 1.GB * task.attempt }
+        time   = { 1.h  * task.attempt }
+    }
+    withLabel: 'tiny' {
+        cpus   = { 1    * task.attempt }
         memory = { 2.GB * task.attempt }
-        time = { 2.hour * task.attempt }
+        time   = { 2.h  * task.attempt }
     }
-    withLabel:'small' {
-        cpus = { 1 * task.attempt }
+    withLabel: 'small' {
+        cpus   = { 1    * task.attempt }
+        memory = { 3.GB * task.attempt }
+        time   = { 3.h  * task.attempt }
+    }
+    withLabel: 'medium' {
+        cpus   = { 1    * task.attempt }
         memory = { 4.GB * task.attempt }
-        time = { 2.hour * task.attempt }
+        time   = { 4.h  * task.attempt }
     }
-    withLabel:'medium' {
-        cpus = { 1 * task.attempt }
-        memory = { 8.GB * task.attempt }
-        time = { 3.hour * task.attempt }
-    }
-    withLabel:'large' {
-        cpus = { 1 * task.attempt }
+    withLabel: 'large' {
+        cpus   = { 1     * task.attempt }
         memory = { 12.GB * task.attempt }
-        time = { 4.hour * task.attempt }
+        time   = { 4.h * task.attempt }
+    }
+    withName: 'SEARCH_PANTHER' {
+        memory = { 2.GB * task.attempt }
+        time   = { 3.h  * task.attempt }
+    }
+    withName: 'SEARCH_GENE3D' {
+        time   = { 3.h  * task.attempt }
+    }
+    withName: 'SEARCH_FUNFAM' {
+        time   = { 4.h  * task.attempt }
     }
 }

--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -41,9 +41,6 @@ process {
         memory = { 2.GB * task.attempt }
         time   = { 3.h  * task.attempt }
     }
-    withName: 'SEARCH_GENE3D' {
-        time   = { 3.h  * task.attempt }
-    }
     withName: 'SEARCH_FUNFAM' {
         time   = { 4.h  * task.attempt }
     }

--- a/modules/cath/funfam/main.nf
+++ b/modules/cath/funfam/main.nf
@@ -65,7 +65,7 @@ process SEARCH_FUNFAM {
 }
 
 process RESOLVE_FUNFAM {
-    label 'small', 'ips6_container'
+    label 'tiny', 'ips6_container'
 
     input:
     tuple val(meta), path(hmmseach_out)

--- a/modules/cath/funfam/main.nf
+++ b/modules/cath/funfam/main.nf
@@ -5,11 +5,11 @@ process PREPARE_FUNFAM {
     executor 'local'
 
     input:
-    tuple val(meta), val(cathgene3d_json)
+    tuple val(meta), val(meta2), val(cathgene3d_json)
     val root_dir
 
     output:
-    tuple val(meta), val(funfams)
+    tuple val(meta), val(meta2), val(funfams)
     
     exec:
     File jsonFile = new File(cathgene3d_json.toString())
@@ -42,11 +42,11 @@ process SEARCH_FUNFAM {
     label 'medium', 'ips6_container'
 
     input:
-    tuple val(meta), path(fasta), val(supfams)
+    tuple val(meta), val(meta2), path(fasta), val(supfams)
     path root_dir
 
     output:
-    tuple val(meta), path("hmmsearch.out")
+    tuple val(meta), val(meta2), path("hmmsearch.out")
 
     script:
     def commands = ""
@@ -68,10 +68,10 @@ process RESOLVE_FUNFAM {
     label 'tiny', 'ips6_container'
 
     input:
-    tuple val(meta), path(hmmseach_out)
+    tuple val(meta), val(meta2), path(hmmseach_out)
 
     output:
-    tuple val(meta), path("resolved.out")
+    tuple val(meta), val(meta2), path("resolved.out")
 
     script:
     """
@@ -89,10 +89,10 @@ process PARSE_FUNFAM {
     executor 'local'
 
     input:
-    tuple val(meta), val(hmmseach_out), val(resolved_tsv)
+    tuple val(meta), val(meta2), val(hmmseach_out), val(resolved_tsv)
 
     output:
-    tuple val(meta), path("cathfunfam.json")
+    tuple val(meta), val(meta2), path("cathfunfam.json")
 
     exec:
     def memberDb = "CATH-FunFam"

--- a/modules/cath/gene3d/main.nf
+++ b/modules/cath/gene3d/main.nf
@@ -1,13 +1,33 @@
 import groovy.json.JsonOutput
 
+process SEARCH_GENE3D {
+    label 'small', 'ips6_container'
+
+    input:
+    tuple val(meta), val(meta2), path(fasta)
+    path hmmdir
+    val hmmfile
+
+    output:
+    tuple val(meta), val(meta2), path("hmmsearch.out")
+
+    script:
+    """
+    /opt/hmmer3/bin/hmmsearch \
+        -Z 65245 -E 0.001 \
+        --cpu ${task.cpus} \
+        ${hmmdir}/${hmmfile} ${fasta} > hmmsearch.out
+    """
+}
+
 process RESOLVE_GENE3D {
     label 'tiny', 'ips6_container'
 
     input:
-    tuple val(meta), path(hmmseach_out)
+    tuple val(meta), val(meta2), path(hmmseach_out)
 
     output:
-    tuple val(meta), path("resolved.out")
+    tuple val(meta), val(meta2), path("resolved.out")
 
     script:
     """
@@ -24,13 +44,13 @@ process ASSIGN_CATH {
     label 'tiny', 'ips6_container'
 
     input:
-    tuple val(meta), path(cath_resolve_out)
+    tuple val(meta), val(meta2), path(cath_resolve_out)
     path dirpath
     val dom2fam
     val disc_pickle
 
     output:
-    tuple val(meta), path("cath.tsv")
+    tuple val(meta), val(meta2), path("cath.tsv")
 
     script:
     """
@@ -46,10 +66,10 @@ process PARSE_CATHGENE3D {
     executor 'local'
 
     input:
-    tuple val(meta), val(hmmseach_out), val(cath_tsv)
+    tuple val(meta), val(meta2), val(hmmseach_out), val(cath_tsv)
 
     output:
-    tuple val(meta), path("cathgene3d.json")
+    tuple val(meta), val(meta2), path("cathgene3d.json")
 
     exec:
     def memberDb = "CATH-Gene3D"

--- a/modules/cath/gene3d/main.nf
+++ b/modules/cath/gene3d/main.nf
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 process RESOLVE_GENE3D {
-    label 'small', 'ips6_container'
+    label 'tiny', 'ips6_container'
 
     input:
     tuple val(meta), path(hmmseach_out)
@@ -21,7 +21,7 @@ process RESOLVE_GENE3D {
 }
 
 process ASSIGN_CATH {
-    label 'small', 'ips6_container'
+    label 'tiny', 'ips6_container'
 
     input:
     tuple val(meta), path(cath_resolve_out)

--- a/modules/cdd/main.nf
+++ b/modules/cdd/main.nf
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 process RUN_RPSBLAST {
-    label 'small', 'ips6_container'
+    label 'mini', 'ips6_container'
 
     input:
     tuple val(meta), path(fasta)
@@ -35,7 +35,7 @@ process RUN_RPSPROC {
     processes dumped datafiles to obtain required information. All data files
     are downloadable from NCBI ftp site. Read README file for details
     */
-    label 'small', 'ips6_container'
+    label 'mini', 'ips6_container'
 
     input:
     tuple val(meta), val(rpsblast_out)

--- a/modules/coils/main.nf
+++ b/modules/coils/main.nf
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 process RUN_COILS {
-    label 'small', 'ips6_container'
+    label 'mini', 'ips6_container'
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/hamap/main.nf
+++ b/modules/hamap/main.nf
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 process PREPROCESS_HAMAP {
-    label 'small', 'ips6_container'
+    label 'mini', 'ips6_container'
 
     input:
     tuple val(meta), path(fasta)
@@ -77,7 +77,7 @@ process PREPARE_HAMAP {
 }
 
 process RUN_HAMAP {
-    label 'small', 'ips6_container'
+    label 'mini', 'ips6_container'
 
     input:
     tuple val(meta), val(profiles), path(fasta_files)

--- a/modules/hmmer/main.nf
+++ b/modules/hmmer/main.nf
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 process RUN_HMMER {
-    label 'small', 'ips6_container'
+    label 'mini', 'ips6_container'
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/mobidblite/main.nf
+++ b/modules/mobidblite/main.nf
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 process RUN_MOBIDBLITE {
-    label 'small', 'mobidblite_container'
+    label 'mini', 'mobidblite_container'
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/pirsf/main.nf
+++ b/modules/pirsf/main.nf
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 process SEARCH_PIRSF {
-    label 'small', 'ips6_container'
+    label 'mini', 'ips6_container'
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -3,7 +3,7 @@ import Prints
 import HierarchyEntry
 
 process RUN_PRINTS {
-    label 'large'
+    label 'medium', 'ips6_container'
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/prosite/patterns/main.nf
+++ b/modules/prosite/patterns/main.nf
@@ -7,7 +7,7 @@ process RUN_PFSCAN {
     pftools developers. It automates running pfscan for all provided patterns and
     includes post-processing of the hits.
     */
-    label 'small', 'ips6_container'
+    label 'mini', 'ips6_container'
 
     input:
         tuple val(meta), path(fasta)

--- a/modules/prosite/profiles/main.nf
+++ b/modules/prosite/profiles/main.nf
@@ -2,7 +2,7 @@ import groovy.io.FileType
 import groovy.json.JsonOutput
 
 process RUN_PFSEARCH {
-    label 'small', 'ips6_container'
+    label 'tiny', 'ips6_container'
 
     input:
         tuple val(meta), path(fasta)

--- a/modules/sfld/main.nf
+++ b/modules/sfld/main.nf
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 process SEARCH_SFLD {
-    label 'small', 'ips6_container'
+    label 'mini', 'ips6_container'
 
     input:
     tuple val(meta), path(fasta)
@@ -25,7 +25,7 @@ process SEARCH_SFLD {
 }
 
 process POST_PROCESS_SFLD {
-    label 'small'
+    label 'mini', 'ips6_container'
 
     input:
     tuple val(meta), path(hmmsearch_out), val(hmmsearch_dtbl), val(hmmsearch_alignment)

--- a/modules/superfamily/main.nf
+++ b/modules/superfamily/main.nf
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 process SEARCH_SUPERFAMILY {
-    label 'small', 'ips6_container'
+    label 'tiny', 'ips6_container'
 
     input:
     tuple val(meta), path(fasta)

--- a/nextflow.config
+++ b/nextflow.config
@@ -78,7 +78,7 @@ manifest {
 }
 
 process {
-    withLabel: write_results {1
+    withLabel: write_results {
         publishDir = [
             path: params.outdir,
             mode: "copy"

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,7 @@ params {
     batchSize             = 5000
     maxWorkers            = null
     matchesApiUrl         = "https://www.ebi.ac.uk/interpro/matches/api"
-    matchesApiChunkSize   = 100
+    matchesApiChunkSize   = 1000
     matchesApiMaxRetries  = 3
 }
 

--- a/subworkflows/cath/main.nf
+++ b/subworkflows/cath/main.nf
@@ -17,9 +17,12 @@ workflow CATH {
     main:
     results = Channel.empty()
 
+    ch_split = ch_seqs
+        .splitFasta( by: 1000, file: true )
+
     // Search Gene3D profiles
     SEARCH_GENE3D(
-        ch_seqs,
+        ch_split,
         cathgene3d_dir,
         cathgene3d_hmm,
         "-Z 65245 -E 0.001"
@@ -56,7 +59,7 @@ workflow CATH {
             Join input fasta file with superfamilies.
             We split in smaller chunks to parallelize searching FunFam profiles
         */
-        ch_seqs
+        ch_split
             .join(PREPARE_FUNFAM.out)
             .flatMap { id, file, supfams ->
                 supfams

--- a/subworkflows/cath/main.nf
+++ b/subworkflows/cath/main.nf
@@ -1,6 +1,5 @@
-include { RUN_HMMER as SEARCH_GENE3D                                  } from  "../../modules/hmmer"
-include { RESOLVE_GENE3D; ASSIGN_CATH; PARSE_CATHGENE3D               } from  "../../modules/cath/gene3d"
-include { PREPARE_FUNFAM; SEARCH_FUNFAM; RESOLVE_FUNFAM; PARSE_FUNFAM } from  "../../modules/cath/funfam"
+include { SEARCH_GENE3D; RESOLVE_GENE3D; ASSIGN_CATH; PARSE_CATHGENE3D } from  "../../modules/cath/gene3d"
+include { PREPARE_FUNFAM; SEARCH_FUNFAM; RESOLVE_FUNFAM; PARSE_FUNFAM  } from  "../../modules/cath/funfam"
 
 workflow CATH {
     take:
@@ -12,20 +11,24 @@ workflow CATH {
     cathgene3d_disc_regs
     report_cathfunfam
     cathfunfam_dir
-    cathfunfam_chunksize
 
     main:
     results = Channel.empty()
 
     ch_split = ch_seqs
-        .splitFasta( by: 1000, file: true )
-
+        .map { meta, fasta ->
+            fasta
+                .splitFasta( by: 1000, file: true )
+                .indexed()
+                .collect { index, chunk -> [meta, index, chunk] }
+        }
+        .flatMap()
+    
     // Search Gene3D profiles
     SEARCH_GENE3D(
         ch_split,
         cathgene3d_dir,
-        cathgene3d_hmm,
-        "-Z 65245 -E 0.001"
+        cathgene3d_hmm
     )
     ch_gene3d = SEARCH_GENE3D.out
 
@@ -41,8 +44,10 @@ workflow CATH {
     )
 
     // Join results and parse them
-    ch_gene3d = ch_gene3d.join(ASSIGN_CATH.out)
-    PARSE_CATHGENE3D(ch_gene3d)
+    ch_cathgene3d = ch_gene3d
+        .join(ASSIGN_CATH.out, by: [0, 1])
+   
+    PARSE_CATHGENE3D(ch_cathgene3d)
 
     if (report_cathgene3d) {
         results = results.mix(PARSE_CATHGENE3D.out)
@@ -55,18 +60,9 @@ workflow CATH {
             cathfunfam_dir
         )
 
-        /*
-            Join input fasta file with superfamilies.
-            We split in smaller chunks to parallelize searching FunFam profiles
-        */
-        ch_split
-            .join(PREPARE_FUNFAM.out)
-            .flatMap { id, file, supfams ->
-                supfams
-                    .collate(cathfunfam_chunksize)
-                    .collect { chunk -> [id, file, chunk] }
-            }
-            .set { ch_funfams }
+        // Join input fasta file with superfamilies.
+        ch_funfams = ch_split
+            .join(PREPARE_FUNFAM.out, by: [0, 1])
 
         // Search FunFam profiles
         SEARCH_FUNFAM(
@@ -78,11 +74,11 @@ workflow CATH {
         RESOLVE_FUNFAM(SEARCH_FUNFAM.out)
 
         // Join results and parse them
-        ch_cathfunfam = SEARCH_FUNFAM.out.join(RESOLVE_FUNFAM.out)
+        ch_cathfunfam = SEARCH_FUNFAM.out.join(RESOLVE_FUNFAM.out, by: [0, 1])
         PARSE_FUNFAM(ch_cathfunfam)
         results = results.mix(PARSE_FUNFAM.out)
     }
 
     emit:
-    results
+    results.map { meta, meta2, json -> tuple (meta, json) }
 }

--- a/subworkflows/prepare/databases/main.nf
+++ b/subworkflows/prepare/databases/main.nf
@@ -45,9 +45,9 @@ workflow PREPARE_DATABASES {
 
             interpro_version = highest_version
             log.warn """Without the '--download' option enabled, InterProScan uses \
-    the highest locally available version of InterPro data, but cannot \
-    verify compatibility with InterProScan. \
-    To ensure you're using the latest compatible data, re-run with the --download option."""
+the highest locally available version of InterPro data, but cannot \
+verify compatibility with InterProScan. \
+To ensure you're using the latest compatible data, re-run with the --download option."""
         }
 
         // Most members have a single dir, but CATH-Gene3D and CATH-FuNFam are collated under cath for example

--- a/subworkflows/prints/main.nf
+++ b/subworkflows/prints/main.nf
@@ -8,8 +8,11 @@ workflow PRINTS {
     hierarchyfile
 
     main:
+    ch_split = ch_seqs
+        .splitFasta( by: 1000, file: true )
+
     RUN_PRINTS(
-        ch_seqs,
+        ch_split,
         dirpath,
         pvalfile
     )

--- a/subworkflows/scan/main.nf
+++ b/subworkflows/scan/main.nf
@@ -50,8 +50,7 @@ workflow SCAN_SEQUENCES {
             appsConfig.cathgene3d.model2sfs,
             appsConfig.cathgene3d.disc_regs,
             applications.contains("cathfunfam"),
-            db_releases.cathfunfam.dirpath,
-            appsConfig.cathfunfam.chunkSize
+            db_releases.cathfunfam.dirpath
         ).set{ ch_cath }
 
         results = results.mix(ch_cath)


### PR DESCRIPTION
This PR addresses memory and time issues for PRINTS and CATH-FunFam. Using the default batch size (5,000 sequences), I kept having `RUN_PRINTS` processes failing due to memory usage, or `SEARCH_FUNFAM` ones due to time limit.

For PRINTS and CATH (Gene3D + FunFam), sequences batches (up to 5k sequences/batch) are further split to up to 1k sequences/batch, to keep the memory usage and run time low(er).

Other processes have their label been updated to avoid over-requesting resources. 
Two processes (`RUN_PRINTS` and `POST_PROCESS_SFLD`) were missing the `ips6_container` label so they were not running in Singularity/Docker container.
