### PR TITLE
Fix PRINTS sort matches

### DIFF
--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -230,7 +230,7 @@ List<Prints> sortMatches(List<Prints> matches) {
         int evalueComparison = matchA.evalue <=> matchB.evalue
         if (evalueComparison != 0) return evalueComparison
 
-        int modelAccessionComparison = matchA.modelName <=> matchB.modelName
+        int modelAccessionComparison = matchA.modelId <=> matchB.modelId
         if (modelAccessionComparison != 0) return modelAccessionComparison
 
         int motifNumberComparison = matchA.motifNumber <=> matchB.motifNumber


### PR DESCRIPTION
It wasn't necessary to add a new rule to sort the matches on PRINTS (we already have enough rules after the e-value comparison). 
We were just comparing the wrong field in the second rule (the model name instead of the model accession, as expected). Now, there are no more mismatches between the i5 and i6 versions.

The mismatch sequence we had before the fix: [B0CAM3](https://rest.uniprot.org/uniprotkb/B0CAM3.fasta)

Note: if need to check, sort code on i5 [here](https://github.com/ebi-pf-team/interproscan/blob/master/core/persistence/src/main/java/uk/ac/ebi/interpro/scan/persistence/PrintsFilteredMatchDAOImpl.java#L130-L176)