### PR TITLE
Patch FunFam and XML nucleotide writer

### DIFF
--- a/modules/cath/funfam/main.nf
+++ b/modules/cath/funfam/main.nf
@@ -50,7 +50,7 @@ process SEARCH_FUNFAM {
     tuple val(meta), val(meta2), path("hmmsearch.out")
 
     script:
-    def commands = ""
+    def commands = "touch hmmsearch.out\n"
     supfams.each { cathId -> 
         String hmmFilePath = cathId.split("\\.").join(File.separator) + ".hmm"
         String hmmPath = "${root_dir.toString()}/${hmmFilePath}"

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -28,7 +28,7 @@ process WRITE_XML {
                 Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
                 nucleicToProteinMd5 = db.groupProteins(proteins)
                 nucleicToProteinMd5.each { String nucleicMd5, Set<String> proteinMd5s ->
-                    addNucleotideNode(nucleicMd5, proteinMd5s, matchFile, xml, db)
+                    addNucleotideNode(nucleicMd5, proteinMd5s, proteins, xml, db)
                 }
             } else {
                 Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)


### PR DESCRIPTION
Fixes issues #207 (FunFam crashing) and #208 (XML writer crashing when writing nucleotide seqs).

Tested with:

```bash
nextflow run main.nf  \
    --input tests/data/test.fna \
    --datadir <DATA> \
    -profile singularity \
    --outdir <OUTDIR>  \
    --nucleic \
    --applications funfam
...
[e7/89bf4b] PREPARE_DATABASES:FIND_MISSING_DATA       [100%] 1 of 1 ✔
[7f/b51f8f] PREPARE_DATABASES:VALIDATE_DATA           [100%] 1 of 1 ✔
[d2/9ce39c] PREPARE_SEQUENCES:VALIDATE_FASTA (1)      [100%] 1 of 1 ✔
[26/4dfdd7] PREPARE_SEQUENCES:LOAD_SEQUENCES (1)      [100%] 1 of 1 ✔
[62/12c85d] PREPARE_SEQUENCES:ESL_TRANSLATE (1)       [100%] 1 of 1 ✔
[35/24c71b] PREPARE_SEQUENCES:LOAD_ORFS (1)           [100%] 1 of 1 ✔
[a3/66ca6a] PREPARE_SEQUENCES:SPLIT_FASTA (1)         [100%] 1 of 1 ✔
[7a/2212b2] LOOKUP:PREPARE_LOOKUP                     [100%] 1 of 1 ✔
[d9/c78193] LOOKUP:LOOKUP_MATCHES (1)                 [100%] 7 of 7 ✔
[09/c52eb7] SCAN_SEQUENCES:CATH:SEARCH_GENE3D (21)    [100%] 32 of 32 ✔
[41/c80898] SCAN_SEQUENCES:CATH:RESOLVE_GENE3D (32)   [100%] 32 of 32 ✔
[dc/00a8f2] SCAN_SEQUENCES:CATH:ASSIGN_CATH (32)      [100%] 32 of 32 ✔
[3a/e7aeaf] SCAN_SEQUENCES:CATH:PARSE_CATHGENE3D (32) [100%] 32 of 32 ✔
[95/da22cb] SCAN_SEQUENCES:CATH:PREPARE_FUNFAM (32)   [100%] 32 of 32 ✔
[d9/ee5f11] SCAN_SEQUENCES:CATH:SEARCH_FUNFAM (32)    [100%] 32 of 32 ✔
[52/bc87d2] SCAN_SEQUENCES:CATH:RESOLVE_FUNFAM (32)   [100%] 32 of 32 ✔
[be/1ee996] SCAN_SEQUENCES:CATH:PARSE_FUNFAM (32)     [100%] 32 of 32 ✔
[77/5eafcc] SCAN_SEQUENCES:REPORT_NO_MATCHES (6)      [100%] 7 of 7 ✔
[48/0b777b] COMBINE:COMBINE_MATCHES (2)               [100%] 7 of 7 ✔
[71/4e825a] COMBINE:XREFS (7)                         [100%] 7 of 7 ✔
[da/4196d0] COMBINE:REPRESENTATIVE_LOCATIONS (7)      [100%] 7 of 7 ✔
[a1/085488] OUTPUT:WRITE_JSON (1)                     [100%] 1 of 1 ✔
[f1/360cdc] OUTPUT:WRITE_TSV (1)                      [100%] 1 of 1 ✔
[4d/9b4d94] OUTPUT:WRITE_XML (1)                      [100%] 1 of 1 ✔
InterProScan completed successfully.
Results are located at /hps/nobackup/agb/interpro/ehobbs/i6-results/nucleic/test.fna.*
Duration: 55m 16s
Completed at: 29-May-2025 13:41:21
Duration    : 55m 15s
CPU hours   : 3.3
Succeeded   : 302
```

I'm currently double checking the patch by running the above command without the `--applications` flag so that it runs with all unlicensed software.