### PR TITLE
Use BLAST 2.15 for CDD

### DIFF
--- a/conf/profiles/apptainer.config
+++ b/conf/profiles/apptainer.config
@@ -1,6 +1,6 @@
 process {
     withLabel:ips6_container {
-        container = 'docker://interpro/interproscan:6.0.0-alpha'
+        container = 'docker://interpro/interproscan:6.0.0-beta'
     }
     withLabel:mobidblite_container {
         container = 'docker://matblum/idrpred:1.0.3'

--- a/conf/profiles/docker.config
+++ b/conf/profiles/docker.config
@@ -1,6 +1,6 @@
 process {
     withLabel:ips6_container {
-        container = 'docker.io/interpro/interproscan:6.0.0-alpha'
+        container = 'docker.io/interpro/interproscan:6.0.0-beta'
     }
     withLabel:mobidblite_container {
         container = 'docker.io/matblum/idrpred:1.0.3'

--- a/conf/profiles/singularity.config
+++ b/conf/profiles/singularity.config
@@ -1,6 +1,6 @@
 process {
     withLabel:ips6_container {
-        container = 'docker://interpro/interproscan:6.0.0-alpha'
+        container = 'docker://interpro/interproscan:6.0.0-beta'
     }
     withLabel:mobidblite_container {
         container = 'docker://matblum/idrpred:1.0.3'

--- a/utilities/docker/interproscan/Dockerfile
+++ b/utilities/docker/interproscan/Dockerfile
@@ -37,11 +37,11 @@ RUN coils_url="https://raw.githubusercontent.com/ebi-pf-team/interproscan/master
 # Install NCBI BLAST, only rpsblast (for CDD)
 # Don't pull the NCBI BLAST image as its BIG! - Just get the bits we need
 WORKDIR /opt/blast
-RUN curl -L -O https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.13.0/ncbi-blast-2.13.0+-x64-linux.tar.gz && \
-    tar -zxpf ncbi-blast-2.13.0+-x64-linux.tar.gz && \
-    rm ncbi-blast-2.13.0+-x64-linux.tar.gz && \
-    mv ncbi-blast-2.13.0+/bin/rpsblast rpsblast && \
-    rm -rf ncbi-blast-2.13.0+
+RUN curl -L -O https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.15.0/ncbi-blast-2.15.0+-x64-linux.tar.gz && \
+    tar -zxpf ncbi-blast-2.15.0+-x64-linux.tar.gz && \
+    rm ncbi-blast-2.15.0+-x64-linux.tar.gz && \
+    mv ncbi-blast-2.15.0+/bin/rpsblast rpsblast && \
+    rm -rf ncbi-blast-2.15.0+
 
 # Install RpsbProc for CDD post-processing
 WORKDIR /opt/rpsbproc


### PR DESCRIPTION
I noticed that the Docker image uses BLAST 2.13, while InterProScan 5 uses BLAST 2.13. This could explain some of the differences we see between InterProScan 5 and 6.

I published a new image on DockerHub (`interpro/interproscan:6.0.0-beta`). Please run a full Swiss-Prot test before merging.