### PR TITLE
Output prefix

### DIFF
--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -36,6 +36,11 @@ class InterProScan {
             description: "output directory where results will be saved. Default: current working directory."
         ],
         [
+            name: "outprefix",
+            metavar: "<PREFIX>",
+            description: "base name for output files, without directory. Extension will be added automatically. This affects filenames only, not their location. Must not contain slashes or path components. Default: input filename."
+        ],
+        [
             name : "interpro",
             metavar: "<VERSION>",
             description: "the InterPro release to be used. Defaults to 'latest'."

--- a/main.nf
+++ b/main.nf
@@ -27,6 +27,7 @@ workflow {
         params.datadir,
         params.formats,
         params.outdir,
+        params.outprefix,
         params.noMatchesApi,
         params.matchesApiUrl,
         params.interpro,
@@ -37,7 +38,7 @@ workflow {
     fasta_file           = Channel.fromPath(INIT_PIPELINE.out.fasta.val)
     applications         = INIT_PIPELINE.out.apps.val
     data_dir             = INIT_PIPELINE.out.datadir.val
-    out_dir              = INIT_PIPELINE.out.outdir.val
+    outprefix            = INIT_PIPELINE.out.outprefix.val
     formats              = INIT_PIPELINE.out.formats.val
     interpro_version     = INIT_PIPELINE.out.version.val
 
@@ -122,7 +123,7 @@ workflow {
         ch_results,
         seq_db_path,
         formats,
-        out_dir,
+        outprefix,
         params.nucleic,
         workflow.manifest.version,
         db_releases

--- a/main.nf
+++ b/main.nf
@@ -129,15 +129,3 @@ workflow {
         db_releases
     )
 }
-
-workflow.onComplete = {
-    def input_file = file(params.input)
-    def outputFileName = input_file.getName()
-    def outputDir = params.outdir.endsWith('/') ? params.outdir[0..-2] : params.outdir
-
-    if (workflow.success) {
-        println "InterProScan completed successfully."
-        println "Results are located at ${outputDir}/${outputFileName}.*"
-        println "Duration: ${workflow.duration}"
-    }
-}

--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -12,7 +12,7 @@ process WRITE_JSON {
 
     input:
     val matches_files  // {query prot seq md5: {model acc: match}}
-    val output_prefix
+    val output_file
     val seq_db_file
     val nucleic
     val interproscan_version
@@ -20,8 +20,6 @@ process WRITE_JSON {
 
     exec:
     ObjectMapper jacksonMapper = new ObjectMapper()
-    def output_file = "${output_prefix}.json"
-
     SeqDB db = new SeqDB(seq_db_file.toString())
 
     streamJson(output_file.toString(), jacksonMapper) { JsonGenerator jsonWriter ->

--- a/modules/output/tsv/main.nf
+++ b/modules/output/tsv/main.nf
@@ -8,13 +8,13 @@ process WRITE_TSV {
 
     input:
     val matchesFiles
-    val outputPath
+    val output_file
     val seqDbPath
     val nucleic
 
     exec:
     SeqDB db = new SeqDB(seqDbPath.toString())
-    def tsvFile = new File("${outputPath}.tsv".toString())
+    def tsvFile = new File(output_file)
     tsvFile.text = "" // clear the file if it already exists
 
     // Each line contains: seqId md5 seqLength memberDb modelAcc sigDesc start end evalue status date entryAcc entryDesc goterms pathways

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -9,7 +9,7 @@ process WRITE_XML {
 
     input:
     val matches_files  // {query prot seq md5: {model acc: match}}
-    val output_prefix
+    val output_file
     val seq_db_file
     val nucleic
     val interproscan_version
@@ -39,8 +39,7 @@ process WRITE_XML {
         }
     }
 
-    def outputFilePath = "${output_prefix}.xml"
-    new File(outputFilePath).text = writer.toString()
+    new File(output_file).text = writer.toString()
 }
 
 def addNucleotideNode(String nucleicMd5, Set<String> proteinMd5s, Map proteinMatches, def xml, SeqDB db) {

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,6 +6,7 @@ params {
     formats               = "json,tsv,xml"
     goterms               = false
     outdir                = "."
+    outprefix             = null
     pathways              = false
     skipInterpro          = false
     interpro              = "latest"

--- a/subworkflows/init/main.nf
+++ b/subworkflows/init/main.nf
@@ -7,6 +7,7 @@ workflow INIT_PIPELINE {
     datadir
     formats
     outdir
+    outprefix
     no_matches_api
     matches_api_url
     interpro_version
@@ -69,6 +70,15 @@ workflow INIT_PIPELINE {
         exit 1
     }
 
+    if (outprefix == null) {
+        outprefix = "${outdir}/${fasta.split('/').last()}"
+    } else if (outprefix.contains("/") || outprefix.contains(File.separator)) {
+        log.error "--outprefix must not contain slashes or directory names. Use --outdir to control output location."
+        exit 1
+    } else {
+        outprefix = "${outdir}/${outprefix}"
+    }
+
     if (!no_matches_api) {
         invalidApps = apps.findAll { app ->
             ["signalp_euk", "signalp_prok", "deeptmhmm"].contains(app)
@@ -84,7 +94,7 @@ workflow INIT_PIPELINE {
     fasta            // str: path to input fasta file
     apps             // list: list of application to
     datadir          // str: path to data directory, or null if not needed
-    outdir           // str: path to output directory
+    outprefix        // str: base path for output files
     formats          // set<String>: output file formats
     version          // str: InterPro version (or "latest")
 }

--- a/subworkflows/output/main.nf
+++ b/subworkflows/output/main.nf
@@ -7,22 +7,19 @@ workflow OUTPUT {
     ch_results
     seq_db_path
     formats
-    outdir
+    outprefix
     nucleic
     iprscan_version
     db_releases
 
     main:
-    def fileName = params.input.split('/').last()
-    def outFileName = "${outdir}/${fileName}"
-
     if (formats.contains("JSON")) {
-        WRITE_JSON(ch_results, "${outFileName}", seq_db_path, nucleic, iprscan_version, db_releases)
+        WRITE_JSON(ch_results, "${outprefix}.json", seq_db_path, nucleic, iprscan_version, db_releases)
     }
     if (formats.contains("TSV")) {
-        WRITE_TSV(ch_results, "${outFileName}", seq_db_path, nucleic)
+        WRITE_TSV(ch_results, "${outprefix}.tsv", seq_db_path, nucleic)
     }
     if (formats.contains("XML")) {
-        WRITE_XML(ch_results, "${outFileName}", seq_db_path, nucleic, iprscan_version, db_releases)
+        WRITE_XML(ch_results, "${outprefix}.xml", seq_db_path, nucleic, iprscan_version, db_releases)
     }
 }


### PR DESCRIPTION
This PR introduces a new `--outprefix` option that allows users to customise the basename of the output files.

Previously, output files were placed in the directory specified by `--outdir` and named after the input file. For example, running:

```sh
--input test.fasta --outdir results --format json,xml
```

would produce:

- `results/test.fasta.json`
- `results/test.fasta.xml`

With the new `--outprefix` option, we can now control the output filenames directly. For example:

```sh
nextflow run interproscan6/main.nf \
  -profile docker,test \
  --datadir data \
  --interpro 105.0 \
  --applications cdd,pfam \
  --no-matches-api \
  --outdir results \
  --outprefix hello
```

This will generate:

```sh
$ ls results/
hello.json  hello.tsv  hello.xml
```