### PR TITLE
PANTHER filtering

### DIFF
--- a/modules/panther/main.nf
+++ b/modules/panther/main.nf
@@ -42,7 +42,7 @@ process PREPARE_TREEGRAFTER {
                 m2.treegrafter = new TreeGrafter(null)
                 return m2
             }
-            .findAll { it != null }
+            .findAll { it != null && it.evalue <= 0.00000001 }
 
         Match bestMatch = filteredMatches.max { it.score }
         return bestMatch ? [(seqId): [(bestMatch.modelAccession): bestMatch]] : [:]

--- a/subworkflows/panther/main.nf
+++ b/subworkflows/panther/main.nf
@@ -13,7 +13,7 @@ workflow PANTHER {
         ch_seqs,
         dir,
         hmm,
-        "-Z 65000000 -E 0.001 --domE 0.00000001 --incdomE 0.00000001"
+        "-Z 65000000 -E 0.001"
     )
     ch_panther = SEARCH_PANTHER.out
 

--- a/subworkflows/panther/main.nf
+++ b/subworkflows/panther/main.nf
@@ -13,7 +13,7 @@ workflow PANTHER {
         ch_seqs,
         dir,
         hmm,
-        "-Z 65000000 -E 0.001"
+        "-Z 65000000 -E 0.001 --domE 0.00000001 --incdomE 0.00000001"
     )
     ch_panther = SEARCH_PANTHER.out
 


### PR DESCRIPTION
Filter matches by evalue after `hmmsearch`, which isn't ideal (we could either no filter at all, or change the value of the `-E` option when running `hmmsearch`), but this how it's done in InterProScan 5.

Next time we update PANTHER (`19.0` to `20.0`), we can revisit the post`-hmmsearch` filtering step. 