### PR TITLE
Refactor deep-learning analyses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # InterProScan 6
 
+[![Nextflow](https://img.shields.io/badge/%E2%89%A524.10.4-0dc09d?style=flat&logo=nextflow&label=nextflow&labelColor=f5fafe)](https://www.nextflow.io/)
+[![run with docker](https://img.shields.io/badge/docker-1D63ED?logo=docker&logoColor=1D63ED&label=run%20with&labelColor=f5fafe)](https://www.docker.com/)
+[![run with singularity](https://img.shields.io/badge/singularity-1E4383?label=run%20with&labelColor=f5fafe)](https://sylabs.io/docs/)
+
 [InterPro](http://www.ebi.ac.uk/interpro/) is a database that brings together predictive information on protein function from multiple partner resources. It provides an integrated view of the families, domains and functional sites to which a given protein belongs.
 
 **InterProScan** is the command‑line tool that allows you to scan protein or nucleotide sequences against the InterPro member‑database signatures in a single workflow. Researchers with novel sequences can use InterProScan to annotate their data with family classifications, domain architectures and site predictions.
@@ -17,7 +21,7 @@ Before you begin, you will need:
     * [SingularityCE](https://sylabs.io/singularity/)
     * [Apptainer](https://apptainer.org/)
 
-> [!NOTE]  
+> [!IMPORTANT]  
 > Phobius, SignalP and DeepTMHMM also require separate licenses and data downloads. See [Licensed analyses](#licensed-analyses) below.
 
 ## Usage
@@ -37,7 +41,7 @@ nextflow run ebi-pf-team/interproscan6 \
 
 Explanation of parameters:
 
-* `-r 6.0.0-alpha`: Specify the version of the InterProScan workflow to use, in this case version `6.0.0-alpha`. For consistent and reproducible results, we strongly recommend always specifying a version.
+* `-r 6.0.0-alpha`: Specify the version of InterProScan to use, in this case version `6.0.0-alpha`. For consistent and reproducible results, we strongly recommend always specifying a version.
 * `-profile test,docker`:
   * `test`: Run InterProScan with a small example FASTA file included in the workflow.
   * `docker`: Execute tasks in Docker containers.
@@ -48,7 +52,7 @@ Explanation of parameters:
 > [!TIP]
 > To use a specific version of InterPro, use the release number, e.g. `--interpro 105.0`.
 
-After completion, you’ll find three output files in your working directory:
+After completion, you'll find three output files in your working directory:
 
 * `test.faa.json`: full annotations (JSON)
 * `test.faa.tsv`: tabular summary (TSV)
@@ -121,15 +125,31 @@ The available analyses are:
 > [!TIP]
 > If you only run COILS, DeepTMHMM, MobiDB‑lite, Phobius, SignalP‑Euk or SignalP‑Prok, you don't need `--datadir`, `--interpro`, or `--download`.
 
-### Licensed analyses
+### Running InterProScan on an HPC cluster with Slurm
+
+To run InterProScan on your institute's Slurm cluster, use the `slurm` profile. This ensures that each task in the pipeline is submitted as a job to the Slurm scheduler.
+
+Most HPC systems do not support Docker, but they often support Singularity or Apptainer for containerized execution. Include the appropriate profile (`singularity` or `apptainer`).
+
+```sh
+nextflow run ebi-pf-team/interproscan6 \
+  -r 6.0.0-alpha \
+  -profile singularity,slurm,test \
+  --datadir /path/to/data
+```
+
+> [!IMPORTANT]
+> The directory specified by `--datadir` must be accessible from all cluster nodes. This usually means it should be located on a shared network file system (e.g. NFS or Lustre).
+
+## Licensed analyses
 
 DeepTMHMM, Phobius and SignalP contain licensed components and are disabled by default. To enable and execute these analyses, you first need to obtain their license, and data.
 
-#### Obtaining licensed components
+### Obtaining licensed components
 
 For each analyses, you need to request a license, then download and extract an archive that contains the data and machine learning model(s) required to run the analysis.
 
-##### DeepTMHMM 1.0
+#### DeepTMHMM 1.0
 
 Request a standalone copy of DeepTMHMM 1.0 by sending an email to <licensing@biolib.com>, then extract it when you receive it:
 
@@ -143,7 +163,7 @@ and make note of the full path to the package:
 echo "${PWD}/DeepTMHMM
 ```
 
-##### Phobius 1.01
+#### Phobius 1.01
 
 Download a copy of Phobius 1.01 [from Erik Sonnhammer's website](https://software.sbc.su.se/phobius.html), then extract it:
 
@@ -157,7 +177,7 @@ and make note of the full path to the package:
 echo "${PWD}/phobius"
 ```
 
-##### SignalP 6.0
+#### SignalP 6.0
 
 SignalP 6.0 supports two modes: a slow one that uses the full model, and a fast one that uses a distilled version of the full mode. InterProScan suppports both, but only one at a time. The fast mode is recommended for most users.
 
@@ -178,7 +198,7 @@ and make note of the full path to the package:
 echo "${PWD}/signal6p_fast"
 ```
 
-#### Executing licensed analyses
+### Executing licensed analyses
 
 Create a Nextflow config (e.g. `licensed.conf`) that points to each tool directory:
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To test InterProScan, run the following command:
 
 ```sh
 nextflow run ebi-pf-team/interproscan6 \
+  -r 6.0.0-alpha \
   -profile test,docker \
   --datadir data \
   --interpro latest \
@@ -36,10 +37,11 @@ nextflow run ebi-pf-team/interproscan6 \
 
 Explanation of parameters:
 
+* `-r 6.0.0-alpha`: Specify the version of the InterProScan workflow to use, in this case version `6.0.0-alpha`. For consistent and reproducible results, we strongly recommend always specifying a version.
 * `-profile test,docker`:
-  * `test`: Use an included example FASTA file.
+  * `test`: Run InterProScan with a small example FASTA file included in the workflow.
   * `docker`: Execute tasks in Docker containers.
-* `--datadir data`: Specify `data` as the directory for storing all required InterPro and member database files. The directory is created automatically if it doesn't exist.
+* `--datadir data`: Set `data` as the directory for storing all required InterPro and member database files. The directory is created automatically if it doesn't exist.
 * `--interpro latest`: Use the most recent InterPro release.
 * `--download`: Download any missing metadata and database files into the specified `--datadir`
 
@@ -60,6 +62,7 @@ To annotate your own sequences FASTA file, omit the `test` profile and specify `
 
 ```sh
 nextflow run ebi-pf-team/interproscan6 \
+  -r 6.0.0-alpha \
   -profile docker \
   --datadir data \
   --input /path/to/sequences.fasta
@@ -69,6 +72,7 @@ For nucleotide sequences, add `--nucleic`:
 
 ```sh
 nextflow run ebi-pf-team/interproscan6 \
+  -r 6.0.0-alpha \
   -profile docker \
   --datadir data \
   --input /path/to/sequences.fna \
@@ -81,6 +85,7 @@ To run only certain analyses (for example, Pfam and MobiDB‑lite):
 
 ```sh
 nextflow run ebi-pf-team/interproscan6 \
+  -r 6.0.0-alpha \
   -profile test,docker \
   --datadir data \
   --applications Pfam,MobiDB-lite
@@ -200,15 +205,16 @@ And run with your config:
 
 ```sh
 nextflow run ebi-pf-team/interproscan6 \
-  -c licensed.conf \
+  -r 6.0.0-alpha \
   -profile docker \
+  -c licensed.conf \
   --input /path/to/sequences.fasta \
   --applications deeptmhmm,phobius,signalp_euk,signalp_prok \
   --offline
 ```
 
 > [!WARNING]  
-> DeepTMHMM 1.0 and SignalP 6.0 predictions are not yet available in the [Matches API](https://www.ebi.ac.uk/interpro/matches/api/). The pre-calculated matches lookup needs to be disabled with `--offline`.
+> As DeepTMHMM 1.0 and SignalP 6.0 predictions are not yet available in the [Matches API](https://www.ebi.ac.uk/interpro/matches/api/), the pre-calculated matches lookup must be disabled with `--offline`.
 
 > [!WARNING]  
 > Phobius does not support certain non-standard or ambiguous residues. Any sequence containing pyrrolysine (one-letter code `O`), Asx (Asp/Asn ambiguity, `B`), Glx (Glu/Gln ambiguity, `Z`) or Xle (Leu/Ile ambiguity, `J`) will be skipped by Phobius but will continue to be processed normally by all other applications.
@@ -220,12 +226,12 @@ nextflow run ebi-pf-team/interproscan6 \
 
 Our full documentation is available on [ReadTheDocs](https://interproscan-docs.readthedocs.io/en/v6/).
 
-# Citation
+## Citation
 
 If you use InterPro in your work, please cite the following publication:
 
 > Blum M, Andreeva A, Florentino LC, Chuguransky SR, Grego T, Hobbs E, Pinto BL, Orr A, Paysan-Lafosse T, Ponamareva I, Salazar GA, Bordin N, Bork P, Bridge A, Colwell L, Gough J, Haft DH, Letunic I, Llinares-López F, Marchler-Bauer A, Meng-Papaxanthos L, Mi H, Natale DA, Orengo CA, Pandurangan AP, Piovesan D, Rivoire C, Sigrist CJA, Thanki N, Thibaud-Nissen F, Thomas PD, Tosatto SCE, Wu CH, Bateman A. **InterPro: the protein sequence classification resource in 2025**. *Nucleic Acids Res*. 2025 Jan;53(D1):D444-D456. [doi: 10.1093/nar/gkae1082](https://doi.org/10.1093/nar/gkae1082).
 
-# Support
+## Support
 
 For further assistance, please [create an issue](https://github.com/ebi-pf-team/interproscan6/issues) or [contact us](http://www.ebi.ac.uk/support/interproscan).

--- a/conf/applications.config
+++ b/conf/applications.config
@@ -36,6 +36,7 @@ params {
             name = "DeepTMHMM"
             dir = ""
             has_data = false
+            use_gpu = false
         }
         hamap {
             name = "HAMAP"
@@ -143,6 +144,7 @@ params {
             dir = ""
             mode = "fast"
             has_data = false
+            use_gpu = false
         }
         signalp_prok {
             name = "SignalP-Prok"
@@ -150,6 +152,7 @@ params {
             dir = ""
             mode = "fast"
             has_data = false
+            use_gpu = false
         }
     }
 }

--- a/conf/profiles/apptainer.config
+++ b/conf/profiles/apptainer.config
@@ -12,7 +12,7 @@ process {
         container = 'docker://interpro/deeptmhmm:1.0'
     }
     withLabel:use_gpu {
-        containerOptions = '-nv'
+        containerOptions = '--nv'
     }
 }
 

--- a/conf/profiles/apptainer.config
+++ b/conf/profiles/apptainer.config
@@ -7,11 +7,12 @@ process {
     }
     withLabel:signalp_container {
         container = 'docker://interpro/signalp:6.0h'
-        containerOptions = params.signalpGpu ? '--nv' : ''
     }
     withLabel:deeptmhmm_container {
         container = 'docker://interpro/deeptmhmm:1.0'
-        containerOptions = params.deeptmhmmGpu ? '--nv' : ''
+    }
+    withLabel:use_gpu {
+        containerOptions = '-nv'
     }
 }
 

--- a/conf/profiles/apptainer.config
+++ b/conf/profiles/apptainer.config
@@ -7,10 +7,11 @@ process {
     }
     withLabel:signalp_container {
         container = 'docker://interpro/signalp:6.0h'
-        containerOptions = params.signalpGPU ? '--nv' : ''
+        containerOptions = params.signalpGpu ? '--nv' : ''
     }
     withLabel:deeptmhmm_container {
         container = 'docker://interpro/deeptmhmm:1.0'
+        containerOptions = params.deeptmhmmGpu ? '--nv' : ''
     }
 }
 

--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -41,4 +41,8 @@ process {
         memory = { 2.GB * task.attempt }
         time   = { 3.h  * task.attempt }
     }
+    withName: 'RUN_DEEPTMHMM_CPU|RUN_DEEPTMHMM_GPU' {
+        memory = { 8.GB * task.attempt }
+        time   = { 1.h  * task.attempt }
+    }
 }

--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -34,15 +34,11 @@ process {
     }
     withLabel: 'large' {
         cpus   = { 1     * task.attempt }
-        memory = { 12.GB * task.attempt }
-        time   = { 4.h * task.attempt }
+        memory = { 8.GB  * task.attempt }
+        time   = { 4.h   * task.attempt }
     }
     withName: 'SEARCH_PANTHER' {
         memory = { 2.GB * task.attempt }
         time   = { 3.h  * task.attempt }
-    }
-    withName: 'RUN_DEEPTMHMM_CPU|RUN_DEEPTMHMM_GPU' {
-        memory = { 8.GB * task.attempt }
-        time   = { 1.h  * task.attempt }
     }
 }

--- a/conf/profiles/docker.config
+++ b/conf/profiles/docker.config
@@ -7,10 +7,11 @@ process {
     }
     withLabel:signalp_container {
         container = 'docker.io/interpro/signalp:6.0h'
-        containerOptions = params.signalpGPU ? '--gpus all' : ''
+        containerOptions = params.signalpGpu ? '--gpus all' : ''
     }
     withLabel:deeptmhmm_container {
         container = 'docker.io/interpro/deeptmhmm:1.0'
+        containerOptions = params.deeptmhmmGpu ? '--gpus all' : ''
     }
 }
 

--- a/conf/profiles/docker.config
+++ b/conf/profiles/docker.config
@@ -7,11 +7,12 @@ process {
     }
     withLabel:signalp_container {
         container = 'docker.io/interpro/signalp:6.0h'
-        containerOptions = params.signalpGpu ? '--gpus all' : ''
     }
     withLabel:deeptmhmm_container {
-        container = 'docker.io/interpro/deeptmhmm:1.0'
-        containerOptions = params.deeptmhmmGpu ? '--gpus all' : ''
+        container = 'docker.io/matblum/deeptmhmm:1.0'
+    }
+    withLabel:use_gpu {
+        containerOptions = '--gpus all'
     }
 }
 

--- a/conf/profiles/lsf.config
+++ b/conf/profiles/lsf.config
@@ -13,4 +13,8 @@ executor {
 
 process {
     executor = 'lsf'
+
+    withLabel: use_gpu {
+        clusterOptions = '-gpu "num=1"'
+    }
 }

--- a/conf/profiles/singularity.config
+++ b/conf/profiles/singularity.config
@@ -12,7 +12,7 @@ process {
         container = 'docker://interpro/deeptmhmm:1.0'
     }
     withLabel:use_gpu {
-        containerOptions = '-nv'
+        containerOptions = '--nv'
     }
 }
 

--- a/conf/profiles/singularity.config
+++ b/conf/profiles/singularity.config
@@ -9,7 +9,7 @@ process {
         container = 'docker://interpro/signalp:6.0h'
     }
     withLabel:deeptmhmm_container {
-        container = 'docker://interpro/deeptmhmm:1.0'
+        container = 'docker://matblum/deeptmhmm:1.0'
     }
     withLabel:use_gpu {
         containerOptions = '--nv'

--- a/conf/profiles/singularity.config
+++ b/conf/profiles/singularity.config
@@ -7,11 +7,12 @@ process {
     }
     withLabel:signalp_container {
         container = 'docker://interpro/signalp:6.0h'
-        containerOptions = params.signalpGpu ? '--nv' : ''
     }
     withLabel:deeptmhmm_container {
         container = 'docker://interpro/deeptmhmm:1.0'
-        containerOptions = params.deeptmhmmGpu ? '--nv' : ''
+    }
+    withLabel:use_gpu {
+        containerOptions = '-nv'
     }
 }
 

--- a/conf/profiles/singularity.config
+++ b/conf/profiles/singularity.config
@@ -7,10 +7,11 @@ process {
     }
     withLabel:signalp_container {
         container = 'docker://interpro/signalp:6.0h'
-        containerOptions = params.signalpGPU ? '--nv' : ''
+        containerOptions = params.signalpGpu ? '--nv' : ''
     }
     withLabel:deeptmhmm_container {
         container = 'docker://interpro/deeptmhmm:1.0'
+        containerOptions = params.deeptmhmmGpu ? '--nv' : ''
     }
 }
 

--- a/conf/profiles/slurm.config
+++ b/conf/profiles/slurm.config
@@ -13,4 +13,8 @@ executor {
 
 process {
     executor = 'slurm'
+
+    withLabel: use_gpu {
+        clusterOptions = '--gres=gpu:1'
+    }
 }

--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -89,14 +89,6 @@ class InterProScan {
             description: null
         ],
         [
-            name: "signalp-gpu",
-            description: null
-        ],
-        [
-            name: "deeptmhmm-gpu",
-            description: null
-        ],
-        [
             name: "skip-interpro",
             description: null
             // Used in production. Skips adding InterPro xrefs and identifying representative locations

--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -93,9 +93,13 @@ class InterProScan {
             description: null
         ],
         [
-                name: "skip-interpro",
-                description: null
-                // Used in production. Skips adding InterPro xrefs and identifying representative locations
+            name: "deeptmhmm-gpu",
+            description: null
+        ],
+        [
+            name: "skip-interpro",
+            description: null
+            // Used in production. Skips adding InterPro xrefs and identifying representative locations
         ],
         [
             name: "apps-config",

--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -85,10 +85,6 @@ class InterProScan {
             description: null
         ],
         [
-            name: "signalp-mode",
-            description: null
-        ],
-        [
             name: "skip-interpro",
             description: null
             // Used in production. Skips adding InterPro xrefs and identifying representative locations

--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -199,7 +199,7 @@ class InterProScan {
 
     static List<String> getAppsWithData(List<String> applications, Map appsConfig) {
         return applications.findAll { String appName ->
-            appsConfig.get(appName)?.has_data //|| InterProScan.LICENSED_SOFTWARE.contains(appName)
+            appsConfig.get(appName)?.has_data
         }
     }
 
@@ -274,6 +274,16 @@ class InterProScan {
                 return [null, error]
             }
         }
+
+        def invalidApps = appsToRun.findAll { app ->
+            this.LICENSED_SOFTWARE.contains(app) && !appsConfig[app]?.dir
+        }
+
+        if (invalidApps) {
+            def error = "The following applications cannot be run: ${invalidApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
+            return [null, error]
+        }
+
         return [appsToRun.toSet().toList(), null]
     }
 

--- a/main.nf
+++ b/main.nf
@@ -72,9 +72,7 @@ workflow {
             db_releases,
             applications,
             params.appsConfig,
-            data_dir,
-            params.signalpGpu,
-            params.deeptmhmmGpu
+            data_dir
         )
         match_results = SCAN_SEQUENCES.out
     } else {
@@ -98,9 +96,7 @@ workflow {
             db_releases,
             applications,
             params.appsConfig,
-            data_dir,
-            params.signalpGpu,
-            params.deeptmhmmGpu
+            data_dir
         )
 
         def expandedScan = SCAN_SEQUENCES.out.flatMap { scan ->

--- a/main.nf
+++ b/main.nf
@@ -29,7 +29,6 @@ workflow {
         params.datadir,
         params.formats,
         params.outdir,
-        params.signalpMode,
         params.matchesApiUrl,
         params.interpro,
         params.skipInterpro,
@@ -41,7 +40,6 @@ workflow {
     data_dir             = INIT_PIPELINE.out.datadir.val
     out_dir              = INIT_PIPELINE.out.outdir.val
     formats              = INIT_PIPELINE.out.formats.val
-    signalp_mode         = INIT_PIPELINE.out.signalp_mode.val
     interpro_version     = INIT_PIPELINE.out.version.val
 
     PREPARE_DATABASES(

--- a/main.nf
+++ b/main.nf
@@ -72,7 +72,9 @@ workflow {
             db_releases,
             applications,
             params.appsConfig,
-            data_dir
+            data_dir,
+            params.signalpGpu,
+            params.deeptmhmmGpu
         )
         match_results = SCAN_SEQUENCES.out
     } else {
@@ -96,7 +98,9 @@ workflow {
             db_releases,
             applications,
             params.appsConfig,
-            data_dir
+            data_dir,
+            params.signalpGpu,
+            params.deeptmhmmGpu
         )
 
         def expandedScan = SCAN_SEQUENCES.out.flatMap { scan ->

--- a/modules/deeptmhmm/main.nf
+++ b/modules/deeptmhmm/main.nf
@@ -2,7 +2,7 @@ import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
 process RUN_DEEPTMHMM_CPU {
-    label 'medium', 'deeptmhmm_container'
+    label 'large', 'deeptmhmm_container'
     stageInMode 'copy'
 
     input:
@@ -26,7 +26,7 @@ process RUN_DEEPTMHMM_CPU {
 }
 
 process RUN_DEEPTMHMM_GPU {
-    label 'medium', 'deeptmhmm_container', 'use_gpu'
+    label 'large', 'deeptmhmm_container', 'use_gpu'
     stageInMode 'copy'
 
     input:

--- a/modules/deeptmhmm/main.nf
+++ b/modules/deeptmhmm/main.nf
@@ -1,8 +1,32 @@
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
-process RUN_DEEPTMHMM {
+process RUN_DEEPTMHMM_CPU {
     label 'medium', 'deeptmhmm_container'
+    stageInMode 'copy'
+
+    input:
+    tuple val(meta), path(fasta)
+    path tmhmm_dir
+
+    output:
+    tuple val(meta), path("outdir")
+
+    script:
+    """
+    # deeptmhmm has a hard coded assumption it is being run within its dir
+    cd ${tmhmm_dir}
+    python3 predict.py \
+        --fasta ../${fasta} \
+        --output-dir ../outdir
+    cd ..
+    rm -r ${tmhmm_dir} outdir/embeddings
+    chmod -R 777 outdir
+    """
+}
+
+process RUN_DEEPTMHMM_GPU {
+    label 'medium', 'deeptmhmm_container', 'use_gpu'
     stageInMode 'copy'
 
     input:

--- a/modules/phobius/main.nf
+++ b/modules/phobius/main.nf
@@ -53,7 +53,7 @@ process PARSE_PHOBIUS {
     boolean isSignalPeptide = false
     boolean isTransmembrane = false
 
-    SignatureLibraryRelease library = new SignatureLibraryRelease("Phobius", "1.0.1")
+    SignatureLibraryRelease library = new SignatureLibraryRelease("Phobius", "1.01")
     def signatures = [
         "CYTOPLASMIC_DOMAIN"     : new Signature("CYTOPLASMIC_DOMAIN", "Cytoplasmic domain", 
                                                  "Region of a membrane-bound protein predicted to be outside the membrane, in the cytoplasm", library, null),

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,8 +9,6 @@ params {
     outdir                = "."
     pathways              = false
     signalpMode           = "fast"
-    signalpGpu            = false
-    deeptmhmmGpu          = false
     skipInterpro          = false
     interpro              = "latest"
     download              = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,7 +9,8 @@ params {
     outdir                = "."
     pathways              = false
     signalpMode           = "fast"
-    signalpGPU            = false
+    signalpGpu            = false
+    deeptmhmmGpu          = false
     skipInterpro          = false
     interpro              = "latest"
     download              = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,7 +8,6 @@ params {
     offline               = false
     outdir                = "."
     pathways              = false
-    signalpMode           = "fast"
     skipInterpro          = false
     interpro              = "latest"
     download              = false

--- a/subworkflows/deeptmhmm/main.nf
+++ b/subworkflows/deeptmhmm/main.nf
@@ -1,4 +1,4 @@
-include { RUN_DEEPTMHMM_CPU, RUN_DEEPTMHMM_GPU; PARSE_DEEPTMHMM } from  "../../modules/deeptmhmm"
+include { RUN_DEEPTMHMM_CPU; RUN_DEEPTMHMM_GPU; PARSE_DEEPTMHMM } from  "../../modules/deeptmhmm"
 
 workflow DEEPTMHMM {
     take:

--- a/subworkflows/deeptmhmm/main.nf
+++ b/subworkflows/deeptmhmm/main.nf
@@ -14,8 +14,11 @@ workflow DEEPTMHMM {
         )
         ch_deeptmhmm = RUN_DEEPTMHMM_GPU.out
     } else {
+        ch_split = ch_seqs
+            .splitFasta( by: 100, file: true )
+
         RUN_DEEPTMHMM_CPU(
-            ch_seqs,
+            ch_split,
             deeptmhmm_dir
         )
         ch_deeptmhmm = RUN_DEEPTMHMM_CPU.out

--- a/subworkflows/deeptmhmm/main.nf
+++ b/subworkflows/deeptmhmm/main.nf
@@ -1,17 +1,28 @@
-include { RUN_DEEPTMHMM; PARSE_DEEPTMHMM } from  "../../modules/deeptmhmm"
+include { RUN_DEEPTMHMM_CPU, RUN_DEEPTMHMM_GPU; PARSE_DEEPTMHMM } from  "../../modules/deeptmhmm"
 
 workflow DEEPTMHMM {
     take:
     ch_seqs
     deeptmhmm_dir
+    use_gpu
 
     main:
-    RUN_DEEPTMHMM(
-        ch_seqs,
-        deeptmhmm_dir
-    )
-    ch_deeptmhmm = PARSE_DEEPTMHMM(RUN_DEEPTMHMM.out)
+    if (use_gpu) {
+        RUN_DEEPTMHMM_GPU(
+            ch_seqs,
+            deeptmhmm_dir
+        )
+        ch_deeptmhmm = RUN_DEEPTMHMM_GPU.out
+    } else {
+        RUN_DEEPTMHMM_CPU(
+            ch_seqs,
+            deeptmhmm_dir
+        )
+        ch_deeptmhmm = RUN_DEEPTMHMM_CPU.out
+    }
+    
+    ch_results = PARSE_DEEPTMHMM(ch_deeptmhmm)
 
     emit:
-    ch_deeptmhmm
+    ch_results
 }

--- a/subworkflows/init/main.nf
+++ b/subworkflows/init/main.nf
@@ -75,6 +75,17 @@ workflow INIT_PIPELINE {
         exit 1
     }
 
+    if (!offline) {
+        def invalidApps = apps.findAll { app ->
+            ["signalp_euk", "signalp_prok", "deeptmhmm"].contains(app)
+        }
+
+        if (invalidApps) {
+            log.error "Pre-calculated results for DeepTMHMM, SignalP_Euk, and SignalP_Prok are not yet available in the Matches API. To ensure these analyses run locally and produce results, please add the '--offline' flag when invoking the pipeline."
+            exit 1
+        }
+    }
+
     emit:
     fasta            // str: path to input fasta file
     apps             // list: list of application to

--- a/subworkflows/init/main.nf
+++ b/subworkflows/init/main.nf
@@ -9,7 +9,6 @@ workflow INIT_PIPELINE {
     datadir
     formats
     outdir
-    signalp_mode
     matches_api_url
     interpro_version
     skip_intepro
@@ -64,13 +63,6 @@ workflow INIT_PIPELINE {
         datadir = null
     }
   
-    // SignalP mode validation
-    (signalp_mode, error) = InterProScan.validateSignalpMode(signalp_mode)
-    if (!signalp_mode) {
-        log.error error
-        exit 1
-    }
-
     version = InterProScan.validateInterProVersion(interpro_version)
     if (version == null) {
         log.error "--interpro <VERSION>: invalid format; expecting number of 'latest'"
@@ -89,6 +81,5 @@ workflow INIT_PIPELINE {
     datadir          // str: path to data directory, or null if not needed
     outdir           // str: path to output directory
     formats          // set<String>: output file formats
-    signalp_mode     // str: Models to be used with SignalP
     version          // str: InterPro version (or "latest")
 }

--- a/subworkflows/init/main.nf
+++ b/subworkflows/init/main.nf
@@ -76,7 +76,7 @@ workflow INIT_PIPELINE {
     }
 
     if (!offline) {
-        def invalidApps = apps.findAll { app ->
+        invalidApps = apps.findAll { app ->
             ["signalp_euk", "signalp_prok", "deeptmhmm"].contains(app)
         }
 

--- a/subworkflows/scan/main.nf
+++ b/subworkflows/scan/main.nf
@@ -27,8 +27,6 @@ workflow SCAN_SEQUENCES {
     applications        // list of applications to run
     appsConfig          // map of applications
     datadir             // path to data directory
-    signalp_gpu
-    deeptmhmm_gpu
 
     main:
     results = Channel.empty()
@@ -78,7 +76,7 @@ workflow SCAN_SEQUENCES {
         DEEPTMHMM(
             ch_seqs,
             appsConfig.deeptmhmm.dir,
-            deeptmhmm_gpu
+            appsConfig.deeptmhmm.use_gpu
         )
         results = results.mix(DEEPTMHMM.out)
     }
@@ -213,10 +211,11 @@ workflow SCAN_SEQUENCES {
             appsConfig.signalp_euk.organism,
             appsConfig.signalp_euk.mode,
             appsConfig.signalp_euk.dir,
+            appsConfig.signalp_euk.use_gpu,
             appsConfig.signalp_prok.organism,
             appsConfig.signalp_prok.mode,
             appsConfig.signalp_prok.dir,
-            signalp_gpu
+            appsConfig.signalp_prok.use_gpu,
         ).set{ ch_signalp }
         results = results.mix(ch_signalp)
     }

--- a/subworkflows/scan/main.nf
+++ b/subworkflows/scan/main.nf
@@ -27,6 +27,8 @@ workflow SCAN_SEQUENCES {
     applications        // list of applications to run
     appsConfig          // map of applications
     datadir             // path to data directory
+    signalp_gpu
+    deeptmhmm_gpu
 
     main:
     results = Channel.empty()
@@ -212,7 +214,8 @@ workflow SCAN_SEQUENCES {
             appsConfig.signalp_euk.dir,
             appsConfig.signalp_prok.organism,
             appsConfig.signalp_prok.mode,
-            appsConfig.signalp_prok.dir
+            appsConfig.signalp_prok.dir,
+            signalp_gpu
         ).set{ ch_signalp }
         results = results.mix(ch_signalp)
     }

--- a/subworkflows/scan/main.nf
+++ b/subworkflows/scan/main.nf
@@ -77,7 +77,8 @@ workflow SCAN_SEQUENCES {
     if (applications.contains("deeptmhmm")) {
         DEEPTMHMM(
             ch_seqs,
-            appsConfig.deeptmhmm.dir
+            appsConfig.deeptmhmm.dir,
+            deeptmhmm_gpu
         )
         results = results.mix(DEEPTMHMM.out)
     }

--- a/subworkflows/signalp/main.nf
+++ b/subworkflows/signalp/main.nf
@@ -12,16 +12,17 @@ workflow SIGNALP {
     euk_organism
     euk_mode
     euk_dir
+    euk_gpu
     prok_organism
     prok_mode
     prok_dir
-    use_gpu
+    prok_gpu
 
     main:
     results = Channel.empty()
 
     if (applications.contains("signalp_euk")) {
-        if (use) {
+        if (euk_gpu) {
             RUN_SIGNALP_GPU_EUK(
                 ch_seqs,
                 euk_organism,
@@ -43,7 +44,7 @@ workflow SIGNALP {
     }
 
     if (applications.contains("signalp_prok")) {
-        if (use_gpu) {
+        if (prok_gpu) {
             RUN_SIGNALP_GPU_PROK(
                 ch_seqs,
                 prok_organism,

--- a/utilities/docker/deeptmhmm/Dockerfile
+++ b/utilities/docker/deeptmhmm/Dockerfile
@@ -1,9 +1,14 @@
 # This image contains only dependencies for DeepTMHMM. It does not include a copy of DeepTMHMM
-FROM python:3.8-slim
+FROM python:3.9-slim
+
 ENV TZ=Europe/London
-WORKDIR /opt/tmhmm
-COPY . .
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y libhdf5-dev procps
-RUN python3 -m pip install wheel Cython==0.29.37 pkgconfig==1.5.5 \
-  && python3 -m pip install https://download.pytorch.org/whl/cu92/torch-1.5.0%2Bcu92-cp38-cp38-linux_x86_64.whl#sha256=77586f5deca99bf854dce2bce9e533a90dd97694d190b15bd17c170ef493e2b1 \
-  && python3 -m pip install -r requirements.txt
+
+RUN apt-get -y update \
+ && apt-get -y install procps
+
+RUN pip install --no-cache-dir cython==0.29.37 pkgconfig==1.5.5 \
+ && pip install --no-cache-dir torch==1.13.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
+
+COPY requirements.txt /tmp/requirements.txt
+
+RUN pip install --no-cache-dir -r /tmp/requirements.txt

--- a/utilities/docker/deeptmhmm/requirements.txt
+++ b/utilities/docker/deeptmhmm/requirements.txt
@@ -17,6 +17,6 @@ pyparsing==3.0.9
 python-dateutil==2.8.2
 requests==2.28.1
 six==1.16.0
-torch==1.5.0+cu92
+torch==1.13.1+cu117
 tqdm==4.64.1
 urllib3==1.26.12


### PR DESCRIPTION
# Changes

- add a `use_gpu` label for processes that run on GPU
- support switching between CPU and GPU for SignalP and DeepTMHMM using a `use_gpu` property in the apps configuration (`params.appsConfig.deeptmhmm.use_gpu`, `params.appsConfig.signalp_euk.use_gpu`, `params.appsConfig.signalp_prok.use_gpu`)
- remove `--signalp-mode` and `params.signalpMode` as they are not used. The SignalP mode (`fast` or `slow-sequential`) come from the `params.appsConfig`
- raise an error if SignalP or DeepTMHMM are run without `--offline` (their results are not in the Matches API)
- subsplit FASTA files if DeepTMHMM is executed on CPU
- create a new Docker image for DeepTMHMM so it can run on GPU on modern chips (e.g. the A100 we have on the cluster requires CUDA 11, the image used 9). ⚠️ The new image is under my account at `matblum/deeptmhmm:1.0`. When this PR is approved, I'll replace `interpro/deeptmhmm:1.0` with the new image.

## DeepTMHMM

Testing CPU vs GPU on Slurm with 10,000 human sequences.

### CPU

Command:

```sh
nextflow run ebi-pf-team/interproscan6 \
   -profile singularity,slurm \
   -c /hps/software/interproscan/data/licensed.conf \
   -r e367d08 \
   -with-timeline \
   -with-report \
   --input /hps/nobackup/agb/interpro/mblum/interproscran/6.0.0/10000-human-sequences.fa \
   --applications deeptmhmm\
   --formats json \
   --offline
```

**Runtime: 1h 40min**

<details>
<summary>Console</summary>

![image](https://github.com/user-attachments/assets/9b5af70c-ec45-4a6d-969f-f8e0205adf61)
</details>

<details>
<summary>Job duration</summary>

![image](https://github.com/user-attachments/assets/08d9b62f-0a1c-492a-a46c-a0ade3fd0097)
</details>

<details>
<summary>Memory</summary>

![image](https://github.com/user-attachments/assets/be596eeb-dc81-4d86-917a-e0375a573d06)
</details>

### GPU

Command:

```sh
nextflow run ebi-pf-team/interproscan6 \
   -profile singularity,slurm \
   -c /hps/software/interproscan/data/licensed_gpu.conf \
   -r e367d08 \
   -with-timeline \
   -with-report \
   --input /hps/nobackup/agb/interpro/mblum/interproscran/6.0.0/10000-human-sequences.fa \
   --applications deeptmhmm\
   --formats json \
   --offline
```

**Runtime: 1h 06min**

<details>
<summary>Console</summary>

![image](https://github.com/user-attachments/assets/906a38de-7a7c-485b-978f-6fce64cba7a8)
</details>

<details>
<summary>Job duration</summary>

![image](https://github.com/user-attachments/assets/bf432b9d-b9a6-4c74-9a09-4be6c522c7d4)
</details>

<details>
<summary>Memory</summary>

![image](https://github.com/user-attachments/assets/1b10365b-2979-446b-8341-947653f2599e)
</details>

## SignalP

Didn't test GPU or update the Docker image.
