### PR TITLE
Fix prints

### DIFF
--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -98,14 +98,21 @@ process PARSE_PRINTS {
                     double pvalue = lineData3TBHN[7] as double
                     String motifSequence = lineData3TBHN[8]
                     int motifLength = lineData3TBHN[9] as int
-                    int locationStart = (lineData3TBHN[11] as int) < 1 ? 1 : (lineData3TBHN[11] as int)
-                    // A starting position that is more than 5 figures merges into the high column
-                    String locationStartStr = locationStart.toString()
-                    if (locationStartStr.length() >= 6) {
-                        locationStartStr = locationStartStr.substring(0, 5)
+
+                    String locationStartString
+                    if (lineData3TBHN[11].length() >= 6) {
+                        // A starting position that is more than 5 figures merges into the high column
+                        locationStartString = lineData3TBHN[11].take(6)
+                    } else {
+                        locationStartString = lineData3TBHN[11]
                     }
-                    locationStart = locationStartStr as int
+
+                    int locationStart = locationStartString as int
                     int locationEnd = locationStart + motifLength - 1
+
+                    // Adjust the locationStart if the motif starts before the sequence
+                    locationStart = Math.max(1, locationStart) 
+
                     if (motifSequence.endsWith("#")) { // it overhangs the protein seq so adjust locationEnd
                         int motifSeqLength = motifSequence.length()
                         int indexCheck = motifSeqLength - 1

--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -100,9 +100,9 @@ process PARSE_PRINTS {
                     int motifLength = lineData3TBHN[9] as int
 
                     String locationStartString
-                    if (lineData3TBHN[11].length() >= 6) {
+                    if (lineData3TBHN[11].length() > 5) {
                         // A starting position that is more than 5 figures merges into the high column
-                        locationStartString = lineData3TBHN[11].take(6)
+                        locationStartString = lineData3TBHN[11].take(5)
                     } else {
                         locationStartString = lineData3TBHN[11]
                     }

--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -164,7 +164,7 @@ process PARSE_PRINTS {
                     )
                     if (passed) {
                         filteredMatches.addAll(motifMatchesForCurrentModel)
-                        if (currentHierarchyEntry.siblingsIds.length < hierarchyEntryIdLimitation.size()) {
+                        if (currentHierarchyEntry.siblingsIds.length < hierarchyEntryIdLimitation.size() && !currentHierarchyEntry.isDomain) {
                             hierarchyEntryIdLimitation = new HashSet<>(Arrays.asList(currentHierarchyEntry.siblingsIds))
                         }
                     }


### PR DESCRIPTION
Issue: Some matches were not been selected on parse. 
Fix: we need to avoid to clear the hierarchy set in case of domains (i5 code block [here](https://github.com/ebi-pf-team/interproscan/blob/691e62b7253fd49fc442bc604d61880d32bed1f3/core/business/src/main/java/uk/ac/ebi/interpro/scan/business/postprocessing/prints/PrintsPostProcessing.java#L208-L229) )

The mismatches on regression tests to the SwissProt fasta decreased from:

- 4255 only i5
- 151 only i6

to:

- 150 only i5
- 151 only i6

Note: the remained mismatches (~0.2%) are related to the end location of "fragments" started in position 1 (one example [here](https://www.ebi.ac.uk/interpro/result/InterProScan/iprscan5-R20250626-101458-0006-11887279-p1m/internal-1750929291165-66-1/) - on this example i5 reports 1-28 but i6 report 1-30, for the other "fragments" on the signature the positions are matching correctly between i5 and i6). Below more samples of mismatches:

i5 reports:
```
< EA480D60EE050464B90EBB2C632FF666      PR01653 1       18
< EBD74C8A4975787A0D1654208CDBED1F      PR00076 1       15
< ECBB5BBD3FB8B506FE05BB813F753574      PR00086 1       23
< ECE37D210E9983E4FE1A864BA3017C9B      PR00289 1       19
< ED99B04619516C9E8745DEBC9754A072      PR01640 1       12
< EDBBD36829608E5145DF797BC71156DA      PR01653 1       18
< EDD9559D399227C65FBC933D8E11FA51      PR01366 1       7
< EF26DCD6DF8745FE07C63237FE00EF0C      PR01640 1       12
< F880ACBC45B8C2F32E84E2E7E003DB4B      PR01653 1       20
< F8D67401117EE3915AC9B875842819B8      PR01303 1       16
< F8D791EE92F780881B3F8D074E3DEFA6      PR00173 1       15
< F95D07930B0B474AA682D897337848EE      PR00058 1       12
< FA82DAF9CDA338B7C24BDE404241AC13      PR01653 1       20
< FECA0EB36BE6C421749221F17B9369EF      PR00291 1       28
```
i6 reports:
```
> EA480D60EE050464B90EBB2C632FF666      PR01653 1       21
> EBD74C8A4975787A0D1654208CDBED1F      PR00076 1       24
> ECBB5BBD3FB8B506FE05BB813F753574      PR00086 1       25
> ECE37D210E9983E4FE1A864BA3017C9B      PR00289 1       20
> ED99B04619516C9E8745DEBC9754A072      PR01640 1       14
> EDBBD36829608E5145DF797BC71156DA      PR01653 1       21
> EDD9559D399227C65FBC933D8E11FA51      PR01366 1       26
> EF26DCD6DF8745FE07C63237FE00EF0C      PR01640 1       14
> F880ACBC45B8C2F32E84E2E7E003DB4B      PR01653 1       21
> F8D67401117EE3915AC9B875842819B8      PR01303 1       17
> F8D791EE92F780881B3F8D074E3DEFA6      PR00173 1       21
> F95D07930B0B474AA682D897337848EE      PR00058 1       20
> FA82DAF9CDA338B7C24BDE404241AC13      PR01653 1       21
> FECA0EB36BE6C421749221F17B9369EF      PR00291 1       30
```

To find the sequence related to md5:
`grep '<MD5>' -C 3 /hps/nobackup/agb/interpro/lcf/regression_tests/prints.json`

