### PR TITLE
Include location fragments in the Signalp json output

### DIFF
--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -448,7 +448,8 @@ def writeSignalp(Map match, JsonGenerator jsonWriter) {
                 "start"             : loc.start,
                 "end"               : loc.end,
                 "representative"    : loc.representative,
-                "pvalue"            : loc.score
+                "pvalue"            : loc.score,
+                "location-fragments": formatFragments(loc.fragments),
             ]
         }
     ])


### PR DESCRIPTION
Add location fragments to the SignalP to the JSON output file as we need this data for the production databases and standardises the output file. Locations for SignalP should now look like:
```json
"locations" : [
            {
              "start" : 1,
              "end" : 35,
              "representative" : false,
              "pvalue" : 0.86579764,
              "location-fragments" : [
                {
                  "start" : 1,
                  "end" : 35,
                  "dc-status" : "CONTINUOUS"
                }
              ]
            }
          ]
``` 
