### PR TITLE
Fix division undefined error

### DIFF
--- a/modules/pirsf/main.nf
+++ b/modules/pirsf/main.nf
@@ -101,7 +101,7 @@ process PARSE_PIRSF {
             double ld = Math.abs(sequenceLength - meanL)
 
             // Ratio over coverage of sequence and profile hmm
-            double r = (location.hmmEnd - location.hmmStart) / (location.end - location.start)
+            double r = (location.hmmEnd - location.hmmStart + 1) / (location.end - location.start + 1)
 
             return r > LENGTH_RATIO_THRESHOLD
                 && ovl >= OVERLAP_THRESHOLD


### PR DESCRIPTION
The `+1 ` on ratio calculation was to avoid 0 division, so putting it back (or maybe a better suggestion to solve this issue?)

```
ERROR ~ Error executing process > 'SCAN_SEQUENCES:PIRSF:PARSE_PIRSF (1)'

Caused by:
  Division undefined -- Check script './subworkflows/scan/../pirsf/../../modules/pirsf/main.nf' at line: 104
```

How to reproduce:
nextflow run main.nf --input debug.fasta --formats json --datadir data -profile docker --offline --applications pirsf

debug.fasta:
```
>sp|Q8IFN0|YD115_PLAF7 Uncharacterized protein PFD1115c OS=Plasmodium falciparum (isolate 3D7) OX=36329 GN=PFD1115c PE=1 SV=1
MNLLRKKVKNEKSLSTLLINEEENKNIEMTTLKDKKEMKNENLSKINVKKENHDKNHDKN
HDKNHDKNHDKNHDKNHDKNHDKNHDKNHDKNHVKNNVEYYNDVFTHLYNCDDGGEEPKE
YSHKKKQVNNKKKWKKQYKAVKLYMNMFLNNYKLKKGKGNCKNLSSVKKRRKKKKIIQND
YIRIINAEKEYVQKYHEDKIFLDNIKNVSSCELIKDCSYSVFFYNLFIKGLYLNKQNLEH
ATEKEHIQKNITKNITKNELHINKTSEHVSNITKLKKNYNKHNVILFKGKYTRQLICDYL
KFLLNSIQNEHTIKAHFYILDYVNDLENKKKEMAKKIKMESFIFTNSNEEDKLCKDIILN
CNILNEQKEDDNKSDNPLYSNNNTLKEQNTSTPLPSHEIQTESMNSPNLLNVKNMNQTKD
DNGCTKEEIIKSNNLMKTYDIKINEHIYNKILNNFISELKSFFFSILEKIRSSKLLLRFI
VTLSEICLILTPHYVNIINFIEILCDFGHIIPIHYISHFIHFFQCNKNIFIQKYKEFQHC
IINNDPIKIQSVGARLIGFIKILQKKIHLNNNEQSMYSFFLNLLLSECLPINHLGFCNRQ
SAKNNFHYFFQESLDCCYKKFKEEQILYDNFELNIQNNIKNYKKIKTIIEHEIELNSDKY
LIKEEDENFISAKNVISDEQDGEDTLYKKRKREEFKETSLTKKKQKKKNDEIKKTGEEKK
KTGEEKKKTGEEKKKTGEEKKKTGEEKKKTGEEKKKTGEEKKKTGEEKKKTGEEKKLTND
VTHLTNDVTHLTNDVTHLTNDVTHLTNDVTHLTNDVTHLTNDVTHLTNDVTHLTNDVTHL
TNDVTHLTNDVTHLTNDVTHLTNEKYIEEKDTKEMYLSYMSFISLVAFIKYPEIITQDNI
ILVEDVYNSFKTFLNYINSLEKEKKENFKRTKKYMNMIKAYLFNDHIDILANVHIFKVLV
YDENFLRVLFFNILVVLNYLNRELQICVKDDNELDNNNNKNNNNNKNNNNNKNNNNNNNN
NNNNNNNNDNGVKKNDPAIISPRSSFLFFVEYDKNDDHELGDPEKINNHLNGLMTRGHQK
SIRENIKNKESGKSSILTTGTSNNNNNVNNMNNNMNNNMNNNMNNHMNSNNNVVDSNSTN
FKENVKNKDNSNNRNMSVNQNILHNKTKDIKFCKENDDKFVIKEKIKKIMFTFVKELLNY
LDGFINSNHNFMLAKEYSWYVWKKQLNVAKYNKDDYDISFKFKCIDENIKEQNYDINQTT
NNNTYNNQTSNHMNENLHTDESSKSNNNQDKTVYTNEVSYLPNIPKKNKKTDNQSPVQTL
INIIQNFELLNKKMKPFYCNNKNKNKNKNKNKNKNMEQINNKDITMNLCNNNNNIIHNKE
QDNIQQHDDNNIINTNNDQSSYNNDIFHINNFLLEINKIYLRREAEFWELDESDSLTDEK
KNDSNKKILIEKLIDKLDDYKKKINIDNDPINEIEENEKSKNNPVFKFRLSKLFILKYID
LYTIVKNKEFTTDCDFLYNLMIQMDKNVEKKKSLLNKGVVENDEDINVEHHINMEDEKNE
KLNDKEGEYEDVTENLNEQEAEEEAEEEAEEEEEEEDKFLTPEHLPINVEIK
```