### PR TITLE
Update post processes

### DIFF
--- a/conf/applications.config
+++ b/conf/applications.config
@@ -115,7 +115,7 @@ params {
             name = "SFLD"
             dir = "sfld"
             hmm = "sfld.hmm"
-            hierarchy = "sfld_hierarchy.txt"
+            hierarchy = "sfld_hierarchy.tsv"
             sites_annotation = "sfld_sites.annot"
             has_data = true
         }

--- a/modules/panther/main.nf
+++ b/modules/panther/main.nf
@@ -22,7 +22,7 @@ process PREPARE_TREEGRAFTER {
         def filteredMatches = matches
             .values()
             .collect { m1 ->
-                if (!m1.included || m1.evalue > 0.00000001) {
+                if (!m1.included) {
                     return null
                 }
 
@@ -44,7 +44,7 @@ process PREPARE_TREEGRAFTER {
             }
             .findAll { it != null }
 
-        Match bestMatch = filteredMatches.max { it.locations[0].score }
+        Match bestMatch = filteredMatches.max { it.score }
         return bestMatch ? [(seqId): [(bestMatch.modelAccession): bestMatch]] : [:]
     }
 

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -69,15 +69,10 @@ def decode(byte[] b) {
 
 def filterMatches(Map<String, Map<String, Match>> hmmerMatches, Map<String, Map<String, Object>> dat) {
     /*
-        A match is ignored only if it meets all of the following conditions when compared
-        to previously evaluated Pfam matches:
-        - It overlaps with another match.
-        - Both matches belong to the same clan.
-        - Neither match is fully nested within the other.
-        Reasoning: Pfam matches aren't supposed to overlap, but families within the
-        same clan are evolutionary related so overlapping is common.
-        Therefore, the `nested` field in `pfam_a.dat` is used to whitelist overlaps that
-        can occur between two families.
+        Remove overlapping matches, only keeping the one with the best e-value or score.
+        Pfam matches are not supposed to overlap, but some families can be evolutionary related,
+        especially those belonging to the same clan, so curators can whitelist overlaps using the
+        NE (nested) flag.
     */
     Map<String, List<Match>> filteredMatches = [:]
     hmmerMatches.each { seqId, matches ->
@@ -91,26 +86,42 @@ def filterMatches(Map<String, Map<String, Match>> hmmerMatches, Map<String, Map<
         filteredMatches[seqId] = []
         allMatches.each { match ->
             boolean keep = true
-            Map<String, List<String>> candidateMatch = dat[match.modelAccession] ?: [:]
-            String candidateMatchClan = candidateMatch?.clan
-            filteredMatches[seqId].each { filteredMatch -> // iterate through the matches that have already been chosen
-                Map<String, List<String>> filteredMatchInfo = dat[filteredMatch.modelAccession] ?: [:]
-                String filteredMatchClan = filteredMatchInfo?.clan
-                if (candidateMatchClan == filteredMatchClan) {  // check if both are in the same clan
-                    boolean overlapped = isOverlapping(
-                            match.locations[0].start, match.locations[0].end,
-                            filteredMatch.locations[0].start, filteredMatch.locations[0].end
+
+            Map<String, List<String>> candidateFamily = dat[match.modelAccession] ?: [:]
+            // String candidateFamilyClan = candidateFamily?.clan
+            List<String> candidateNested = candidateFamily?.nested ?: []
+
+            // Compare the current match with matches already accepted
+            filteredMatches[seqId].each { filteredMatch ->
+                boolean overlapped = isOverlapping(
+                        match.locations[0].start, 
+                        match.locations[0].end,
+                        filteredMatch.locations[0].start, 
+                        filteredMatch.locations[0].end
+                )
+
+                if (overlapped) {
+                    // Matches are overlapping
+
+                    Map<String, List<String>> filteredFamily = dat[filteredMatch.modelAccession] ?: [:]
+                    // String filteredFamilyClan = filteredFamily?.clan
+                    List<String> filteredNested = filteredFamily?.nested ?: []
+
+                    boolean canBeNested = (candidateNested.contains(filteredMatch.modelAccession)
+                                           || filteredNested.contains(match.modelAccession))
+                    boolean fullyEnclosed = isFullyEnclosed(
+                            match.locations[0].start,
+                            match.locations[0].end,
+                            filteredMatch.locations[0].start,
+                            filteredMatch.locations[0].end
                     )
-                    if (overlapped) {
-                        List<String> candidateNested = candidateMatch?.nested ?: []
-                        List<String> filteredNested = filteredMatchInfo?.nested ?: []
-                        // check if candidates are NOT nested
-                        if (!candidateNested.contains(filteredMatch.modelAccession) && !filteredNested.contains(match.modelAccession)) {
-                            keep = false
-                        }
+
+                    if (!canBeNested || !fullyEnclosed) {
+                        keep = false
                     }
                 }
             }
+
             if (keep) {
                 filteredMatches[seqId] << match
             }
@@ -142,112 +153,71 @@ def isOverlapping(location1Start, location1End, location2Start, location2End) {
     Math.max(location1Start, location2Start) <= Math.min(location1End, location2End)
 }
 
+def isFullyEnclosed(location1Start, location1End, location2Start, location2End) {
+    return (location1Start <= location2Start && location1End >= location2End) 
+           || (location2Start <= location1Start && location2End >= location1End)
+}
+
 def buildFragments(Map<String, Map<String, Match>> filteredMatches,
                    Map<String, Map<String, Object>> dat,
                    int MINLENGTH) {
-    /* Add fragmentLocation objects to the Matches and gather Matches for the same
-    model accession into a single Match object */
     Map<String, Map<String, Match>> processedMatches = [:]
     filteredMatches.each { String seqId, List<Match> matches ->
         def aggregatedMatches = [:]
         matches.each { Match match ->
+            // We flattened matches and locations so one location only per match here
+            def location = match.locations[0]
+
             List<String> nestedModels = dat[match.modelAccession]?.nested ?: []
             if (nestedModels) {
-                /* Find all matches whose models are listed as nested within the current model
-                in pfam_a.dat AND which overlap the current match.
-                Then these matches are converted into a list of maps, that each contain a
-                `start` and `end` field. */
-                List<Map<String, Integer>> locationFragments = matches.findAll { otherMatch ->
-                    otherMatch.modelAccession in nestedModels &&
-                            isLocationFullyEnclosed(otherMatch.locations[0].start, otherMatch.locations[0].end,
-                                    match.locations[0].start, match.locations[0].end)
-                }.collect { otherMatch ->
-                    [start: otherMatch.locations[0].start, end: otherMatch.locations[0].end]
-                }
-                locationFragments.sort { a, b -> a.start <=> b.start ?: a.end <=> b.end }
-
-                /* Process fragments and identify discontinuous matches.
-                The fragmentDcStatus var tracks whether a match is continuous or has discontinuities
-                due to nested fragments */
-                String fragmentDcStatus = "CONTINUOUS"
-                def discontinuousMatchesList = [match]
-                locationFragments.each { fragment ->
-                    // As we iterate over each fragment, we will attempt to split or adjust matches
-                    def newMatchesFromFragment = []
-                    discontinuousMatchesList.each { rawDiscontinuousMatch ->
-                        List<LocationFragment> fragments = []
-                        int newLocationStart = rawDiscontinuousMatch.locations[0].start
-                        int newLocationEnd = rawDiscontinuousMatch.locations[0].end
-                        int finalLocationEnd = rawDiscontinuousMatch.locations[0].end
-
-                        // The fragment does NOT overlap the match, so the match is left unchanged
-                        if (!isOverlapping(newLocationStart, newLocationEnd, fragment['start'], fragment['end'])) {
-                            newMatchesFromFragment << rawDiscontinuousMatch
-                            return
-                        }
-
-                        if (fragment['start'] <= newLocationStart && fragment['end'] >= newLocationEnd) {
-                            fragmentDcStatus = "NC_TERMINAL_DISC"
-                            fragments.add(new LocationFragment(newLocationStart, newLocationEnd, fragmentDcStatus))
-                            rawDiscontinuousMatch.locations[0].fragments = fragments
-                            newMatchesFromFragment << rawDiscontinuousMatch
-                            return
-                        }
-
-                        boolean areSeparateFrags = false
-                        if (fragment['start'] <= newLocationStart) {
-                            newLocationStart = fragment['end'] + 1
-                            fragmentDcStatus = "N_TERMINAL_DISC"
-                        } else if (fragment['end'] >= newLocationEnd) {
-                            newLocationEnd = fragment['start'] - 1
-                            fragmentDcStatus = "C_TERMINAL_DISC"
-                        } else if (fragment['start'] > newLocationStart && fragment['end'] < newLocationEnd) {
-                            newLocationEnd = fragment['start'] - 1
-                            areSeparateFrags = true
-                            fragmentDcStatus = "C_TERMINAL_DISC"
-                        }
-
-                        // Keep the region only if it meets the MINLENGTH
-                        if (newLocationEnd - newLocationStart + 1 >= MINLENGTH) {
-                            fragments.add(new LocationFragment(newLocationStart, newLocationEnd, fragmentDcStatus))
-                            rawDiscontinuousMatch.locations[0].fragments = fragments
-                        }
-                        newLocationStart = fragment.end + 1
-                        // The first region (located upstream of the fragment) has already been handled, not handle the second regions (downstream of the fragment)
-                        if (areSeparateFrags) {
-                            fragmentDcStatus = "N_TERMINAL_DISC"
-                            rawDiscontinuousMatch.locations[0].end = finalLocationEnd  // ensure the 2nd frag extends to the original match's end position
-                            // Keep the 2nd region only if it meets the MINLENGTH and store as a new LocationFragment inside discontinuousMatch
-                            if (finalLocationEnd - newLocationStart + 1 >= MINLENGTH) {
-                                fragments.add(new LocationFragment(newLocationStart, finalLocationEnd, fragmentDcStatus))
-                                rawDiscontinuousMatch.locations[0].fragments = fragments
-                            }
-                        }
-
-                        // If only one valid fragment remains after filtering, update the match start and end to reflect the new fragment boundaries
-                        if (rawDiscontinuousMatch.locations[0].fragments.size() == 1) {
-                            rawDiscontinuousMatch.locations[0].start = rawDiscontinuousMatch.locations[0].fragments[0].start
-                            rawDiscontinuousMatch.locations[0].end = rawDiscontinuousMatch.locations[0].fragments[0].end
-                        }
-
-                        newMatchesFromFragment << rawDiscontinuousMatch
+                /*
+                    Find all locations belonging to matches that:
+                    - overlap the current location
+                    - belong to models that can be nested within the model of the current match
+                */
+                List<Map<String, Integer>> overlappingLocations = matches
+                    .findAll { otherMatch ->
+                        otherMatch.modelAccession in nestedModels 
+                        && isFullyEnclosed(
+                            otherMatch.locations[0].start, 
+                            otherMatch.locations[0].end,
+                            location.start, 
+                            location.end
+                        )
                     }
-                    // filter out fragment matches that are shorter than MINLENGTH
-                    discontinuousMatchesList = newMatchesFromFragment.findAll { it.locations[0].end - it.locations[0].start + 1 >= MINLENGTH }
+                    .collect { otherMatch ->
+                        [start: otherMatch.locations[0].start, end: otherMatch.locations[0].end]
+                    }
+
+                // Sort these locations by position
+                overlappingLocations.sort { a, b -> a.start <=> b.start ?: a.end <=> b.end }
+
+                def fragments = []
+                int start = location.start
+
+                overlappingLocations.each { otherLocation ->
+                    if (otherLocation.start > start && otherLocation.end < location.end) {
+                        String status = fragments.isEmpty() ? "C_TERMINAL_DISC" : "NC_TERMINAL_DISC"
+                        fragments.add(new LocationFragment(start, otherLocation.start - 1, status))
+                        start = otherLocation.end + 1
+                    }
                 }
-                aggregatedMatches = storeMatches(aggregatedMatches, discontinuousMatchesList)
-            } else if (match.locations[0].end - match.locations[0].start + 1 >= MINLENGTH) {  // filter out matches that are shorter than MINLENGTH
-                aggregatedMatches = storeMatches(aggregatedMatches, [match])
+
+                fragments.add(new LocationFragment(start, location.end, "N_TERMINAL_DISC"))
+                location.fragments = fragments
+            }
+            
+            if (location.end - location.start + 1 >= MINLENGTH) {
+                if (aggregatedMatches.containsKey(match.modelAccession)) {
+                    aggregatedMatches[match.modelAccession].locations << location
+                } else {
+                    aggregatedMatches[match.modelAccession] = match
+                }
             }
         }
         processedMatches[seqId] = aggregatedMatches
     }
     return processedMatches
-}
-
-def isLocationFullyEnclosed(location1Start, location1End, location2Start, location2End) {
-    return (location1Start <= location2Start && location1End >= location2End) ||
-            (location2Start <= location1Start && location2End >= location1End)
 }
 
 def storeMatches(Map<String, Match> aggregatedMatches, List<Match> matches) {

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -103,7 +103,6 @@ def filterMatches(Map<String, Map<String, Match>> hmmerMatches, Map<String, Map<
                     // Matches are overlapping
 
                     Map<String, List<String>> filteredFamily = dat[filteredMatch.modelAccession] ?: [:]
-                    // String filteredFamilyClan = filteredFamily?.clan
                     List<String> filteredNested = filteredFamily?.nested ?: []
 
                     boolean canBeNested = (candidateNested.contains(filteredMatch.modelAccession)

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -88,7 +88,6 @@ def filterMatches(Map<String, Map<String, Match>> hmmerMatches, Map<String, Map<
             boolean keep = true
 
             Map<String, List<String>> candidateFamily = dat[match.modelAccession] ?: [:]
-            // String candidateFamilyClan = candidateFamily?.clan
             List<String> candidateNested = candidateFamily?.nested ?: []
 
             // Compare the current match with matches already accepted

--- a/modules/sfld/main.nf
+++ b/modules/sfld/main.nf
@@ -63,7 +63,7 @@ process PARSE_SFLD {
     def outputFilePath = task.workDir.resolve("sfld.json")
     def (hmmLengths, hmmBounds) = getHmmData(hmmsearch_out.toString())
     def sequences = parseOutput(postprocess_out.toString(), hmmLengths, hmmBounds)
-    def hierarchy = parseHierarchy("${dirpath.toString()}/${hierarchydb}")
+    def hierarchies = getHierarchies("${dirpath.toString()}/${hierarchydb}")
     SignatureLibraryRelease library = new SignatureLibraryRelease("SFLD", null)
 
     sequences = sequences.collectEntries { seqId, matches -> 
@@ -78,22 +78,22 @@ process PARSE_SFLD {
         }
 
         if (matches.size() > 1) {
-            // Now resolve matches to remove overlapping matches from the same hierarchy
+            // Remove overlapping matches from models in the same hierarchy (keep the most specific)
             Set<Integer> ignored = [] as Set
             matches = matches
                 .collect { match ->
                     if (match.modelAccession.startsWith("SFLDF")) {
-                        // Hihgly specific model: always add
+                        // Hihgly specific model (family): always keep
                         return match
                     }
 
-                    boolean overlaps = false
+                    boolean ignore = false
                     for (Match otherMatch: matches) {
-                        if (ignored.contains(otherMatch)) {
-                            // Current match overlaps with another match: ignore
+                        if (match.modelAccession == otherMatch.modelAccession) {
+                            // Two matches/locations from the same mode: keep
                             continue
-                        } else if (match.modelAccession == otherMatch.modelAccession) {
-                            // Two matches/locations from the same model: keep
+                        } else if (ignored.contains(otherMatch)) {
+                            // otherMatch has previously been flagged as to be ignored
                             continue
                         }
 
@@ -103,16 +103,19 @@ process PARSE_SFLD {
                         if (!(l1.start > l2.end || l2.start > l1.end)) {
                             // Matches overlap
                             
-                            def otherParents = hierarchy.get(otherMatch.modelAccession)
+                            def otherParents = hierarchies.get(otherMatch.modelAccession)
                             if (otherParents != null && otherParents.contains(match.modelAccession)) {
-                                // Current match overlaps a more specific match: we want to keep the most specific
-                                overlaps = true
+                                /*
+                                    The current match overlaps a match from a more specific model:
+                                    we want to keep the most specific match, so we ignore the current match
+                                */
+                                ignore = true
                                 break
                             }    
                         }
                     }
 
-                    if (overlaps) {
+                    if (ignore) {
                         // Mark this match as to be ignored
                         ignored.add(match)
                         return null
@@ -123,93 +126,79 @@ process PARSE_SFLD {
                 .findAll { it != null }
         }
 
-        def selectedMatches = [] as Set
+        def matchesWithPromoted = matches.clone()
         matches.each { match ->
-            def parents = hierarchy.get(match.modelAccession)
+            def parents = hierarchies.get(match.modelAccession)
             if (parents) {
                 /*
                     Propagate match up through it hierarchy.
                     If there are Superfamily, Group, and Family models in a tree,
                     and a sequence matches F, it should inherit the S and G annotations
                 */
-                def promotedMatches = parents
-                    .findAll { it != match.modelAccession }
-                    .collect {
-                        Signature signature = new Signature(it, library)
-                        Match promotedMatch = new Match(it, match.evalue, match.score, match.bias, signature)
-                        promotedMatch.addLocation(match.locations[0].clone())
-                        return promotedMatch
-                    }
-                selectedMatches.addAll(promotedMatches)
-            }
-        }
-        
-        if (selectedMatches.size() > 0) {
-            /*
-                Cases where matches have the same locations and the same ancestor (e.g., SFLDF00273
-                and SFLDF00413 have the same ali location and the same ancestor — SFLDS00029 —
-                so SFLDS00029 is duplicated when promoted).
-            */
-            List<Match> uniqueMatches = []
-            Set<String> seenKeys = [] as Set
-            // sorting matches by location evalue ASC, location score DESC to keep the best matches
-            List<Match> sortedMatches = selectedMatches.sort { a, b ->
-                (a.locations[0].evalue <=> b.locations[0].evalue) ?: -(a.locations[0].score <=> b.locations[0].score)
-            }
-            sortedMatches.each { match ->
-                String key = "${match.modelAccession}:${match.locations[0].start}:${match.locations[0].end}"
-                if (seenKeys.contains(key)) {
-                    return
+                parents.each { parent ->
+                    Signature signature = new Signature(parent, library)
+                    Match promotedMatch = new Match(parent, match.evalue, match.score, match.bias, signature)
+                    Location location = match.locations[0].clone()
+                    location.sites.clear()
+                    promotedMatch.addLocation(location)
+                    matchesWithPromoted.add(promotedMatch)
                 }
-                uniqueMatches.add(match)
-                seenKeys.add(key)
             }
-            selectedMatches = uniqueMatches
         }
 
-        // Add initial matches (the ones used for promotion)
-        selectedMatches.addAll(matches)
-
-        // List to Map
-        def finalMatches = [:]
-        selectedMatches.each { match ->
-            Match finalMatch = finalMatches.get(match.modelAccession)
-            if (finalMatch) {
-                finalMatch.addLocation(match.locations[0])
+        // Merge locations from the same model together
+        matches = [:]
+        matchesWithPromoted.each { match ->
+            Match mergedMatch = matches.get(match.modelAccession)
+            if (mergedMatch) {
+                mergedMatch.addLocation(match.locations[0])
             } else {
-                finalMatches[match.modelAccession] = match
+                matches[match.modelAccession] = match
             }
         }
 
-        return [seqId, finalMatches]
+        // Remove nested locations
+        matches.each { modelAccession, match ->
+            def locations = []
+            match.locations
+                .sort { a, b ->
+                    a.start <=> b.start ?: b.end <=> a.end
+                }
+                .each { location ->
+                    boolean isContained = locations.any { loc ->
+                        loc.start <= location.start && loc.end >= location.end
+                    }
+                    if (!isContained) {
+                        locations << location
+                    }
+                }
+
+            match.locations = locations
+        }
+
+        return [seqId, matches]
     }
 
     def json = JsonOutput.toJson(sequences)
     new File(outputFilePath.toString()).write(json)
 }
 
-Map<String, Set<String>> parseHierarchy(String filePath) {
-    def hierarchy = [:]
-    File file = new File(filePath)
-    file.withReader{ reader ->
-        for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-            def accessions = line.split(/\t/).toList()
-            def childAccession = accessions[-2]  // the final component is the description, only take the accs
-            def parents = accessions.subList(0, accessions.size() - 2)
-            hierarchy[childAccession] = parents as Set
-            for (parent in parents) {  // ensure all ancestors are in the hierarchy
-                ancestors = hierarchy.get(parent)
-                if (ancestors.size() > 0) {
-                    hierarchy[childAccession].addAll(ancestors)
-                }
+Map<String, Set<String>> getHierarchies(String filePath) {
+    def hierarchies = [:].withDefault { [] as Set }
+    new File(filePath).eachLine { line ->
+        def nodes = line.split(/\t/).toList()
+        nodes.eachWithIndex { node, idx ->
+            if (idx > 0) {
+                def ancestors = nodes.subList(0, idx) as Set
+                hierarchies[node].addAll(ancestors)
             }
-	    }
+        }
     }
-    return hierarchy
+    return hierarchies
 }
 
 List<Map> getHmmData(String outputFilePath) {
-    def matchesMap = HMMER3.parseOutput(outputFilePath.toString(), "AntiFam")  // proteinMd5: modelAccession: Match
+    def matchesMap = HMMER3.parseOutput(outputFilePath.toString(), "SFLD")  // proteinMd5: modelAccession: Match
     def hmmLengths = [:]  // modelAccession: hmmLength
     def hmmBounds  = [:]  // proteinMd5: modelAccession: (tuple representing loc): hmmbound
     matchesMap.each { String sequenceId, matches ->

--- a/modules/sfld/main.nf
+++ b/modules/sfld/main.nf
@@ -83,7 +83,7 @@ process PARSE_SFLD {
             matches = matches
                 .collect { match ->
                     if (match.modelAccession.startsWith("SFLDF")) {
-                        // Hihgly specific model (family): always keep
+                        // Highly specific model (family): always keep
                         return match
                     }
 


### PR DESCRIPTION
This PR updates the post-processing steps of the following analyses:

- PANTHER: use the full sequence hit score instead of the domain score to select the best hit. This is to make results more consistent with InterProScan 5 and the [PANTHER online search service](https://pantherdb.org/tools/sequenceSearchForm.jsp?).
- Pfam: restructure/simplify the code and enable overlaps if two families are allowed to be nested (`NE` flag) even if they do not belong to the same clan
- SFLD: remove nested locations (can happen if two families from the same superfamily match the same sequence). Also switch to a hierarchy file with a corrected SFLD hierarchy. Download ([sfld_hierarchy.zip](https://github.com/user-attachments/files/20300799/sfld_hierarchy.zip)) and extract the TSV file in `<datadir>/sfld/4`.
