### PR TITLE
Unique nt seqs

### DIFF
--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -311,9 +311,9 @@ def writeCDD(Map match, JsonGenerator jsonWriter) {
                 "location-fragments": formatFragments(loc.fragments),
                 "sites"             : loc.sites.collect { site ->
                     [
-                            "description"  : site.description,
-                            "numLocations" : site.numLocations,
-                            "siteLocations": site.siteLocations
+                        "description"  : site.description,
+                        "numLocations" : site.numLocations,
+                        "siteLocations": site.siteLocations
                     ]
                 }
             ]

--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -248,346 +248,346 @@ def writeMatch(String proteinMd5, Map match, JsonGenerator jsonWriter) {
 
 def writeDefault(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "evalue"   : match.evalue,
-            "score"    : match.score,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "hmmStart"          : loc.hmmStart,
-                        "hmmEnd"            : loc.hmmEnd,
-                        "hmmLength"         : loc.hmmLength,
-                        "hmmBounds"         : Location.getHmmBounds(loc.hmmBounds),
-                        "evalue"            : loc.evalue,
-                        "score"             : loc.score,
-                        "envelopeStart"     : loc.envelopeStart,
-                        "envelopeEnd"       : loc.envelopeEnd,
-                        "location-fragments": formatFragments(loc.fragments)
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "evalue"   : match.evalue,
+        "score"    : match.score,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "hmmStart"          : loc.hmmStart,
+                "hmmEnd"            : loc.hmmEnd,
+                "hmmLength"         : loc.hmmLength,
+                "hmmBounds"         : Location.getHmmBounds(loc.hmmBounds),
+                "evalue"            : loc.evalue,
+                "score"             : loc.score,
+                "envelopeStart"     : loc.envelopeStart,
+                "envelopeEnd"       : loc.envelopeEnd,
+                "location-fragments": formatFragments(loc.fragments)
+            ]
+        }
     ])
 }
 
 def writeDefaultNoHmmBounds(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "evalue"   : match.evalue,
-            "score"    : match.score,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "hmmStart"          : loc.hmmStart,
-                        "hmmEnd"            : loc.hmmEnd,
-                        "hmmLength"         : loc.hmmLength,
-                        "evalue"            : loc.evalue,
-                        "score"             : loc.score,
-                        "envelopeStart"     : loc.envelopeStart,
-                        "envelopeEnd"       : loc.envelopeEnd,
-                        "location-fragments": formatFragments(loc.fragments)
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "evalue"   : match.evalue,
+        "score"    : match.score,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "hmmStart"          : loc.hmmStart,
+                "hmmEnd"            : loc.hmmEnd,
+                "hmmLength"         : loc.hmmLength,
+                "evalue"            : loc.evalue,
+                "score"             : loc.score,
+                "envelopeStart"     : loc.envelopeStart,
+                "envelopeEnd"       : loc.envelopeEnd,
+                "location-fragments": formatFragments(loc.fragments)
+            ]
+        }
     ])
 }
 
 def writeCDD(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "evalue"   : match.evalue,
-            "score"    : match.score,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "evalue"            : loc.evalue,
-                        "score"             : loc.score,
-                        "location-fragments": formatFragments(loc.fragments),
-                        "sites"             : loc.sites.collect { site ->
-                            [
-                                    "description"  : site.description,
-                                    "numLocations" : site.numLocations,
-                                    "siteLocations": site.siteLocations
-                            ]
-                        }
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "evalue"   : match.evalue,
+        "score"    : match.score,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "evalue"            : loc.evalue,
+                "score"             : loc.score,
+                "location-fragments": formatFragments(loc.fragments),
+                "sites"             : loc.sites.collect { site ->
+                    [
+                            "description"  : site.description,
+                            "numLocations" : site.numLocations,
+                            "siteLocations": site.siteLocations
+                    ]
+                }
+            ]
+        }
     ])
 }
 
 def writeMinimalist(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "location-fragments": formatFragments(loc.fragments)
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "location-fragments": formatFragments(loc.fragments)
+            ]
+        }
     ])
 }
 
 def writeHAMAP(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "score"             : loc.score,
-                        "cigarAlignment"    : loc.cigarAlignment,
-                        "alignment"         : loc.targetAlignment,
-                        "location-fragments": formatFragments(loc.fragments)
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "score"             : loc.score,
+                "cigarAlignment"    : loc.cigarAlignment,
+                "alignment"         : loc.targetAlignment,
+                "location-fragments": formatFragments(loc.fragments)
+            ]
+        }
     ])
 }
 
 def writeMobiDBlite(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "location-fragments": formatFragments(loc.fragments),
-                        "sequence-feature"  : loc.sequenceFeature
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "location-fragments": formatFragments(loc.fragments),
+                "sequence-feature"  : loc.sequenceFeature
+            ]
+        }
     ])
 }
 
 def writePANTHER(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature"      : match.signature,
-            "model-ac"       : match.treegrafter.subfamilyAccession ?: match.modelAccession,
-            "name"           : match.treegrafter.subfamilyDescription,
-            "evalue"         : match.evalue,
-            "score"          : match.score,
-            "proteinClass"   : match.treegrafter.proteinClass,
-            "graftPoint"     : match.treegrafter.graftPoint,
-            "ancestralNode": match.treegrafter.ancestralNodeID,
-            "goXRefs"        : match.treegrafter.goXRefs,
-            "locations"      : match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "hmmStart"          : loc.hmmStart,
-                        "hmmEnd"            : loc.hmmEnd,
-                        "hmmLength"         : loc.hmmLength,
-                        "hmmBounds"         : Location.getHmmBounds(loc.hmmBounds),
-                        "envelopeStart"     : loc.envelopeStart,
-                        "envelopeEnd"       : loc.envelopeEnd,
-                        "location-fragments": formatFragments(loc.fragments)
-                ]
-            }
+        "signature"      : match.signature,
+        "model-ac"       : match.treegrafter.subfamilyAccession ?: match.modelAccession,
+        "name"           : match.treegrafter.subfamilyDescription,
+        "evalue"         : match.evalue,
+        "score"          : match.score,
+        "proteinClass"   : match.treegrafter.proteinClass,
+        "graftPoint"     : match.treegrafter.graftPoint,
+        "ancestralNode": match.treegrafter.ancestralNodeID,
+        "goXRefs"        : match.treegrafter.goXRefs,
+        "locations"      : match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "hmmStart"          : loc.hmmStart,
+                "hmmEnd"            : loc.hmmEnd,
+                "hmmLength"         : loc.hmmLength,
+                "hmmBounds"         : Location.getHmmBounds(loc.hmmBounds),
+                "envelopeStart"     : loc.envelopeStart,
+                "envelopeEnd"       : loc.envelopeEnd,
+                "location-fragments": formatFragments(loc.fragments)
+            ]
+        }
     ])
 }
 
 def writePirsr(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "evalue"   : match.evalue,
-            "score"    : match.score,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "hmmStart"          : loc.hmmStart,
-                        "hmmEnd"            : loc.hmmEnd,
-                        "hmmLength"         : loc.hmmLength,
-                        "score"             : loc.score,
-                        "envelopeStart"     : loc.envelopeStart,
-                        "envelopeEnd"       : loc.envelopeEnd,
-                        "location-fragments": formatFragments(loc.fragments),
-                        "sites"             : loc.sites.collect { site ->
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "evalue"   : match.evalue,
+        "score"    : match.score,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "hmmStart"          : loc.hmmStart,
+                "hmmEnd"            : loc.hmmEnd,
+                "hmmLength"         : loc.hmmLength,
+                "score"             : loc.score,
+                "envelopeStart"     : loc.envelopeStart,
+                "envelopeEnd"       : loc.envelopeEnd,
+                "location-fragments": formatFragments(loc.fragments),
+                "sites"             : loc.sites.collect { site ->
+                    [
+                        "description": site.description,
+                        "numLocations": site.numLocations,
+                        "siteLocations": site.siteLocations.collect { siteLoc ->
                             [
-                                    "description": site.description,
-                                    "numLocations": site.numLocations,
-                                    "siteLocations": site.siteLocations.collect { siteLoc ->
-                                        [
-                                                "start"  : siteLoc.start,
-                                                "end"    : siteLoc.end,
-                                                "residue": siteLoc.residue
-                                        ]
-                                    },
+                                "start"  : siteLoc.start,
+                                "end"    : siteLoc.end,
+                                "residue": siteLoc.residue
                             ]
-                        } // end of "sites"
-                ]
-            } // end of "locations"
+                        },
+                    ]
+                } // end of "sites"
+            ]
+        } // end of "locations"
     ])
 }
 
 def writePRINTS(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "evalue"   : match.evalue,
-            "graphscan": match.graphscan,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "pvalue"            : loc.pvalue,
-                        "score"             : loc.score,
-                        "motifNumber"       : loc.motifNumber,
-                        "location-fragments": formatFragments(loc.fragments)
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "evalue"   : match.evalue,
+        "graphscan": match.graphscan,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "pvalue"            : loc.pvalue,
+                "score"             : loc.score,
+                "motifNumber"       : loc.motifNumber,
+                "location-fragments": formatFragments(loc.fragments)
+            ]
+        }
     ])
 }
 
 def writePROSITEpatterns(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "level"             : loc.level,
-                        "cigarAlignment"    : loc.cigarAlignment,
-                        "alignment"         : loc.targetAlignment,
-                        "location-fragments": formatFragments(loc.fragments)
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "level"             : loc.level,
+                "cigarAlignment"    : loc.cigarAlignment,
+                "alignment"         : loc.targetAlignment,
+                "location-fragments": formatFragments(loc.fragments)
+            ]
+        }
     ])
 }
 
 def writePROSITEprofiles(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "score"             : loc.score,
-                        "cigarAlignment"    : loc.cigarAlignment,
-                        "alignment"         : loc.targetAlignment,
-                        "location-fragments": formatFragments(loc.fragments)
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "score"             : loc.score,
+                "cigarAlignment"    : loc.cigarAlignment,
+                "alignment"         : loc.targetAlignment,
+                "location-fragments": formatFragments(loc.fragments)
+            ]
+        }
     ])
 }
 
 def writeSignalp(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "pvalue"            : loc.score,
-                        "location-fragments": formatFragments(loc.fragments),
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "pvalue"            : loc.score,
+                "location-fragments": formatFragments(loc.fragments),
+            ]
+        }
     ])
 }
 
 def writeSFLD(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "evalue"   : match.evalue,
-            "score"    : match.score,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "hmmStart"          : loc.hmmStart,
-                        "hmmEnd"            : loc.hmmEnd,
-                        "hmmLength"         : loc.hmmLength,
-                        "score"             : loc.score,
-                        "envelopeStart"     : loc.envelopeStart,
-                        "envelopeEnd"       : loc.envelopeEnd,
-                        "location-fragments": formatFragments(loc.fragments),
-                        "sites"             : loc.sites.collect { site ->
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "evalue"   : match.evalue,
+        "score"    : match.score,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "hmmStart"          : loc.hmmStart,
+                "hmmEnd"            : loc.hmmEnd,
+                "hmmLength"         : loc.hmmLength,
+                "score"             : loc.score,
+                "envelopeStart"     : loc.envelopeStart,
+                "envelopeEnd"       : loc.envelopeEnd,
+                "location-fragments": formatFragments(loc.fragments),
+                "sites"             : loc.sites.collect { site ->
+                    [
+                        "description": site.description,
+                        "numLocations": site.numLocations,
+                        "siteLocations": site.siteLocations.collect { siteLoc ->
                             [
-                                    "description": site.description,
-                                    "numLocations": site.numLocations,
-                                    "siteLocations": site.siteLocations.collect { siteLoc ->
-                                        [
-                                                "start"  : siteLoc.start,
-                                                "end"    : siteLoc.end,
-                                                "residue": siteLoc.residue
-                                        ]
-                                    },
+                                "start"  : siteLoc.start,
+                                "end"    : siteLoc.end,
+                                "residue": siteLoc.residue
                             ]
-                        } // end of "sites"
-                ]
-            } // end of "locations"
+                        },
+                    ]
+                } // end of "sites"
+            ]
+        } // end of "locations"
     ])
 }
 
 def writeSMART(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "evalue"   : match.evalue,
-            "score"     : match.score,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "hmmStart"          : loc.hmmStart,
-                        "hmmEnd"            : loc.hmmEnd,
-                        "hmmLength"         : loc.hmmLength,
-                        "hmmBounds"         : Location.getHmmBounds(loc.hmmBounds),
-                        "evalue"            : loc.evalue,
-                        "score"             : loc.score,
-                        "location-fragments": formatFragments(loc.fragments)
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "evalue"   : match.evalue,
+        "score"     : match.score,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "hmmStart"          : loc.hmmStart,
+                "hmmEnd"            : loc.hmmEnd,
+                "hmmLength"         : loc.hmmLength,
+                "hmmBounds"         : Location.getHmmBounds(loc.hmmBounds),
+                "evalue"            : loc.evalue,
+                "score"             : loc.score,
+                "location-fragments": formatFragments(loc.fragments)
+            ]
+        }
     ])
 }
 
 def writeSUPERFAMILY(Map match, JsonGenerator jsonWriter) {
     jsonWriter.writeObject([
-            "signature": match.signature,
-            "model-ac" : match.modelAccession,
-            "evalue"   : match.evalue,
-            "locations": match.locations.collect { loc ->
-                [
-                        "start"             : loc.start,
-                        "end"               : loc.end,
-                        "representative"    : loc.representative,
-                        "hmmLength"         : loc.hmmLength,
-                        "location-fragments": formatFragments(loc.fragments)
-                ]
-            }
+        "signature": match.signature,
+        "model-ac" : match.modelAccession,
+        "evalue"   : match.evalue,
+        "locations": match.locations.collect { loc ->
+            [
+                "start"             : loc.start,
+                "end"               : loc.end,
+                "representative"    : loc.representative,
+                "hmmLength"         : loc.hmmLength,
+                "location-fragments": formatFragments(loc.fragments)
+            ]
+        }
     ])
 }
 
 def formatFragments(fragments) {
     return fragments.collect { frag ->
         [
-                "start"    : frag.start,
-                "end"      : frag.end,
-                "dc-status": frag.dcStatus
+            "start"    : frag.start,
+            "end"      : frag.end,
+            "dc-status": frag.dcStatus
         ]
     }
 }

--- a/modules/output/json/main.nf
+++ b/modules/output/json/main.nf
@@ -601,7 +601,7 @@ def writeXref(seqData, JsonGenerator jsonWriter) {
     seqData.each { row ->
         // jsonWrite.writeObject([name: "$seqId $seqDesc"]) does not correctly handle the formatted str
         jsonWriter.writeStartObject()
-        jsonWriter.writeStringField("name", "${row.id} ${row.description}")
+        jsonWriter.writeStringField("name", "${row.id} ${row.description}".trim())
         jsonWriter.writeStringField("id", row.id)
         jsonWriter.writeEndObject()
     }

--- a/modules/output/tsv/main.nf
+++ b/modules/output/tsv/main.nf
@@ -28,7 +28,8 @@ process WRITE_TSV {
             nucleicToProteinMd5.each { String nucleicMd5, Set<String> proteinMd5s ->
                 if (!seenNucleicMd5s.contains(nucleicMd5)) {
                     seenNucleicMd5s.add(nucleicMd5)
-                    seqData = db.nucleicMd5ToNucleicSeq(nucleicMd5)
+                    def ntSeqData = db.nucleicMd5ToNucleicSeq(nucleicMd5)
+                    String parentId = ntSeqData[0].id
                     proteinMd5s.each { String proteinMd5 ->
                         def proteinMatches = proteins[proteinMd5]
                         if (proteinMatches == null) return
@@ -40,8 +41,9 @@ process WRITE_TSV {
                             def pathways = match.signature.entry?.pathwayXRefs
                             String entryAcc = match.signature.entry?.accession ?: '-'
                             String entryDesc = match.signature.entry?.description ?: '-'
-                            seqData.each { row ->
-                                String seqId = row.id
+                            def proteinSeqData = db.getOrfSeq(proteinMd5, nucleicMd5)
+                            proteinSeqData.each { row ->
+                                String seqId = "${parentId}_${row.id}"
                                 int seqLength = row.sequence.trim().length()
                                 match.locations.each { Location loc ->
                                     def line = formatLine(seqId, proteinMd5, seqLength, match, loc, memberDb, sigDesc, currentDate, entryAcc, entryDesc, goterms, pathways)

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -24,15 +24,18 @@ process WRITE_XML {
     SeqDB db = new SeqDB(seq_db_file.toString())
 
     xml."results"("interproscan-version": interproscan_version, "interpro-version": db_releases?.interpro?.version) {
+        Set<String> seenNucleicMd5s = new HashSet<>()
         matches_files.each { matchFile ->
+            Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
             if (nucleic) {
-                Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
                 nucleicToProteinMd5 = db.groupProteins(proteins)
                 nucleicToProteinMd5.each { String nucleicMd5, Set<String> proteinMd5s ->
-                    addNucleotideNode(nucleicMd5, proteinMd5s, proteins, xml, db)
+                    if (!seenNucleicMd5s.contains(nucleicMd5)) {
+                        addNucleotideNode(nucleicMd5, proteinMd5s, proteins, xml, db)
+                        seenNucleicMd5s.add(nucleicMd5)
+                    }
                 }
             } else {
-                Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
                 proteins.each { String proteinMd5, Map proteinMatches ->
                     addProteinNodes(proteinMd5, proteinMatches, xml, db)
                 }

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -557,6 +557,6 @@ def addSiteNodes(locationSites, memberDB, xml) {
 def writeXref(seqData, xml) {
     // <xref id="id" name="id desc"/>
     seqData.each { row ->
-        xml.xref(id: row.id, name: "${row.id} ${row.description}")
+        xml.xref(id: row.id, name: "${row.id} ${row.description}".trim())
     }
 }


### PR DESCRIPTION
Removing duplicates when nucleic.

Running:
`nextflow run main.nf --input tests/data/sequences/test.fna --datadir data -profile docker --no-matches-api --outdir results --applications prositepatterns --nucleic`

How to check the duplicate sequences (using tsv output): 
`sort results/test.fna.tsv | uniq -c | awk '$1 > 1' | wc -l`

Note: MobiDB is the only member with duplicates, caused by duplicated locations (I will open another PR fixing it on mobidb parse)