### PR TITLE
SMART little fix

### DIFF
--- a/modules/smart/main.nf
+++ b/modules/smart/main.nf
@@ -156,7 +156,7 @@ process PARSE_SMART {
     String serThrKinaseAccession = "SM00220"
     def serThrKinasePattern = ~/.*D[LIVM]K\w\wN.*/
 
-    matches.collectEntries { seqId, models ->
+    def filteredMatches = matches.collectEntries { seqId, models ->
         def filteredModels = [:]
 
         if (models.containsKey(tyrKinaseAccession) && models.containsKey(serThrKinaseAccession)) {
@@ -187,6 +187,6 @@ process PARSE_SMART {
     }
 
     def outputFilePath = task.workDir.resolve("smart.json")
-    def json = JsonOutput.toJson(matches)
+    def json = JsonOutput.toJson(filteredMatches)
     new File(outputFilePath.toString()).write(json)
 }


### PR DESCRIPTION
Small issue on SMART:

For tyrKinaseAccession (SM00219) and  serThrKinaseAccession (SM00220) it was filtering correct but not saving to output.
Debug of this case:
```
>tr|A3KFJ0|A3KFJ0_HUMAN non-specific serine/threonine protein kinase OS=Homo sapiens OX=9606 GN=AURKA PE=1 SV=1
MDRSKENCISGPVKATAPVGGPKRVLVTQQFPCQNPLPVNSGQAQRVLCPSNSSQRIPLQ
AQKLVSSHKPVQNQKQKQLQATSVPHPVSRPLNNTQKSKQPLPSAPENNPEEELASKQKN
EESKKRQWALEDFEIGRPLGKGKFGNVYLAREKQSKFILALKVLFKAQLEKAGVEHQLRR
EVEIQSHLRHPNILRLYGYFHDATRVYLILEYAPLGTVYRELQKLSKFDEQRTATYITEL
ANALSYCHSKRVIHRDIKPENLLLGSAGELKIADFGWSVHAPSSRRTTLCGTLDYLPPEM
IEGRMHDEKVDLWSLGVLCYEFLVGKPPFEANTYQETYKRISRVRRN

> D6BAC0683FEE7D97CACDF412B0C1CBFD      SM00219 133     346 (only on i6)
- D6BAC0683FEE7D97CACDF412B0C1CBFD      SM00220 133     347 (in both, i5 and i6)
```
Prints of debug:
first -> enter in correct IF
second -> print for filteredModels
third -> print of matches
```
Adding Serine-Threonine Kinase model: SM00220 for sequence: D6BAC0683FEE7D97CACDF412B0C1CBFD
Sequence ID: D6BAC0683FEE7D97CACDF412B0C1CBFD, Models: [SM00220]
Filtered matches: [D6BAC0683FEE7D97CACDF412B0C1CBFD:[SM00220:Match@196f4b90, SM00219:Match@4b80d61e]]
```

After this change, no more differences between i5 and i6 o/