### PR TITLE
Use HMMER output for SFLD matches

### DIFF
--- a/modules/sfld/main.nf
+++ b/modules/sfld/main.nf
@@ -199,24 +199,6 @@ Map<String, Set<String>> getHierarchies(String filePath) {
     return hierarchies
 }
 
-List<Map> getHmmData(String outputFilePath) {
-    def matchesMap = HMMER3.parseOutput(outputFilePath.toString(), "SFLD")  // proteinMd5: modelAccession: Match
-    def hmmLengths = [:]  // modelAccession: hmmLength
-    def hmmBounds  = [:]  // proteinMd5: modelAccession: (tuple representing loc): hmmbound
-    matchesMap.each { String sequenceId, matches ->
-        matches.each { String modelAccession, Match match ->
-            match.locations.each { Location loc ->
-                def locKey = [loc.start, loc.end, loc.hmmStart, loc.hmmEnd, loc.envelopeStart, loc.envelopeEnd]
-                hmmLengths[modelAccession] = loc.hmmLength
-                hmmBounds.computeIfAbsent(sequenceId) {     [:] }
-                         .computeIfAbsent(modelAccession) { [:] }
-                         .computeIfAbsent(locKey) {         loc.hmmBounds }
-            }
-        }
-    }
-    return [hmmLengths, hmmBounds]
-}
-
 Map<String, Map<String, Match>> parseOutput(
     String outputFilePath,
     Map<String, Map> hmmerMatches


### PR DESCRIPTION
It looks like some very low e-values in the SFLD post-processing binary get floored to zero. I haven't checked the C source, but the e-value/score variables are likely defined as floats and get rounded when the value is lower that the min value a float can represent.
With this PR, we use the HMMER output to get matches information, and we only use the output of the C program to:

- find filtered matches
- get site information