### PR TITLE
Pfam post-processing

### DIFF
--- a/conf/applications.config
+++ b/conf/applications.config
@@ -72,8 +72,6 @@ params {
             name = "Pfam"
             dir = "pfam"
             hmm = "pfam_a.hmm"
-            seed = "pfam_a.seed"
-            clan = "pfam_clans"
             dat = "pfam_a.dat"
             has_data = true
         }

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -19,8 +19,8 @@ process PARSE_PFAM {
     String datPath = "${dirpath.toString()}/${datfile}"
     Map<String, Map<String, Object>> dat = stockholmDatParser(datPath)  // [modelAcc: [clan: str, nested: [str]]]
 
-    Map<String, List<Match>> filteredMatches = filterMatches(hmmerMatches, dat)
-    Map<String, Map<String, Match>> processedMatches = buildFragments(filteredMatches, dat, MINLENGTH)
+    Map<String, List<Match>> filteredMatches = filterMatches(hmmerMatches, dat, MINLENGTH)
+    Map<String, Map<String, Match>> processedMatches = buildFragments(filteredMatches, dat)
 
     json = JsonOutput.toJson(processedMatches)
     new File(outputFilePath.toString()).write(json)
@@ -67,7 +67,9 @@ def decode(byte[] b) {
     }
 }
 
-def filterMatches(Map<String, Map<String, Match>> hmmerMatches, Map<String, Map<String, Object>> dat) {
+def filterMatches(Map<String, Map<String, Match>> hmmerMatches, 
+                  Map<String, Map<String, Object>> dat,
+                  int minLength) {
     /*
         Remove overlapping matches, only keeping the one with the best e-value or score.
         Pfam matches are not supposed to overlap, but some families can be evolutionary related,
@@ -76,7 +78,9 @@ def filterMatches(Map<String, Map<String, Match>> hmmerMatches, Map<String, Map<
     */
     Map<String, List<Match>> filteredMatches = [:]
     hmmerMatches.each { seqId, matches ->
-        List<Match> allMatches = flattenMatchLocations(matches)
+        List<Match> allMatches = flattenMatchLocations(matches).findAll{ m ->
+            m.locations[0].end - m.locations[0].start + 1 >= minLength 
+        }
 
         // Sort matches by evalue ASC, score DESC, length DESC, and accession ASC (last resort) 
         allMatches.sort { a, b ->
@@ -160,8 +164,7 @@ def isFullyEnclosed(location1Start, location1End, location2Start, location2End) 
 }
 
 def buildFragments(Map<String, Map<String, Match>> filteredMatches,
-                   Map<String, Map<String, Object>> dat,
-                   int MINLENGTH) {
+                   Map<String, Map<String, Object>> dat) {
     Map<String, Map<String, Match>> processedMatches = [:]
     filteredMatches.each { String seqId, List<Match> matches ->
         def aggregatedMatches = [:]
@@ -208,12 +211,10 @@ def buildFragments(Map<String, Map<String, Match>> filteredMatches,
                 location.fragments = fragments
             }
             
-            if (location.end - location.start + 1 >= MINLENGTH) {
-                if (aggregatedMatches.containsKey(match.modelAccession)) {
-                    aggregatedMatches[match.modelAccession].locations << location
-                } else {
-                    aggregatedMatches[match.modelAccession] = match
-                }
+            if (aggregatedMatches.containsKey(match.modelAccession)) {
+                aggregatedMatches[match.modelAccession].locations << location
+            } else {
+                aggregatedMatches[match.modelAccession] = match
             }
         }
         processedMatches[seqId] = aggregatedMatches

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -207,7 +207,12 @@ def buildFragments(Map<String, Map<String, Match>> filteredMatches,
                     }
                 }
 
-                fragments.add(new LocationFragment(start, location.end, "N_TERMINAL_DISC"))
+                if (fragments) {
+                    fragments.add(new LocationFragment(start, location.end, "N_TERMINAL_DISC"))
+                } else {
+                    fragments.add(new LocationFragment(location.start, location.end, "CONTINUOUS"))
+                }
+
                 location.fragments = fragments
             }
             

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -80,7 +80,10 @@ def filterMatches(Map<String, Map<String, Match>> hmmerMatches, Map<String, Map<
 
         // Sort matches by evalue ASC, score DESC to keep the best matches
         allMatches.sort { a, b ->
-            (a.locations[0].evalue <=> b.locations[0].evalue) ?: -(a.locations[0].score <=> b.locations[0].score)
+            (a.locations[0].evalue <=> b.locations[0].evalue) ?: 
+            -(a.locations[0].score <=> b.locations[0].score) ?:
+            -( (a.locations[0].end - a.locations[0].start) <=> (b.locations[0].end - b.locations[0].start) ) ?:
+            (a.modelAccession <=> b.modelAccession)
         }
 
         filteredMatches[seqId] = []

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -87,7 +87,8 @@ def filterMatches(Map<String, Map<String, Match>> hmmerMatches,
             (a.locations[0].evalue <=> b.locations[0].evalue) ?: 
             -(a.locations[0].score <=> b.locations[0].score) ?:
             -( (a.locations[0].end - a.locations[0].start) <=> (b.locations[0].end - b.locations[0].start) ) ?:
-            (a.modelAccession <=> b.modelAccession)
+            (a.locations[0].start <=> b.locations[0].start) ?:
+            (a.locations[0].end <=> b.locations[0].end)
         }
 
         filteredMatches[seqId] = []

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -78,7 +78,7 @@ def filterMatches(Map<String, Map<String, Match>> hmmerMatches, Map<String, Map<
     hmmerMatches.each { seqId, matches ->
         List<Match> allMatches = flattenMatchLocations(matches)
 
-        // Sort matches by evalue ASC, score DESC to keep the best matches
+        // Sort matches by evalue ASC, score DESC, length DESC, and accession ASC (last resort) 
         allMatches.sort { a, b ->
             (a.locations[0].evalue <=> b.locations[0].evalue) ?: 
             -(a.locations[0].score <=> b.locations[0].score) ?:
@@ -219,16 +219,4 @@ def buildFragments(Map<String, Map<String, Match>> filteredMatches,
         processedMatches[seqId] = aggregatedMatches
     }
     return processedMatches
-}
-
-def storeMatches(Map<String, Match> aggregatedMatches, List<Match> matches) {
-    // Aggregate processed matches under their respective model accessions
-    matches.each { match ->
-        if (aggregatedMatches.containsKey(match.modelAccession)) {
-            aggregatedMatches[match.modelAccession].locations << match.locations[0]
-        } else {
-            aggregatedMatches[match.modelAccession] = match
-        }
-    }
-    return aggregatedMatches
 }

--- a/tests/unit_tests/subworkflows/init_pipeline/main.nf.test
+++ b/tests/unit_tests/subworkflows/init_pipeline/main.nf.test
@@ -12,8 +12,6 @@ nextflow_workflow {
                         name: "Pfam",
                         dir: "pfam",
                         hmm: "pfam_a.hmm",
-                        seed: "pfam_a.seed",
-                        clan: "pfam_clans",
                         dat: "pfam_a.dat",
                         has_data: true
                     ],
@@ -57,8 +55,6 @@ nextflow_workflow {
                         name: "Pfam",
                         dir: "pfam",
                         hmm: "pfam_a.hmm",
-                        seed: "pfam_a.seed",
-                        clan: "pfam_clans",
                         dat: "pfam_a.dat",
                         has_data: true
                     ],
@@ -103,8 +99,6 @@ nextflow_workflow {
                         name: "Pfam",
                         dir: "pfam",
                         hmm: "pfam_a.hmm",
-                        seed: "pfam_a.seed",
-                        clan: "pfam_clans",
                         dat: "pfam_a.dat",
                         has_data: true
                     ],
@@ -148,8 +142,6 @@ nextflow_workflow {
                         name: "Pfam",
                         dir: "pfam",
                         hmm: "pfam_a.hmm",
-                        seed: "pfam_a.seed",
-                        clan: "pfam_clans",
                         dat: "pfam_a.dat",
                         has_data: true
                     ],
@@ -193,8 +185,6 @@ nextflow_workflow {
                         name: "Pfam",
                         dir: "pfam",
                         hmm: "pfam_a.hmm",
-                        seed: "pfam_a.seed",
-                        clan: "pfam_clans",
                         dat: "pfam_a.dat",
                         has_data: true
                     ],
@@ -238,8 +228,6 @@ nextflow_workflow {
                         name: "Pfam",
                         dir: "pfam",
                         hmm: "pfam_a.hmm",
-                        seed: "pfam_a.seed",
-                        clan: "pfam_clans",
                         dat: "pfam_a.dat",
                         has_data: true
                     ],
@@ -283,8 +271,6 @@ nextflow_workflow {
                         name: "Pfam",
                         dir: "pfam",
                         hmm: "pfam_a.hmm",
-                        seed: "pfam_a.seed",
-                        clan: "pfam_clans",
                         dat: "pfam_a.dat",
                         has_data: true
                     ],
@@ -328,8 +314,6 @@ nextflow_workflow {
                         name: "Pfam",
                         dir: "pfam",
                         hmm: "pfam_a.hmm",
-                        seed: "pfam_a.seed",
-                        clan: "pfam_clans",
                         dat: "pfam_a.dat",
                         has_data: true
                     ],


### PR DESCRIPTION
Refactor Pfam post-processing:

- remove short (less than 8 residues) at the beginning of the post-processing instead of the end
- stop using the Pfam clan file (`pfam_clan`), we don't need it anymore. All the information we need can be found in `pfam_a.dat`
- create a single continuous fragment if no other matches overlap a given match
- expand the criteria used to sort matches
