### PR TITLE
CATH-Gene3D/FunFam from Matches API

### DIFF
--- a/modules/download/main.nf
+++ b/modules/download/main.nf
@@ -60,15 +60,16 @@ process FIND_MISSING_DATA {
         Ugly trick to make sure that metadata for both CATH-Gene3D are CATH-FunFam
         are available even if we need only one
     */
-    if (apps_to_run.contains("cathgene3d") || apps_to_run.contains("cathfunfam")) {
-        apps_to_run.add("cathgene3d")
-        apps_to_run.add("cathfunfam")
+    def apps_to_check = apps_to_run.clone() as Set
+    if (apps_to_check.contains("cathgene3d") || apps_to_check.contains("cathfunfam")) {
+        apps_to_check.add("cathgene3d")
+        apps_to_check.add("cathfunfam")
     }
 
     with_data = [] as Set
     without_data = [] as Set
     to_download = [] as Set
-    apps_to_run.each { db_name ->
+    apps_to_check.each { db_name ->
         if (app_dirs.containsKey(db_name)) {
             def normalised_name = db_name.replaceAll(/[\s\-]+/, '').toLowerCase()
             assert normalised_json.containsKey(normalised_name)


### PR DESCRIPTION
You mentioned seeing CATH-Gene3D matches reported when:

- only requesting CATH-FunFam
- using the Matches API

It's due to my ugly trick to check that data files are present for both CATH-Gene3D _and_ CATH-FunFam, even when only one is requested:

https://github.com/ebi-pf-team/interproscan6/blob/d6d9307cb04dd77d127e9be27815d1d018143549/modules/download/main.nf#L59-L66

Turns out that values passed to processes are mutable. In your case, `apps_to_run` would then contain `cathgene3d` and `cathfunfam`. And the same value is passed to the `LOOKUP_MATCHES` process and is used to filter out matches returned by the API:

https://github.com/ebi-pf-team/interproscan6/blob/d6d9307cb04dd77d127e9be27815d1d018143549/modules/lookup/main.nf#L86-L89

But in your case, `applications` contains `cathgene3d`.

Workaround is to make a local copy of the list of applications.
