### PR TITLE
Bump nf

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 Before you begin, install:
 
-* [Nextflow](https://www.nextflow.io/) 24.10.04 or later
+* [Nextflow](https://www.nextflow.io/) 25.04 or later
 * A container runtime. The currently supported are:
     * [Docker](https://www.docker.com/)
     * [SingularityCE](https://sylabs.io/singularity/)

--- a/nextflow.config
+++ b/nextflow.config
@@ -73,7 +73,7 @@ manifest {
     license                = "Apache License 2.0"
     mainScript             = "main.nf" 
     name                   = "InterProScan6"
-    nextflowVersion        = ">=24.10.4"
+    nextflowVersion        = ">=25.04"
     organization           = "EMBL-EBI"
     version                = "6.0.0-beta"
 }


### PR DESCRIPTION
Bumps the minimum NF version to 25.04 (`nextflow self-update`) - not this increases the minimum Java requirements to 17. For the best performance use Java 19 with virtual threads enabled or Java 21 for virtual threads to be enabled by default.