### PR TITLE
JSON Lines output format

### DIFF
--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -110,7 +110,7 @@ class InterProScan {
         ],
     ]
 
-    static final def VALID_FORMATS = ["JSON", "TSV", "XML", "GFF3"]
+    static final def VALID_FORMATS = ["JSON", "JSONL", "TSV", "XML", "GFF3"]
 
     static final def LICENSED_SOFTWARE = ["phobius", "signalp_euk", "signalp_prok", "deeptmhmm"]
 

--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -1,8 +1,10 @@
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.io.SerializedString
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.core.util.DefaultIndenter
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import groovy.json.JsonException
 import java.util.regex.Pattern
 
@@ -19,30 +21,68 @@ process WRITE_JSON {
     val nucleic
     val interproscan_version
     val db_releases
+    val jsonlines
 
     exec:
     ObjectMapper jacksonMapper = new ObjectMapper()
     SeqDB db = new SeqDB(seq_db_file.toString())
-    streamJson(output_file.toString(), jacksonMapper) { JsonGenerator jsonWriter ->
-        jsonWriter.writeStringField("interproscan-version", interproscan_version)
-        jsonWriter.writeStringField("interpro-version", db_releases?.interpro?.version)
-        jsonWriter.writeFieldName("results")
-        jsonWriter.writeStartArray()  // start of results [...
-        matches_files.each { matchFile ->
-            if (nucleic) {  // input was nucleic acid sequence
+
+    streamJson(output_file.toString(), jacksonMapper, jsonlines) { JsonGenerator generator ->
+        if (jsonlines) {
+            generator.setRootValueSeparator(new SerializedString(''))
+            matches_files.each { matchFile ->
                 Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
-                nucleicToProteinMd5 = db.groupProteins(proteins)
-                nucleicToProteinMd5.each { String nucleicMd5, Set<String> proteinMd5s ->
-                    writeNucleic(nucleicMd5, proteinMd5s, proteins, jsonWriter, db)
-                }
-            } else {  // input was protein sequences
-                Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
-                proteins.each { String proteinMd5, Map proteinMatches ->
-                    writeProtein(proteinMd5, proteinMatches, jsonWriter, db)
+
+                if (nucleic) {
+                    nucleicToProteinMd5 = db.groupProteins(proteins)
+                    nucleicToProteinMd5.each { String nucleicMd5, Set<String> proteinMd5s ->
+                        generator.writeStartObject()
+                        generator.writeStringField("interproscan-version", interproscan_version)
+                        generator.writeStringField("interpro-version", db_releases?.interpro?.version)
+                        generator.writeFieldName("results")
+                        writeNucleic(nucleicMd5, proteinMd5s, proteins, generator, db)
+                        generator.writeEndObject()
+                        generator.writeRaw('\n')
+                    }
+                } else {
+                    proteins.each { String proteinMd5, Map proteinMatches ->
+                        generator.writeStartObject()
+                        generator.writeStringField("interproscan-version", interproscan_version)
+                        generator.writeStringField("interpro-version", db_releases?.interpro?.version)
+                        generator.writeFieldName("results")
+                        writeProtein(proteinMd5, proteinMatches, generator, db)
+                        generator.writeEndObject()
+                        generator.writeRaw('\n')
+                    }
                 }
             }
+        } else {
+            DefaultPrettyPrinter pp = new DefaultPrettyPrinter()
+            pp.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE)
+            generator.setPrettyPrinter(pp)
+            generator.writeStartObject()
+
+            generator.writeStringField("interproscan-version", interproscan_version)
+            generator.writeStringField("interpro-version", db_releases?.interpro?.version)
+            generator.writeFieldName("results")
+            generator.writeStartArray()  // start of results [...
+            matches_files.each { matchFile ->
+                if (nucleic) {  // input was nucleic acid sequence
+                    Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
+                    nucleicToProteinMd5 = db.groupProteins(proteins)
+                    nucleicToProteinMd5.each { String nucleicMd5, Set<String> proteinMd5s ->
+                        writeNucleic(nucleicMd5, proteinMd5s, proteins, generator, db)
+                    }
+                } else {  // input was protein sequences
+                    Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
+                    proteins.each { String proteinMd5, Map proteinMatches ->
+                        writeProtein(proteinMd5, proteinMatches, generator, db)
+                    }
+                }
+            }
+            generator.writeEndArray() // end of "results" ...]
+            generator.writeEndObject()
         }
-        jsonWriter.writeEndArray() // end of "results" ...]
     }
 }
 
@@ -557,30 +597,14 @@ def writeXref(seqData, JsonGenerator jsonWriter) {
     jsonWriter.writeEndArray()
 }
 
-def streamJson(String filePath, ObjectMapper mapper, Closure closure) {
-    /* Write out json objects while streaming the file.
-    ObjectMapper jacksonMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
-    JsonWriter.streamMap(outputFilePath.toString(), jacksonMapper) { JsonGenerator jsonGenerator ->
-        jsonGenerator.writeStringField("exampleKey", "exampleValue")
-    }
-    */
+def streamJson(String filePath, ObjectMapper mapper, boolean jsonlines, Closure closure) {
     FileWriter fileWriter = null
     JsonGenerator generator = null
     try {
         JsonFactory factory = mapper.getFactory()
-
         fileWriter = new FileWriter(new File(filePath))
         generator = factory.createGenerator(fileWriter)
-
-        DefaultPrettyPrinter pp = new DefaultPrettyPrinter()
-        pp.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE)
-        generator.setPrettyPrinter(pp)
-
-        generator.writeStartObject()
-
         closure.call(generator)  // Call the closure to write key-value pairs
-
-        generator.writeEndObject()
     } catch (IOException e) {
         throw new JsonException("IO error writing file: $filePath\nException: $e\nCause: ${e.getCause()}", e)
     } catch (Exception e) {
@@ -593,4 +617,4 @@ def streamJson(String filePath, ObjectMapper mapper, Closure closure) {
             fileWriter.close()
         }
     }
-}   
+}

--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -40,7 +40,9 @@ process WRITE_JSON {
                         generator.writeStringField("interproscan-version", interproscan_version)
                         generator.writeStringField("interpro-version", db_releases?.interpro?.version)
                         generator.writeFieldName("results")
+                        generator.writeStartArray()
                         writeNucleic(nucleicMd5, proteinMd5s, proteins, generator, db)
+                        generator.writeEndArray()
                         generator.writeEndObject()
                         generator.writeRaw('\n')
                     }
@@ -50,7 +52,9 @@ process WRITE_JSON {
                         generator.writeStringField("interproscan-version", interproscan_version)
                         generator.writeStringField("interpro-version", db_releases?.interpro?.version)
                         generator.writeFieldName("results")
+                        generator.writeStartArray()
                         writeProtein(proteinMd5, proteinMatches, generator, db)
+                        generator.writeEndArray()
                         generator.writeEndObject()
                         generator.writeRaw('\n')
                     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,7 +3,7 @@ params {
     datadir               = null
     applications          = null
     nucleic               = false
-    formats               = "json,tsv,xml,gff3"
+    formats               = "json,jsonl,tsv,xml,gff3"
     goterms               = false
     outdir                = "."
     outprefix             = null

--- a/subworkflows/output/main.nf
+++ b/subworkflows/output/main.nf
@@ -1,7 +1,8 @@
-include { WRITE_JSON } from "../../modules/output/json"
-include { WRITE_TSV  } from "../../modules/output/tsv"
-include { WRITE_XML  } from "../../modules/output/xml"
-include { WRITE_GFF3 } from "../../modules/output/gff3"
+include { WRITE_JSON                     } from "../../modules/output/json"
+include { WRITE_JSON as WRITE_JSON_LINES } from "../../modules/output/json"
+include { WRITE_TSV                      } from "../../modules/output/tsv"
+include { WRITE_XML                      } from "../../modules/output/xml"
+include { WRITE_GFF3                     } from "../../modules/output/gff3"
 
 workflow OUTPUT {
     take:
@@ -18,7 +19,10 @@ workflow OUTPUT {
         WRITE_GFF3(ch_results, "${outprefix}.gff3", seq_db_path, nucleic, iprscan_version)
     }
     if (formats.contains("JSON")) {
-        WRITE_JSON(ch_results, "${outprefix}.json", seq_db_path, nucleic, iprscan_version, db_releases)
+        WRITE_JSON(ch_results, "${outprefix}.json", seq_db_path, nucleic, iprscan_version, db_releases, false)
+    }
+    if (formats.contains("JSONL")) {
+        WRITE_JSON_LINES(ch_results, "${outprefix}.jsonl", seq_db_path, nucleic, iprscan_version, db_releases, true)
     }
     if (formats.contains("TSV")) {
         WRITE_TSV(ch_results, "${outprefix}.tsv", seq_db_path, nucleic)

--- a/tests/regression_tests/test_matches.py
+++ b/tests/regression_tests/test_matches.py
@@ -75,12 +75,14 @@ def parse_jsonl(iprscan_path: str):
     matches = []  # [[md5, sig_acc, loc start, loc end]]
     with open(iprscan_path, "r") as fh:
         for line in map(str.rstrip, fh):
-            protein_dict = json.loads(line)["results"]
-            md5 = protein_dict["md5"].upper()
-            for match in protein_dict["matches"]:
-                sig_acc = match["signature"]["accession"]
-                for loc in match["locations"]:
-                    matches.append([md5, sig_acc, loc["start"], loc["end"]])
+            iprsn_dict = json.loads(line)
+
+            for protein_dict in iprsn_dict["results"]:
+                md5 = protein_dict["md5"].upper()
+                for match in protein_dict["matches"]:
+                    sig_acc = match["signature"]["accession"]
+                    for loc in match["locations"]:
+                        matches.append([md5, sig_acc, loc["start"], loc["end"]])
     return [repr(nested) for nested in matches]
 
 

--- a/tests/regression_tests/test_matches.py
+++ b/tests/regression_tests/test_matches.py
@@ -14,7 +14,7 @@ def main():
     parser.add_argument("--expected", type=str, default="tests/data/output/test.faa.json", help="JSON with expected results")
     parser.add_argument("--observed", type=str, default="tests/data/output/test.faa.json", help="JSON output file from IPS6")
     parser.add_argument("--summary", action="store_true", help="Print only the summary message")
-    parser.add_argument("--format", choices=["gff3", "json", "tsv", "xml", "intermediate"], default="json", help=(
+    parser.add_argument("--format", choices=["gff3", "json", "jsonl", "tsv", "xml", "intermediate"], default="json", help=(
         "Format of input files.\n"
         "'gff3', 'json' [default], 'tsv', or 'xml' for final output files\n"
         "or 'intermediate' to compare the temporary working files of InterProScan6."
@@ -28,6 +28,9 @@ def main():
     elif args.format == "json":
         expected = parse_json(args.expected)
         observed = parse_json(args.observed)
+    elif args.format == "jsonl":
+        expected = parse_jsonl(args.expected)
+        observed = parse_jsonl(args.observed)
     elif args.format == "tsv":
         expected = parse_tsv(args.expected)
         observed = parse_tsv(args.observed)
@@ -65,6 +68,20 @@ def main():
         f"Matches only in observed : {observed_only}\n"
         f"Matches in both          : {both}"
     )
+
+
+def parse_jsonl(iprscan_path: str):
+    """Convert all matches into lists, keeping only the data we care about"""
+    matches = []  # [[md5, sig_acc, loc start, loc end]]
+    with open(iprscan_path, "r") as fh:
+        for line in map(str.rstrip, fh):
+            protein_dict = json.loads(line)["results"]
+            md5 = protein_dict["md5"].upper()
+            for match in protein_dict["matches"]:
+                sig_acc = match["signature"]["accession"]
+                for loc in match["locations"]:
+                    matches.append([md5, sig_acc, loc["start"], loc["end"]])
+    return [repr(nested) for nested in matches]
 
 
 def parse_json(iprscan_path: str):

--- a/tests/unit_tests/modules/output/json/main.nf.test
+++ b/tests/unit_tests/modules/output/json/main.nf.test
@@ -36,6 +36,7 @@ nextflow_process {
                 input[3] = false
                 input[4] = "105.0"
                 input[5] = params.db_releases
+                input[6] = false
                 """
             }
         }

--- a/tests/unit_tests/modules/output/json/nucleic.nf.test
+++ b/tests/unit_tests/modules/output/json/nucleic.nf.test
@@ -41,6 +41,7 @@ nextflow_process {
                 input[3] = true
                 input[4] = "105.0"
                 input[5] = params.db_releases
+                input[6] = false
                 """
             }
         }

--- a/tests/unit_tests/modules/output/jsonl/main.nf.test
+++ b/tests/unit_tests/modules/output/jsonl/main.nf.test
@@ -1,0 +1,59 @@
+nextflow_process {
+
+    name "Test Process WRITE_JSON_LINES"
+    script "modules/output/json/main.nf"
+    process "WRITE_JSON"
+
+    test("Should run without failures") {
+
+        when {
+            params {
+                db_releases = [
+                    interpro: [version: "105.0", dirpath: ""],
+                    antifam: [version: "8.0", dirpath: ""],
+                    cathgene3d: [version: "4.3.0", dirpath: ""],
+                    cathfunfam: [version: "4.3.0", dirpath: ""],
+                    cdd: [version: "3.21", dirpath: ""],
+                    hamap: [version: "2025_01", dirpath: ""],
+                    ncbifam: [version: "17.0", dirpath: ""],
+                    panther: [version: "19.0", dirpath: ""],
+                    pfam: [version: "37.3", dirpath: ""],
+                    pirsf: [version: "3.10", dirpath: ""],
+                    pirsr: [version: "2025_01", dirpath: ""],
+                    prints: [version: "42.0", dirpath: ""],
+                    prositepatterns: [version: "2025_01", dirpath: ""],
+                    prositeprofiles: [version: "2025_01", dirpath: ""],
+                    sfld: [version: "4", dirpath: ""],
+                    smart: [version: "9.0", dirpath: ""],
+                    superfamily: [version: "1.75", dirpath: ""]
+                ]
+            }
+            process {
+                """
+                input[0] = [file("$baseDir/tests/data/channels/matches_with_representative.json")]
+                input[1] = "../../../unit_test_output.jsonl"
+                input[2] = file("$baseDir/tests/data/sequences/sequences.db")
+                input[3] = false
+                input[4] = "105.0"
+                input[5] = params.db_releases
+                input[6] = true
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            def expected = "tests/data/output/test.faa.jsonl"
+            def observed = "unit_test_output.jsonl"
+            def cmd = "python3 tests/regression_tests/test_matches.py --expected ${expected} --observed ${observed} --summary --format jsonl"
+            def process = cmd.execute()
+            process.waitFor()
+            def stdout = process.text.trim().readLines()
+            assert stdout[1] == "Matches only in expected : 0"
+            assert stdout[2] == "Matches only in observed : 0"
+            def observedFile = new File(observed)
+            observedFile.delete()
+        }
+    }
+
+}

--- a/tests/unit_tests/modules/output/jsonl/nucleic.nf.test
+++ b/tests/unit_tests/modules/output/jsonl/nucleic.nf.test
@@ -1,0 +1,54 @@
+nextflow_process {
+
+    name "Test Process WRITE_JSON_LINES [nucleic]"
+    script "modules/output/json/main.nf"
+    process "WRITE_JSON"
+
+    stage {
+        symlink "tests/data/channels/nucleic.matches_with_representative.json"
+        symlink "tests/data/sequences/nt_sequences.db"
+    }
+
+    test("Should run without failures") {
+
+        when {
+            params {
+                db_releases = [
+                    interpro: [version: "105.0", dirpath: ""],
+                    antifam: [version: "8.0", dirpath: ""],
+                    cathgene3d: [version: "4.3.0", dirpath: ""],
+                    cathfunfam: [version: "4.3.0", dirpath: ""],
+                    cdd: [version: "3.21", dirpath: ""],
+                    hamap: [version: "2025_01", dirpath: ""],
+                    ncbifam: [version: "17.0", dirpath: ""],
+                    panther: [version: "19.0", dirpath: ""],
+                    pfam: [version: "37.3", dirpath: ""],
+                    pirsf: [version: "3.10", dirpath: ""],
+                    pirsr: [version: "2025_01", dirpath: ""],
+                    prints: [version: "42.0", dirpath: ""],
+                    prositepatterns: [version: "2025_01", dirpath: ""],
+                    prositeprofiles: [version: "2025_01", dirpath: ""],
+                    sfld: [version: "4", dirpath: ""],
+                    smart: [version: "9.0", dirpath: ""],
+                    superfamily: [version: "1.75", dirpath: ""]
+                ]
+            }
+            process {
+                """
+                input[0] = [file("$baseDir/tests/data/channels/nucleic.matches_with_representative.json")]
+                input[1] = "unit_test_output"
+                input[2] = file("$baseDir/tests/data/sequences/nt_sequences.db")
+                input[3] = true
+                input[4] = "105.0"
+                input[5] = params.db_releases
+                input[6] = true
+                """
+            }
+        }
+
+        then {
+            assert process.success
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds a new output format: JSON Lines.

Instead of having the output file containing one valid JSON string, which includes results for all sequences, the output file in JSON Lines format contains one JSON string per line. Each value represent the matches for one sequence. This is an advantage when processing many sequences: you don't need to load the entire JSON output in memory before processing, you can process the output one line (i.e. one sequence) at a time.