### PR TITLE
report panther node id and prot class

### DIFF
--- a/lib/Match.groovy
+++ b/lib/Match.groovy
@@ -15,7 +15,7 @@ class Match implements Serializable {
     Integer sequenceLength = null
 
     // PRINTS
-    String graphScan = null
+    String graphscan = null
 
     Match(String modelAccession) {
         this.modelAccession = modelAccession
@@ -26,10 +26,10 @@ class Match implements Serializable {
         this.signature = signature
     }
 
-    Match(String modelAccession, Double evalue, String graphScan, Signature signature) {
+    Match(String modelAccession, Double evalue, String graphscan, Signature signature) {
         this.modelAccession = modelAccession
         this.evalue = evalue
-        this.graphScan = graphScan
+        this.graphscan = graphscan
         this.signature = signature
     }
 
@@ -78,7 +78,7 @@ class Match implements Serializable {
         match.included = data.included
         match.locations = data.locations.collect { Location.fromMap(it) }
         match.treegrafter = TreeGrafter.fromMap(data.treegrafter)
-        match.graphScan = data.graphScan
+        match.graphscan = data.graphscan
         match.representativeInfo = RepresentativeInfo.fromMap(data.representativeInfo)
         return match
     }

--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -321,15 +321,16 @@ def writeMobiDBlite(Map match, JsonGenerator jsonWriter) {
 
 def writePANTHER(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-        "signature"   : match.signature,
-        "model-ac"    : match.treegrafter.subfamilyAccession ?: match.modelAccession,
-        "name"        : match.treegrafter.subfamilyDescription,
-        "evalue"      : match.evalue,
-        "score"       : match.score,
-        "proteinClass": match.treegrafter.proteinClass,
-        "graftPoint"  : match.treegrafter.graftPoint,
-        "goXRefs"     : match.treegrafter.goXRefs,
-        "locations"   : match.locations.collect { loc ->
+        "signature"      : match.signature,
+        "model-ac"       : match.treegrafter.subfamilyAccession ?: match.modelAccession,
+        "name"           : match.treegrafter.subfamilyDescription,
+        "evalue"         : match.evalue,
+        "score"          : match.score,
+        "proteinClass"   : match.treegrafter.proteinClass,
+        "graftPoint"     : match.treegrafter.graftPoint,
+        "ancestralNodeID": match.treegrafter.ancestralNodeID,
+        "goXRefs"        : match.treegrafter.goXRefs,
+        "locations"      : match.locations.collect { loc ->
             [
                 "start"             : loc.start,
                 "end"               : loc.end,

--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -328,7 +328,7 @@ def writePANTHER(Map match, JsonGenerator jsonWriter) {
         "score"          : match.score,
         "proteinClass"   : match.treegrafter.proteinClass,
         "graftPoint"     : match.treegrafter.graftPoint,
-        "ancestralNodeID": match.treegrafter.ancestralNodeID,
+        "ancestralNode": match.treegrafter.ancestralNodeID,
         "goXRefs"        : match.treegrafter.goXRefs,
         "locations"      : match.locations.collect { loc ->
             [

--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -388,7 +388,7 @@ def writePRINTS(Map match, JsonGenerator jsonWriter) {
         "signature": match.signature,
         "model-ac" : match.modelAccession,
         "evalue"   : match.evalue,
-        "graphscan": match.graphScan,
+        "graphscan": match.graphscan,
         "locations": match.locations.collect { loc ->
             [
                 "start"             : loc.start,

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -280,7 +280,7 @@ def fmtPantherMatchNode(Map match) {
 def fmtPrintsMatchNode(Map match) {
     return [
         evalue    : match.evalue,
-        graphscan : match.graphScan,
+        graphscan : match.graphscan,
     ]
 }
 

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -271,7 +271,7 @@ def fmtPantherMatchNode(Map match) {
         evalue             : match.evalue,
         "protein-class"    : match.treegrafter.proteinClass,
         "graft-point"      : match.treegrafter.graftPoint,
-        "ancestral-node-id": match.treegrafter.ancestralNodeID,
+        "ancestral-node": match.treegrafter.ancestralNodeID,
         name               : match.signature.name,
         score              : match.score
     ]

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -267,11 +267,13 @@ def fmtDefaultMatchNode(Map match) {
 
 def fmtPantherMatchNode(Map match) {
     return [
-        ac            : match.treegrafter.subfamilyAccession,
-        evalue        : match.evalue,
-        "graft-point" : match.treegrafter.graftPoint,
-        name          : match.signature.name,
-        score         : match.score
+        ac                 : match.treegrafter.subfamilyAccession,
+        evalue             : match.evalue,
+        "protein-class"    : match.treegrafter.proteinClass,
+        "graft-point"      : match.treegrafter.graftPoint,
+        "ancestral-node-id": match.treegrafter.ancestralNodeID,
+        name               : match.signature.name,
+        score              : match.score
     ]
 }
 

--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -71,14 +71,14 @@ process PARSE_PRINTS {
             }
 
             else if (line.startsWithAny("2TBH", "2TBN")) {
-                // Line: 2TBH|N  modelId  NumMotifs  SumId  AveId  ProfScore  Ppvalue  Evalue  GraphScan
-                // Retrieve the graphScan value
+                // Line: 2TBH|N  modelId  NumMotifs  SumId  AveId  ProfScore  Ppvalue  Evalue  graphscan
+                // Retrieve the graphscan value
                 def lineData2TBHN = line.split(/\s+/)
                 assert lineData2TBHN.length == 11
                 String modelName = lineData2TBHN[1]
-                String graphScan = lineData2TBHN[-1]
+                String graphscan = lineData2TBHN[-1]
                 if (thisProteinsMatches.containsKey(modelName)) {
-                    thisProteinsMatches[modelName].graphScan = graphScan
+                    thisProteinsMatches[modelName].graphscan = graphscan
                 }
             }
 
@@ -195,7 +195,7 @@ process PARSE_PRINTS {
                 Match match = finalMatches.computeIfAbsent(
                     filteredMatch.modelId,
                     {
-                        new Match(filteredMatch.modelId, filteredMatch.evalue, filteredMatch.graphScan, new Signature(filteredMatch.modelId, library))
+                        new Match(filteredMatch.modelId, filteredMatch.evalue, filteredMatch.graphscan, new Signature(filteredMatch.modelId, library))
                     }
                 )
                 Location location = new Location(


### PR DESCRIPTION
A tiny PR to add the ancestral node id for persisting Panther matches in the production database, and adds reporting the Panther match `proteinClass` in the XML output so that it is as comprehensive as the JSON.

```json
          "model-ac" : "PTHR32552:SF74",
          "name" : "FERRICHROME IRON RECEPTOR-RELATED",
          "evalue" : 0.0,
          "score" : 481.4,
          "proteinClass" : null,
          "graftPoint" : "PTN002091552",
          "ancestralNodeID" : "AN39",
```