### PR TITLE
Add skip-applications param

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -31,6 +31,7 @@ workflow {
         params.matchesApiUrl,
         params.interpro,
         params.skipInterpro,
+        params.skipApplications,
         params.goterms,
         params.pathways
     )

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,6 +7,7 @@ params {
     goterms               = false
     outdir                = "."
     pathways              = false
+    skipApplications      = null
     skipInterpro          = false
     interpro              = "latest"
     batchSize             = 5000

--- a/subworkflows/init/main.nf
+++ b/subworkflows/init/main.nf
@@ -11,6 +11,7 @@ workflow INIT_PIPELINE {
     matches_api_url
     interpro_version
     skip_intepro
+    skip_applications
     goterms
     pathways
 
@@ -23,7 +24,7 @@ workflow INIT_PIPELINE {
     }
 
     // Applications validation
-    (apps, error) = InterProScan.validateApplications(applications, apps_config)
+    (apps, error) = InterProScan.validateApplications(applications, skip_applications, apps_config)
     if (!apps) {
         log.error error
         exit 1


### PR DESCRIPTION
How to test:
`nextflow run main.nf --datadir data -profile docker,test --no-matches-api --skip-applications ncbifam,cdd,funfam,panther,prints,prositeprofiles,prositepatterns,coils,superfamily,pfam,gene3d,mobidblite,smart,pirsr,pirsf,deeptmhmm,phobius,signalp_euk,signalp_prok`

It needs to run only antifam, sfld and hamap