### PR TITLE
Enable deeplearning

### DIFF
--- a/conf/applications.config
+++ b/conf/applications.config
@@ -37,6 +37,7 @@ params {
             dir = ""
             has_data = false
             use_gpu = false
+            enabled = false
         }
         hamap {
             name = "HAMAP"
@@ -143,6 +144,7 @@ params {
             mode = "fast"
             has_data = false
             use_gpu = false
+            enabled = false
         }
         signalp_prok {
             name = "SignalP-Prok"
@@ -151,11 +153,13 @@ params {
             mode = "fast"
             has_data = false
             use_gpu = false
+            enabled = false
         }
         tmbed {
             name = "TMbed"
             has_data = false
             use_gpu = false
+            enabled = false
         }
     }
 }

--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -25,7 +25,6 @@ class InterProScan {
         ],
         [
             name: "enable-ml",
-            metavar: "<ENABLE-MACHINELEARNING-APPS",
             description: "include machine (deep) learning-based applications in the default applications."
         ],
         [
@@ -260,10 +259,15 @@ class InterProScan {
         return dirs ? dirs.last().fileName.toString() : null
     }
 
-    static validateApplications(String applications, String skipApplications, Map appsConfig) {
+    static validateApplications(String applications, String skipApplications, Map appsConfig, Boolean enableML) {
         if (!applications && !skipApplications) {
             // Run all applications, except licensed packages with an unpopulated dir field
             def appsToRun = appsConfig.findAll{ it ->
+                if (it.value?.enabled == false ) {  // only include deeplearning apps in the default apps if enabled
+                    if (!enableML) {
+                        return false
+                    }
+                }
                 if (this.LICENSED_SOFTWARE.contains(it.key)) {
                     return it.value?.dir
                 }

--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -24,6 +24,11 @@ class InterProScan {
             description: "comma-separated applications to scan the sequences with. Default: all.",
         ],
         [
+            name: "enable-ml",
+            metavar: "<ENABLE-MACHINELEARNING-APPS",
+            description: "include machine (deep) learning-based applications in the default applications."
+        ],
+        [
             name: "formats",
             metavar: "<FORMATS>",
             description: "comma-separated output formats. Available: JSON,TSV,XML,GFF3. Default: JSON,TSV,XML,GFF3."

--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -25,7 +25,7 @@ class InterProScan {
         ],
         [
             name: "include-ml",
-            description: "include machine (deep) learning-based applications (DeepTMHMM, SignalP_prok, SignalP_euk, TMbed) in the analysis. These applications are not run by default due to their high resource requirements."
+            description: "include activated machine (deep) learning-based applications (DeepTMHMM, SignalP_prok, SignalP_euk, TMbed) in the analysis. These applications are not run by default due to their high resource requirements."
         ],
         [
             name: "formats",
@@ -278,7 +278,7 @@ class InterProScan {
                 }
                 return true
             }.keySet().toList()
-
+    
             if (includeML) {
                 def invalidApps = appsConfig.findAll { it.value.containsKey('enabled') && this.LICENSED_SOFTWARE.contains(it.key) && !it.value?.dir }.keySet().toList()
                 if (invalidApps) {
@@ -332,7 +332,7 @@ class InterProScan {
 
         if (applications) {
             def userApps = applications.replaceAll("[- ]", "").split(",")*.trim()
-            def invalidApps = userApps.findAll { appsConfig[allApps[it]].containsKey('enabled') && !appsConfig[allApps[it]]?.dir }
+            def invalidApps = userApps.findAll { appsConfig[allApps[it]].containsKey('enabled') && this.LICENSED_SOFTWARE.contains(it) && !appsConfig[allApps[it]]?.dir }
             if (invalidApps) {
                 def error = "The following applications cannot be run: ${invalidApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
                 return [null, error, null]
@@ -345,7 +345,7 @@ class InterProScan {
                 invalidApps = appsConfig.findAll { it.value.containsKey('enabled') && this.LICENSED_SOFTWARE.contains(it.key) && !it.value?.dir }.keySet().toList()
             } else if (skipApplications) { // Subtract skipped ml-based apps
                 invalidApps = appsConfig.findAll { appName, appConfig ->
-                    if (appConfig.containsKey('enabled') && !appConfig?.dir) {
+                    if (appConfig.containsKey('enabled') && !appConfig?.dir && this.LICENSED_SOFTWARE.contains(appName)) {
                         def appAliases = allApps.findAll { it.value == appName }.keySet()
                         return !appAliases.any { appsParam.contains(it) }
                     }

--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -24,8 +24,8 @@ class InterProScan {
             description: "comma-separated applications to scan the sequences with. Default: all.",
         ],
         [
-            name: "include-ml",
-            description: "include activated machine (deep) learning-based applications (DeepTMHMM, SignalP_prok, SignalP_euk, TMbed) in the analysis. These applications are not run by default due to their high resource requirements."
+            name: "run-ml",
+            description: "run available activated machine learning (ML) based applications (e.g. DeepTMHMM, SignalP 6, TMbed). By default, ML analyses are disabled due to their high resource requirements."
         ],
         [
             name: "formats",
@@ -259,7 +259,7 @@ class InterProScan {
         return dirs ? dirs.last().fileName.toString() : null
     }
 
-    static validateApplications(String applications, String skipApplications, Map appsConfig, Boolean includeML) {
+    static validateApplications(String applications, String skipApplications, Map appsConfig, Boolean runML) {
         if (applications && skipApplications) {
             return [null, "--applications and --skip-applications are mutually exclusive"]
         }
@@ -269,7 +269,7 @@ class InterProScan {
             // and only include deeplearning apps in the default apps if enabled
             def appsToRun = appsConfig.findAll{ it ->
                 if (it.value?.enabled == false ) {
-                    if (!includeML) {
+                    if (!runML) {
                         return false
                     }
                 }
@@ -279,10 +279,10 @@ class InterProScan {
                 return true
             }.keySet().toList()
     
-            if (includeML) {
+            if (runML) {
                 def invalidApps = appsConfig.findAll { it.value.containsKey('enabled') && this.LICENSED_SOFTWARE.contains(it.key) && !it.value?.dir }.keySet().toList()
                 if (invalidApps) {
-                    def warn = "The following machine learning-based applications were requested with '--include-ml' but cannot be run: ${invalidApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
+                    def warn = "The following machine learning-based analyses are unavailable and will be skipped, even though --run-ml was specified: ${invalidApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
                     return [appsToRun, null, warn]
                 }
             }
@@ -302,7 +302,7 @@ class InterProScan {
         }
         def appsToRun = applications ? [] : allApps.findAll { it ->
             if (appsConfig[it.value].containsKey('enabled')) {
-                if (includeML) {
+                if (runML) {
                     if (this.LICENSED_SOFTWARE.contains(it.value)) {
                         return appsConfig[it.value]?.dir
                     } else {
@@ -339,7 +339,7 @@ class InterProScan {
             }
         }
 
-        if (includeML) {
+        if (runML) {
             def invalidApps = []
             if (applications) {
                 invalidApps = appsConfig.findAll { it.value.containsKey('enabled') && this.LICENSED_SOFTWARE.contains(it.key) && !it.value?.dir }.keySet().toList()
@@ -354,7 +354,7 @@ class InterProScan {
             }
 
             if (invalidApps) {
-                def warn = "The following machine learning-based applications were requested with '--include-ml' but cannot be run: ${invalidApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
+                def warn = "The following machine learning-based analyses are unavailable and will be skipped even though --run-ml was specified: ${invalidApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
                 return [appsToRun.toSet().toList(), null, warn]
             }
         }

--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -323,16 +323,25 @@ class InterProScan {
             }
         }
 
-        def invalidApps = appsToRun.findAll { app ->
-            this.LICENSED_SOFTWARE.contains(app) && !appsConfig[app]?.dir
-        }
-
-        if (invalidApps) {
-            if (skipApplications) {
-                appsToRun.removeAll(invalidApps)
-            } else {
+        if (applications) {
+            // If specified (using --applications) inactivated licensed apps, raise an error
+            appNames = applications.replaceAll("[- ]", "").split(",").collect { it.trim() }.toSet()
+            invalidApps = appNames.findAll { app ->
+                this.LICENSED_SOFTWARE.contains(app) && !appsConfig[app]?.dir
+            }
+            if (invalidApps) {
                 def error = "The following applications cannot be run: ${invalidApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
                 return [null, error]
+            }
+        }
+
+        if (includeML) {
+            // Raise warnings for inactivated ml apps
+            invalidApps = appsToRun.findAll { app ->
+                this.LICENSED_SOFTWARE.contains(app) && !appsConfig[app]?.dir
+            }
+            if (invalidApps) {
+                log.warn "The following machine learning-based applications were requested but cannot be run: ${invalidApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
             }
         }
 

--- a/main.nf
+++ b/main.nf
@@ -27,7 +27,7 @@ workflow {
         params.input,
         params.applications,
         params.appsConfig,
-        params.runML,
+        params.runMl,
         params.datadir,
         params.formats,
         params.outdir,

--- a/main.nf
+++ b/main.nf
@@ -26,6 +26,7 @@ workflow {
         params.input,
         params.applications,
         params.appsConfig,
+        params.enableMl,
         params.datadir,
         params.formats,
         params.outdir,

--- a/main.nf
+++ b/main.nf
@@ -28,7 +28,7 @@ workflow {
         params.input,
         params.applications,
         params.appsConfig,
-        params.enableMl,
+        params.includeMl,
         params.datadir,
         params.formats,
         params.outdir,

--- a/main.nf
+++ b/main.nf
@@ -1,4 +1,5 @@
 nextflow.enable.dsl=2
+import java.time.format.DateTimeFormatter
 
 include { INIT_PIPELINE      } from "./subworkflows/init"
 include { PREPARE_DATABASES  } from "./subworkflows/prepare/databases"
@@ -9,8 +10,6 @@ include { SCAN_SEQUENCES as SCAN_REMAINING;
           SCAN_SEQUENCES     } from "./subworkflows/scan"
 include { COMBINE            } from "./subworkflows/combine"
 include { OUTPUT             } from "./subworkflows/output"
-
-import java.time.format.DateTimeFormatter
 
 workflow {
     println "# ${workflow.manifest.name} ${workflow.manifest.version}"
@@ -28,7 +27,7 @@ workflow {
         params.input,
         params.applications,
         params.appsConfig,
-        params.includeMl,
+        params.runML,
         params.datadir,
         params.formats,
         params.outdir,

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,7 +15,7 @@ params {
     batchSize             = 5000
     maxWorkers            = null
     cpus                  = 1
-    matchesApiUrl         = "https://wwwdev.ebi.ac.uk/interpro/matches/api"
+    matchesApiUrl         = "https://www.ebi.ac.uk/interpro/matches/api"
     matchesApiChunkSize   = 100
     matchesApiMaxRetries  = 3
     noMatchesApi          = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,6 +2,7 @@ params {
     input                 = null
     datadir               = null
     applications          = null
+    enableMl              = false
     nucleic               = false
     formats               = "json,jsonl,tsv,xml,gff3"
     goterms               = false
@@ -14,7 +15,7 @@ params {
     batchSize             = 5000
     maxWorkers            = null
     cpus                  = 1
-    matchesApiUrl         = "https://www.ebi.ac.uk/interpro/matches/api"
+    matchesApiUrl         = "https://wwwdev.ebi.ac.uk/interpro/matches/api"
     matchesApiChunkSize   = 100
     matchesApiMaxRetries  = 3
     noMatchesApi          = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,7 +2,7 @@ params {
     input                 = null
     datadir               = null
     applications          = null
-    enableMl              = false
+    includeMl             = false
     nucleic               = false
     formats               = "json,jsonl,tsv,xml,gff3"
     goterms               = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,7 +2,7 @@ params {
     input                 = null
     datadir               = null
     applications          = null
-    includeMl             = false
+    runMl                 = false
     nucleic               = false
     formats               = "json,jsonl,tsv,xml,gff3"
     goterms               = false

--- a/subworkflows/init/main.nf
+++ b/subworkflows/init/main.nf
@@ -4,6 +4,7 @@ workflow INIT_PIPELINE {
     input
     applications
     apps_config
+    enableML
     datadir
     formats
     outdir
@@ -24,11 +25,12 @@ workflow INIT_PIPELINE {
     }
 
     // Applications validation
-    (apps, error) = InterProScan.validateApplications(applications, skip_applications, apps_config)
+    (apps, error) = InterProScan.validateApplications(applications, skip_applications, apps_config, enableML)
     if (!apps) {
         log.error error
         exit 1
     }
+    println "Applications to be run: ${apps.join(', ')}"
 
     if (skip_intepro && (goterms || pathways)) {
         log.error "--skip_intepro is mutually exclusive with --goterms and --pathways"

--- a/subworkflows/init/main.nf
+++ b/subworkflows/init/main.nf
@@ -4,7 +4,7 @@ workflow INIT_PIPELINE {
     input
     applications
     apps_config
-    includeML
+    runML
     datadir
     formats
     outdir
@@ -27,7 +27,7 @@ workflow INIT_PIPELINE {
     }
 
     // Applications validation
-    (apps, error, warn) = InterProScan.validateApplications(applications, skip_applications, apps_config, includeML)
+    (apps, error, warn) = InterProScan.validateApplications(applications, skip_applications, apps_config, runML)
     if (!apps) {
         log.error error
         exit 1

--- a/subworkflows/init/main.nf
+++ b/subworkflows/init/main.nf
@@ -4,7 +4,7 @@ workflow INIT_PIPELINE {
     input
     applications
     apps_config
-    enableML
+    includeML
     datadir
     formats
     outdir
@@ -27,7 +27,7 @@ workflow INIT_PIPELINE {
     }
 
     // Applications validation
-    (apps, error) = InterProScan.validateApplications(applications, skip_applications, apps_config, enableML)
+    (apps, error) = InterProScan.validateApplications(applications, skip_applications, apps_config, includeML)
     if (!apps) {
         log.error error
         exit 1

--- a/subworkflows/init/main.nf
+++ b/subworkflows/init/main.nf
@@ -27,10 +27,12 @@ workflow INIT_PIPELINE {
     }
 
     // Applications validation
-    (apps, error) = InterProScan.validateApplications(applications, skip_applications, apps_config, includeML)
+    (apps, error, warn) = InterProScan.validateApplications(applications, skip_applications, apps_config, includeML)
     if (!apps) {
         log.error error
         exit 1
+    } else if (warn) {
+        log.warn warn
     }
 
     if (skip_intepro && (goterms || pathways)) {

--- a/subworkflows/init/main.nf
+++ b/subworkflows/init/main.nf
@@ -30,7 +30,6 @@ workflow INIT_PIPELINE {
         log.error error
         exit 1
     }
-    println "Applications to be run: ${apps.join(', ')}"
 
     if (skip_intepro && (goterms || pathways)) {
         log.error "--skip_intepro is mutually exclusive with --goterms and --pathways"

--- a/tests/unit_tests/subworkflows/init_pipeline/main.nf.test
+++ b/tests/unit_tests/subworkflows/init_pipeline/main.nf.test
@@ -28,18 +28,19 @@ nextflow_workflow {
                 input[0] = "$baseDir/tests/data/sequences/test.faa"     // input
                 input[1] = "pfam,ncbifam"                           // applictaions
                 input[2] = params.apps_config                       // apps_config
-                input[3] = "data"                                   // datadir
-                input[4] = "json,tsv,xml"                           // formats
-                input[5] = "results"                                // outdir
-                input[6] = null                                     // outprefix  
-                input[7] = false                                    // no_matches_api
-                input[8] = null                                     // matches_api_url
-                input[9] = "latest"                                 // interpro_version
-                input[10] = false                                    // skip_intepro
-                input[11] = null                                    // skip_applications
-                input[12] = false                                   // goterms
-                input[13] = false                                   // pathways
-                input[14] = params.workflow_manifest                // workflow manifest
+                input[3] = false                                    // run-ml
+                input[4] = "data"                                   // datadir
+                input[5] = "json,tsv,xml"                           // formats
+                input[6] = "results"                                // outdir
+                input[7] = null                                     // outprefix  
+                input[8] = false                                    // no_matches_api
+                input[9] = null                                     // matches_api_url
+                input[10] = "latest"                                 // interpro_version
+                input[11] = false                                   // skip_intepro
+                input[12] = null                                    // skip_applications
+                input[13] = false                                   // goterms
+                input[14] = false                                   // pathways
+                input[15] = params.workflow_manifest                // workflow manifest
                 """
             }
         }
@@ -73,18 +74,19 @@ nextflow_workflow {
                 input[0] = "$baseDir/tests/data/sequences/missing.faa"  // input
                 input[1] = "pfam,ncbifam"                           // applictaions
                 input[2] = params.apps_config                       // apps_config
-                input[3] = "data"                                   // datadir
-                input[4] = "json,tsv,xml"                           // formats
-                input[5] = "results"                                // outdir
-                input[6] = null                                     // outprefix  
-                input[7] = false                                    // no_matches_api
-                input[8] = null                                     // matches_api_url
-                input[9] = "latest"                                 // interpro_version
-                input[10] = false                                    // skip_intepro
-                input[11] = null                                    // skip_applications
-                input[12] = false                                   // goterms
-                input[13] = false                                   // pathways
-                input[14] = params.workflow_manifest                // workflow manifest
+                input[3] = false                                    // run-ml
+                input[4] = "data"                                   // datadir
+                input[5] = "json,tsv,xml"                           // formats
+                input[6] = "results"                                // outdir
+                input[7] = null                                     // outprefix  
+                input[8] = false                                    // no_matches_api
+                input[9] = null                                     // matches_api_url
+                input[10] = "latest"                                 // interpro_version
+                input[11] = false                                    // skip_intepro
+                input[12] = null                                    // skip_applications
+                input[13] = false                                   // goterms
+                input[14] = false                                   // pathways
+                input[15] = params.workflow_manifest                // workflow manifest
                 """
             }
         }
@@ -119,18 +121,19 @@ nextflow_workflow {
                 input[0] = "$baseDir/tests/data/sequences/test.faa"     // input
                 input[1] = "pfam,ncbifam,invalidfam"                // applictaions
                 input[2] = params.apps_config                       // apps_config
-                input[3] = "data"                                   // datadir
-                input[4] = "json,tsv,xml"                           // formats
-                input[5] = "results"                                // outdir
-                input[6] = null                                     // outprefix  
-                input[7] = false                                    // no_matches_api
-                input[8] = null                                     // matches_api_url
-                input[9] = "latest"                                 // interpro_version
-                input[10] = false                                    // skip_intepro
-                input[11] = null                                    // skip_applications
-                input[12] = false                                   // goterms
-                input[13] = false                                   // pathways
-                input[14] = params.workflow_manifest                // workflow manifest
+                input[3] = false                                    // run-ml
+                input[4] = "data"                                   // datadir
+                input[5] = "json,tsv,xml"                           // formats
+                input[6] = "results"                                // outdir
+                input[7] = null                                     // outprefix  
+                input[8] = false                                    // no_matches_api
+                input[9] = null                                     // matches_api_url
+                input[10] = "latest"                                 // interpro_version
+                input[11] = false                                    // skip_intepro
+                input[12] = null                                    // skip_applications
+                input[13] = false                                   // goterms
+                input[14] = false                                   // pathways
+                input[15] = params.workflow_manifest                // workflow manifest
                 """
             }
         }
@@ -164,18 +167,19 @@ nextflow_workflow {
                 input[0] = "$baseDir/tests/data/sequences/test.faa"     // input
                 input[1] = "pfam,ncbifam"                           // applictaions
                 input[2] = params.apps_config                       // apps_config
-                input[3] = "data"                                   // datadir
-                input[4] = "json,tsv,xml"                           // formats
-                input[5] = "results"                                // outdir
-                input[6] = null                                     // outprefix  
-                input[7] = false                                    // no_matches_api
-                input[8] = null                                     // matches_api_url
-                input[9] = "latest"                                 // interpro_version
-                input[10] = true                                    // skip_intepro
-                input[11] = null                                    // skip_applications
-                input[12] = true                                    // goterms
-                input[13] = true                                    // pathways
-                input[14] = params.workflow_manifest                // workflow manifest
+                input[3] = false                                    // run-ml
+                input[4] = "data"                                   // datadir
+                input[5] = "json,tsv,xml"                           // formats
+                input[6] = "results"                                // outdir
+                input[7] = null                                     // outprefix  
+                input[8] = false                                    // no_matches_api
+                input[9] = null                                     // matches_api_url
+                input[10] = "latest"                                 // interpro_version
+                input[11] = true                                    // skip_intepro
+                input[12] = null                                    // skip_applications
+                input[13] = true                                    // goterms
+                input[14] = true                                    // pathways
+                input[15] = params.workflow_manifest                // workflow manifest
                 """
             }
         }
@@ -209,18 +213,19 @@ nextflow_workflow {
                 input[0] = "$baseDir/tests/data/sequences/test.faa"     // input
                 input[1] = "pfam,ncbifam"                           // applictaions
                 input[2] = params.apps_config                       // apps_config
-                input[3] = "data"                                   // datadir
-                input[4] = "json,tsv,xml,csv"                       // formats
-                input[5] = "results"                                // outdir
-                input[6] = null                                     // outprefix  
-                input[7] = false                                    // no_matches_api
-                input[8] = null                                     // matches_api_url
-                input[9] = "latest"                                 // interpro_version
-                input[10] = false                                    // skip_intepro
-                input[11] = null                                    // skip_applications
-                input[12] = false                                   // goterms
-                input[13] = false                                   // pathways
-                input[14] = params.workflow_manifest                // workflow manifest
+                input[3] = false                                    // run-ml
+                input[4] = "data"                                   // datadir
+                input[5] = "json,tsv,xml,csv"                       // formats
+                input[6] = "results"                                // outdir
+                input[7] = null                                     // outprefix  
+                input[8] = false                                    // no_matches_api
+                input[9] = null                                     // matches_api_url
+                input[10] = "latest"                                 // interpro_version
+                input[11] = false                                    // skip_intepro
+                input[12] = null                                    // skip_applications
+                input[13] = false                                   // goterms
+                input[14] = false                                   // pathways
+                input[15] = params.workflow_manifest                // workflow manifest
                 """
             }
         }
@@ -258,18 +263,19 @@ nextflow_workflow {
                 input[0] = "$baseDir/tests/data/sequences/test.faa"     // input
                 input[1] = "pfam,ncbifam"                           // applictaions
                 input[2] = params.apps_config                       // apps_config
-                input[3] = null                                     // datadir
-                input[4] = "json,tsv,xml,csv"                       // formats
-                input[5] = "results"                                // outdir
-                input[6] = null                                     // outprefix  
-                input[7] = false                                    // no_matches_api
-                input[8] = null                                     // matches_api_url
-                input[9] = "latest"                                 // interpro_version
-                input[10] = false                                    // skip_intepro
-                input[11] = null                                    // skip_applications
-                input[12] = false                                   // goterms
-                input[13] = false                                   // pathways
-                input[14] = params.workflow_manifest                // workflow manifest
+                input[3] = false                                    // run-ml
+                input[4] = null                                     // datadir
+                input[5] = "json,tsv,xml,csv"                       // formats
+                input[6] = "results"                                // outdir
+                input[7] = null                                     // outprefix  
+                input[8] = false                                    // no_matches_api
+                input[9] = null                                     // matches_api_url
+                input[10] = "latest"                                 // interpro_version
+                input[11] = false                                    // skip_intepro
+                input[12] = null                                    // skip_applications
+                input[13] = false                                   // goterms
+                input[14] = false                                   // pathways
+                input[15] = params.workflow_manifest                // workflow manifest
                 """
             }
         }
@@ -303,18 +309,19 @@ nextflow_workflow {
                 input[0] = "$baseDir/tests/data/sequences/test.faa"     // input
                 input[1] = "pfam,ncbifam"                           // applictaions
                 input[2] = params.apps_config                       // apps_config
-                input[3] = "$baseDir/tests/data/sequences/test.faa"     // datadir
-                input[4] = "json,tsv,xml,csv"                       // formats
-                input[5] = "results"                                // outdir
-                input[6] = null                                     // outprefix  
-                input[7] = false                                    // no_matches_api
-                input[8] = null                                     // matches_api_url
-                input[9] = "latest"                                 // interpro_version
-                input[10] = false                                    // skip_intepro
-                input[11] = null                                    // skip_applications
-                input[12] = false                                   // goterms
-                input[13] = false                                   // pathways
-                input[14] = params.workflow_manifest                // workflow manifest
+                input[3] = false                                    // run-ml
+                input[4] = "$baseDir/tests/data/sequences/test.faa" // datadir
+                input[5] = "json,tsv,xml,csv"                       // formats
+                input[6] = "results"                                // outdir
+                input[7] = null                                     // outprefix  
+                input[8] = false                                    // no_matches_api
+                input[9] = null                                     // matches_api_url
+                input[10] = "latest"                                 // interpro_version
+                input[11] = false                                    // skip_intepro
+                input[12] = null                                    // skip_applications
+                input[13] = false                                   // goterms
+                input[14] = false                                   // pathways
+                input[15] = params.workflow_manifest                // workflow manifest
                 """
             }
         }
@@ -348,18 +355,19 @@ nextflow_workflow {
                 input[0] = "$baseDir/tests/data/sequences/test.faa"     // input
                 input[1] = "pfam,ncbifam"                           // applictaions
                 input[2] = params.apps_config                       // apps_config
-                input[3] = "$baseDir/tests/data/sequences/test.faa"     // datadir
-                input[4] = "json,tsv,xml,csv"                       // formats
-                input[5] = "results"                                // outdir
-                input[6] = null                                     // outprefix  
-                input[7] = false                                    // no_matches_api
-                input[8] = null                                     // matches_api_url
-                input[9] = "latest"                                 // interpro_version
-                input[10] = false                                    // skip_intepro
-                input[11] = null                                    // skip_applications
-                input[12] = false                                   // goterms
-                input[13] = false                                   // pathways
-                input[14] = params.workflow_manifest                // workflow manifest
+                input[3] = false                                    // run-ml
+                input[4] = "$baseDir/tests/data/sequences/test.faa" // datadir
+                input[5] = "json,tsv,xml,csv"                       // formats
+                input[6] = "results"                                // outdir
+                input[7] = null                                     // outprefix  
+                input[8] = false                                    // no_matches_api
+                input[9] = null                                     // matches_api_url
+                input[10] = "latest"                                 // interpro_version
+                input[11] = false                                    // skip_intepro
+                input[12] = null                                    // skip_applications
+                input[13] = false                                   // goterms
+                input[14] = false                                   // pathways
+                input[15] = params.workflow_manifest                // workflow manifest
                 """
             }
         }
@@ -402,18 +410,19 @@ nextflow_workflow {
                 input[0] = "$baseDir/tests/data/sequences/test.faa"     // input
                 input[1] = "pfam,ncbifam"                           // applictaions
                 input[2] = params.apps_config                       // apps_config
-                input[3] = "$baseDir/tests/data/sequences/test.faa"     // datadir
-                input[4] = "json,tsv,xml,csv"                       // formats
-                input[5] = "results"                                // outdir
-                input[6] = null                                     // outprefix  
-                input[7] = false                                    // no_matches_api
-                input[8] = null                                     // matches_api_url
-                input[9] = "latest"                                 // interpro_version
-                input[10] = false                                    // skip_intepro
-                input[11] = null                                    // skip_applications
-                input[12] = false                                   // goterms
-                input[13] = false                                   // pathways
-                input[14] = params.workflow_manifest                // workflow manifest
+                input[3] = false                                    // run-ml
+                input[4] = "$baseDir/tests/data/sequences/test.faa" // datadir
+                input[5] = "json,tsv,xml,csv"                       // formats
+                input[6] = "results"                                // outdir
+                input[7] = null                                     // outprefix  
+                input[8] = false                                    // no_matches_api
+                input[9] = null                                     // matches_api_url
+                input[10] = "latest"                                 // interpro_version
+                input[11] = false                                    // skip_intepro
+                input[12] = null                                    // skip_applications
+                input[13] = false                                   // goterms
+                input[14] = false                                   // pathways
+                input[15] = params.workflow_manifest                // workflow manifest
                 """
             }
         }


### PR DESCRIPTION
Adds the `--enable-ml` flag that will include the deeplearning-based applications (TMbed, DeepTMHMM and SignalP) in the default applications (i.e. when `--applications` and `--skip-applications` are not used) as long as their `dir` property in the `applications.conf` is populated (if they have one).

Using the default `conf/applications.conf`:
```bash
$ nextflow run main.nf --input tests/data/sequences/test.faa -profile docker --datadir data/

Applications to be run: antifam, cathgene3d, cathfunfam, cdd, coils, hamap, mobidblite, ncbifam, panther, pfam, pirsf, pirsr, prints, prositepatterns, prositeprofiles, sfld, smart, superfamily
```

With `--enable-ml`
```bash
$ nextflow run main.nf --input tests/data/sequences/test.faa -profile docker --datadir data/ --enable-ml

Applications to be run: antifam, cathgene3d, cathfunfam, cdd, coils, hamap, mobidblite, ncbifam, panther, pfam, pirsf, pirsr, prints, prositepatterns, prositeprofiles, sfld, smart, superfamily, tmbed

ERROR ~ Precomputed results for DeepTMHMM, SignalP_Euk, SignalP_Prok and TMbed are not yet available in the Matches API. To ensure these analyses run locally and produce results, please add the '--no-matches-api' flag when invoking the pipeline.
```

Using a conf file where DeepTMHMM and SignalP `dir` properties are populated:
```bash
$ nextflow run main.nf --input tests/data/sequences/test.faa -profile docker --datadir data/ -c conf/apps-license.conf 

Applications to be run: antifam, cathgene3d, cathfunfam, cdd, coils, hamap, mobidblite, ncbifam, panther, phobius, pfam, pirsf, pirsr, prints, prositepatterns, prositeprofiles, sfld, smart, superfamily
```

With `--enable-ml`
```bash
$ nextflow run main.nf --input tests/data/sequences/test.faa -profile docker --datadir data/ -c conf/apps-license.conf --enable-ml

Applications to be run: antifam, cathgene3d, cathfunfam, cdd, coils, deeptmhmm, hamap, mobidblite, ncbifam, panther, phobius, pfam, pirsf, pirsr, prints, prositepatterns, prositeprofiles, sfld, smart, superfamily, signalp_euk, signalp_prok, tmbed

ERROR ~ Precomputed results for DeepTMHMM, SignalP_Euk, SignalP_Prok and TMbed are not yet available in the Matches API. To ensure these analyses run locally and produce results, please add the '--no-matches-api' flag when invoking the pipeline.
```
