### PR TITLE
Fix `alignment: null` in HAMAP matches

### DIFF
--- a/lib/Match.groovy
+++ b/lib/Match.groovy
@@ -101,7 +101,15 @@ class Match implements Serializable {
 
         for (int i = 0; i < alignment.length(); i++) {
             char c = alignment.charAt(i)
-            char op = (c == '-') ? 'D' : 'M' // Treat all letters (including mismatches) as 'M'
+            char op
+
+            if (c == '-') {
+                op = 'D'
+            } else if (Character.isLowerCase(c)) {
+                op = 'I'
+            } else {
+                op = 'M'
+            }
 
             if (op == prevOp) {
                 count++

--- a/lib/Match.groovy
+++ b/lib/Match.groovy
@@ -93,7 +93,7 @@ class Match implements Serializable {
         location.targetAlignment = targetAlignment
     }
 
-    static String parseCigarAlignment(String alignment) {
+    static String encodeCigarAlignment(String alignment) {
         String cigarAlignment = ""
         alignment.each { baseChar ->
             if (baseChar.isUpperCase()) {
@@ -103,13 +103,10 @@ class Match implements Serializable {
             } else if (baseChar == "-") {
                 cigarAlignment += "D" // delete char
             } else {
-                throw new IllegalArgumentException("Unrecognized character ${baseChar} in ${alignment}")
+                throw new IllegalArgumentException("Unrecognised character ${baseChar} in ${alignment}")
             }
         }
-        return cigarAlignment
-    }
-
-    static String encodeCigarAlignment(String cigarAlignment) {  // Compress alignment, to give '5M' instead of 'MMMMM'
+        // compress alignment, to give '5M' instead of 'MMMMM'
         if (!cigarAlignment) return ""
         cigarAlignment
                 .split('')

--- a/modules/hamap/main.nf
+++ b/modules/hamap/main.nf
@@ -132,7 +132,6 @@ process PARSE_HAMAP {
             matches.computeIfAbsent(sequenceId, { [:] })
             matches[sequenceId][modelAccession] = match
         }
-
         Location location = new Location(start, end, score, alignment, cigarAlignment)
         match.addLocation(location)
     }

--- a/modules/hamap/main.nf
+++ b/modules/hamap/main.nf
@@ -123,8 +123,7 @@ process PARSE_HAMAP {
         int end = fields[5].toInteger()
         Double score = Double.parseDouble(fields[7])
         String alignment = fields[9]
-        String cigarAlignment = Match.parseCigarAlignment(alignment)
-        cigarAlignment = Match.encodeCigarAlignment(cigarAlignment)
+        String cigarAlignment = Match.encodeCigarAlignment(alignment)
 
         if (matches.containsKey(sequenceId) && matches[sequenceId].containsKey(modelAccession)) {
             match = matches[sequenceId][modelAccession]

--- a/modules/hamap/main.nf
+++ b/modules/hamap/main.nf
@@ -123,6 +123,8 @@ process PARSE_HAMAP {
         int end = fields[5].toInteger()
         Double score = Double.parseDouble(fields[7])
         String alignment = fields[9]
+        String cigarAlignment = Match.parseCigarAlignment(alignment)
+        cigarAlignment = Match.encodeCigarAlignment(cigarAlignment)
 
         if (matches.containsKey(sequenceId) && matches[sequenceId].containsKey(modelAccession)) {
             match = matches[sequenceId][modelAccession]
@@ -132,7 +134,7 @@ process PARSE_HAMAP {
             matches[sequenceId][modelAccession] = match
         }
 
-        Location location = new Location(start, end, score, alignment)
+        Location location = new Location(start, end, score, alignment, cigarAlignment)
         match.addLocation(location)
     }
 

--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -147,8 +147,11 @@ def decodeAlignment(cigarAlignment, sequence, startIndex) {
             case 'M':
             case '=':
             case 'X':
-            case 'I':
                 targetAlign << sequence.substring(index, index + len)
+                index += len
+                break
+            case 'I':
+                targetAlign << sequence.substring(index, index + len).toLowerCase()
                 index += len
                 break
             case 'D':

--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -121,7 +121,7 @@ def Map transformMatch(Map match, String seq) {
                 "hmmBounds": loc["hmmBounds"] ? getReverseHmmBounds(loc["hmmBounds"]) : null,
                 "fragments": loc["fragments"].collect { tranformFragment(it) },
                 "sites"    : loc["sites"] ?: [],
-                "targetAlignment": loc["cigarAlignment"] ? decodeAlignment(loc["cigarAlignment"], seq) : null
+                "targetAlignment": loc["cigarAlignment"] ? decodeAlignment(loc["cigarAlignment"], seq, loc["start"]) : null
             ]
         },
     ]
@@ -136,9 +136,9 @@ def getReverseHmmBounds(hmmBounds) {
     ][hmmBounds]
 }
 
-def decodeAlignment(cigarAlignment, sequence) {
+def decodeAlignment(cigarAlignment, sequence, startIndex) {
     def targetAlign = new StringBuilder()
-    def index = 0
+    def index = startIndex - 1 // convert from 1-based numbering to 0-based numbering
     def matcher = (cigarAlignment =~ /(\d+)([MID=X])/)
     matcher.each { match ->
         def len = match[1].toInteger()

--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -295,6 +295,7 @@ def writeHAMAP(Map match, JsonGenerator jsonWriter) {
                 "end"               : loc.end,
                 "representative"    : loc.representative,
                 "score"             : loc.score,
+                "cigarAlignment"    : loc.cigarAlignment,
                 "alignment"         : loc.targetAlignment,
                 "location-fragments": loc.fragments
             ]
@@ -429,6 +430,7 @@ def writePROSITEprofiles(Map match, JsonGenerator jsonWriter) {
                 "end"               : loc.end,
                 "representative"    : loc.representative,
                 "score"             : loc.score,
+                "cigarAlignment"    : loc.cigarAlignment,
                 "alignment"         : loc.targetAlignment,
                 "location-fragments": loc.fragments
             ]

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -397,6 +397,7 @@ def addLocationNodes(String memberDB, String proteinMd5, Map match, def xml) {
                 }
                 if (memberDB in ["hamap", "prosite patterns", "prosite profiles"]) {
                     xml.alignment(loc.targetAlignment ?: "")
+                    xml."cigar-alignment"(loc.cigarAlignment ?: "")
                 }
                 if (loc.containsKey("sites") && loc.sites.size() > 0) {
                     addSiteNodes(loc.sites, memberDB, xml)

--- a/modules/prosite/patterns/main.nf
+++ b/modules/prosite/patterns/main.nf
@@ -65,8 +65,8 @@ process PARSE_PFSCAN {
             level = "STRONG"
         }
         String alignment = matchDetails[2].replaceAll('Sequence ', '').replaceAll('"', '').replaceAll('\\.', '').trim()
-        String cigarAlignment = parseCigarAlignment(alignment)
-        cigarAlignment = encodeCigarAlignment(cigarAlignment)
+        String cigarAlignment = Match.parseCigarAlignment(alignment)
+        cigarAlignment = Match.encodeCigarAlignment(cigarAlignment)
         patternsMatches.computeIfAbsent(seqId) { [:] }
         Match matchObj = patternsMatches[seqId].computeIfAbsent(modelAccession) {
             new Match(modelAccession, new Signature(modelAccession, library))
@@ -78,36 +78,4 @@ process PARSE_PFSCAN {
     def outputFilePath = task.workDir.resolve("prositepatterns.json")
     def json = JsonOutput.toJson(patternsMatches)
     new File(outputFilePath.toString()).write(json)
-}
-
-def parseCigarAlignment(String alignment) {
-    String cigarAlignment = ""
-    alignment.each { baseChar ->
-        if (baseChar.isUpperCase()) {
-            cigarAlignment += "M" // match char
-        } else if (baseChar.isLowerCase()) {
-            cigarAlignment += "I" // insert char
-        } else if (baseChar == "-") {
-            cigarAlignment += "D" // delete char
-        } else {
-            throw new IllegalArgumentException("Unrecognized character ${baseChar} in ${alignment}")
-        }
-    }
-    return cigarAlignment
-}
-
-def encodeCigarAlignment(String cigarAlignment) {  // Compress alignment, to give '5M' instead of 'MMMMM'
-    if (!cigarAlignment) return ""
-    cigarAlignment
-        .split('')
-        .inject([]) { groups, alignChar ->
-            if (groups && groups.last()[1] == alignChar) {
-                groups.last()[0]++  // cigar alignment char matches previous so add 1 to the count
-            } else {
-                groups << [1, alignChar]  // change type of alignment char, restart count
-            }
-            groups
-        }
-        .collect { count, alignChar -> "${count}${alignChar}" }
-        .join()
 }

--- a/modules/prosite/patterns/main.nf
+++ b/modules/prosite/patterns/main.nf
@@ -65,8 +65,7 @@ process PARSE_PFSCAN {
             level = "STRONG"
         }
         String alignment = matchDetails[2].replaceAll('Sequence ', '').replaceAll('"', '').replaceAll('\\.', '').trim()
-        String cigarAlignment = Match.parseCigarAlignment(alignment)
-        cigarAlignment = Match.encodeCigarAlignment(cigarAlignment)
+        String cigarAlignment = Match.encodeCigarAlignment(alignment)
         patternsMatches.computeIfAbsent(seqId) { [:] }
         Match matchObj = patternsMatches[seqId].computeIfAbsent(modelAccession) {
             new Match(modelAccession, new Signature(modelAccession, library))

--- a/modules/prosite/profiles/main.nf
+++ b/modules/prosite/profiles/main.nf
@@ -55,8 +55,7 @@ process PARSE_PFSEARCH {
                 new Match(matchData.profile, new Signature(modelAccession, library))
             }
             String alignment = matchData.alignment
-            String cigarAlignment = Match.parseCigarAlignment(alignment)
-            cigarAlignment = Match.encodeCigarAlignment(cigarAlignment)
+            String cigarAlignment = Match.encodeCigarAlignment(alignment)
             Location location = new Location(matchData.start, matchData.end, matchData.normScore, alignment, cigarAlignment)
             matchObj.addLocation(location)
         }

--- a/modules/prosite/profiles/main.nf
+++ b/modules/prosite/profiles/main.nf
@@ -54,7 +54,10 @@ process PARSE_PFSEARCH {
             Match matchObj = matches[seqId].computeIfAbsent(modelAccession) {
                 new Match(matchData.profile, new Signature(modelAccession, library))
             }
-            Location location = new Location(matchData.start, matchData.end, matchData.normScore, matchData.alignment)
+            String alignment = matchData.alignment
+            String cigarAlignment = Match.parseCigarAlignment(alignment)
+            cigarAlignment = Match.encodeCigarAlignment(cigarAlignment)
+            Location location = new Location(matchData.start, matchData.end, matchData.normScore, alignment, cigarAlignment)
             matchObj.addLocation(location)
         }
     }


### PR DESCRIPTION
An alignment should be reported for all HAMAP matches. However, matches that are retrieved from the MLS will have `alignment: null` in the final output. This PR adds a decoder to convert the cigar alignment back to the full seq alignment, meaning an alignment is now reported for all HAMAP matches.