### PR TITLE
Gff3 writer performance [Review after XML]

### DIFF
--- a/modules/output/gff3/main.nf
+++ b/modules/output/gff3/main.nf
@@ -13,6 +13,10 @@ process WRITE_GFF3 {
     val interproscan_version
 
     exec:
+    Pattern esl_pattern = Pattern.compile(/^source=[^"]+\s+coords=(\d+)\.\.(\d+)\s+length=\d+\s+frame=(\d+)\s+desc=.*$/)
+    Pattern fasta_pattern = Pattern.compile(/(.{60})/)
+    Set<String> seenNucleicMd5s = new HashSet<>()
+
     def db = new SeqDBQuery(seq_db_file.toString())
     def gff3File = new File(output_file.toString())
     gff3File.text = "" // Clear file if it exists
@@ -45,7 +49,7 @@ process WRITE_GFF3 {
         Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
 
         if (nucleic) {
-            processNucleotides(db, proteins, gff3LineBuffer, fastaLineBuffer, BATCH_SIZE, flushGff3Buffer, flushFastaBuffer)
+            processNucleotides(db, proteins, gff3LineBuffer, fastaLineBuffer, BATCH_SIZE, flushGff3Buffer, flushFastaBuffer, esl_pattern, seenNucleicMd5s)
         } else {
             def proteinMd5List = proteins.keySet().toList()
             Map<String, List> seqData = db.proteinMd5sToProteinSeqs(proteinMd5List)
@@ -75,7 +79,7 @@ process WRITE_GFF3 {
                     }
 
                     fastaLineBuffer << ">${row.id}"
-                    fastaLineBuffer << "${sequence.replaceAll(/(.{60})/, '$1\n')}"
+                    fastaLineBuffer << "${sequence.replaceAll(fasta_pattern, '$1\n')}"
 
                     if (fastaLineBuffer.size() >= BATCH_SIZE) {
                         flushFastaBuffer()
@@ -100,9 +104,8 @@ process WRITE_GFF3 {
 }
 
 def processNucleotidesBulkGFF3(SeqDBQuery db, Map proteins, Writer gff3Writer, Writer fastaWriter,
-    int batchSize, Closure flushGff3Buffer, Closure flushFastaBuffer) {
-    Pattern esl_pattern = Pattern.compile(/^source=[^"]+\s+coords=(\d+)\.\.(\d+)\s+length=\d+\s+frame=(\d+)\s+desc=.*$/)
-    Set<String> seenNucleicMd5s = new HashSet<>()
+    int batchSize, Closure flushGff3Buffer, Closure flushFastaBuffer,
+    Pattern esl_pattern, Set seenNucleicMd5s) {
 
     Set<String> allProteinMd5s = proteins.keySet().toSet()
     Map<String, Set<String>> nucleicToProteinMd5 = db.groupProteinsBulk(allProteinMd5s)
@@ -189,26 +192,31 @@ def processNucleotidesBulkGFF3(SeqDBQuery db, Map proteins, Writer gff3Writer, W
 def proteinFormatLine(seqId, match, loc, parentId, cdsStart, strand) {
     String memberDb = match.signature.signatureLibraryRelease.library
 
-    def goTerms = []
-    if(memberDb == "PANTHER" && match.treegrafter.goXRefs){
-        goTerms += match.treegrafter.goXRefs
-    }
-    
-    if (match.signature.entry?.goXRefs) {
-        goTerms += match.signature.entry.goXRefs
-    }
-
     def uniqueTermIds = new HashSet<String>()
-    def goTermBuilder = new StringBuilder()
-    boolean firstGo = true
-    for (term in goTerms) {
-        if (uniqueTermIds.add(term.id)) { // HashSet.add() returns false if already exists
-            if (!firstGo) goTermBuilder.append(',')
-            goTermBuilder.append(term.id)
-            firstGo = false
+    if (memberDb == "PANTHER" && match.treegrafter?.goXRefs) {
+        for (term in match.treegrafter.goXRefs) {
+            uniqueTermIds.add(term.id)
         }
     }
-    String goTermString = goTermBuilder.length() > 0 ? goTermBuilder.toString() : ""
+    if (match.signature.entry?.goXRefs) {
+        for (term in match.signature.entry.goXRefs) {
+            uniqueTermIds.add(term.id)
+        }
+    }
+
+    String goTermString = ""
+    if (uniqueTermIds.size() > 0) {
+        def estimatedLength = uniqueTermIds.size() * 12
+        def goTermBuilder = new StringBuilder(estimatedLength)  // pre-size for efficiency
+        
+        boolean firstGo = true
+        for (termId in uniqueTermIds) {
+            if (!firstGo) goTermBuilder.append(',')
+            goTermBuilder.append(termId)
+            firstGo = false
+        }
+        goTermString = goTermBuilder.toString()
+    }
 
     def feature_type = null
     switch (memberDb) {

--- a/modules/output/gff3/main.nf
+++ b/modules/output/gff3/main.nf
@@ -33,54 +33,7 @@ process WRITE_GFF3 {
                 Map proteins = new ObjectMapper().readValue(matchFile, Map)
 
                 if (nucleic) {
-                    nucleicToProteinMd5 = db.groupProteins(proteins)
-                    nucleicToProteinMd5.each { String nucleicMd5, Set<String> proteinMd5s ->
-                        if (seenNucleicMd5s.contains(nucleicMd5)) {
-                            return
-                        }
-                        seenNucleicMd5s.add(nucleicMd5)
-
-                        seqData = db.nucleicMd5ToNucleicSeq(nucleicMd5)
-
-                        seqData.each { seq ->
-                            String seqId = seq.id
-                            String sequence = seq.sequence.trim()
-                            int seqLength = sequence.length()
-                            gff3Writer.writeLine("##sequence-region ${seqId} 1 ${seqLength}")
-
-                            proteinMd5s.each { String proteinMd5 ->
-                                // a proteinSeq/Md5 may be associated with multiple nt md5s/seq, only pull the data where the nt md5/seq is relevant
-                                proteinSeqData = db.getOrfSeq(proteinMd5, nucleicMd5)
-                                proteinSeqData.each { row ->
-                                    def matcher = esl_pattern.matcher(row.description)
-                                    assert matcher.matches()
-                                    int start = matcher.group(1) as int
-                                    int end = matcher.group(2) as int
-                                    String strand = (matcher.group(3) as int) < 4 ? "+" : "-"
-                                    String parentId = "${seqId}_${row.id}"
-
-                                    String line
-                                    if (strand == "+") {
-                                        line = "${seqId}\tesl-translate\tCDS\t${start}\t${end}\t.\t${strand}\t0\tID=${parentId}"
-                                    } else {
-                                        line = "${seqId}\tesl-translate\tCDS\t${end}\t${start}\t.\t${strand}\t0\tID=${parentId}"
-                                    }
-
-                                    gff3Writer.writeLine(line)
-
-                                    proteins[proteinMd5].each { modelAcc, match->
-                                        match = Match.fromMap(match)
-                                        match.locations.each { Location loc ->
-                                            gff3Writer.writeLine(proteinFormatLine(seqId, match, loc, parentId, strand == "+" ? start : end, strand))
-                                        }
-                                    }
-                                }
-                            }
-
-                            fastaWriter.writeLine(">${seqId}")
-                            fastaWriter.writeLine("${sequence.replaceAll(/(.{60})/, '$1\n')}")  
-                        }
-                    }
+                    processNucleotides(db, proteins, seenNucleicMd5s, gff3Writer, fastaWriter, esl_pattern)
                 } else {
                     def proteinMd5List = proteins.keySet().toList()
                     Map<String, List> seqData = db.proteinMd5sToProteinSeqs(proteinMd5List)
@@ -116,6 +69,75 @@ process WRITE_GFF3 {
             }
         }
         tempFastaFile.delete()
+    }
+}
+
+def processNucleotidesBulkGFF3(SeqDBQuery db, Map proteins, Set seenNucleicMd5s, 
+                               Writer gff3Writer, Writer fastaWriter, Pattern esl_pattern) {
+    Set<String> allProteinMd5s = proteins.keySet().toSet()
+    Map<String, Set<String>> nucleicToProteinMd5 = db.groupProteinsBulk(allProteinMd5s)
+    
+    // Filter to only unseen nucleotide MD5s
+    List<String> newNucleicMd5s = nucleicToProteinMd5.keySet().findAll { !seenNucleicMd5s.contains(it) }
+    seenNucleicMd5s.addAll(newNucleicMd5s)
+    if (newNucleicMd5s.isEmpty()) {
+        return
+    }
+
+    Map<String, List> nucleotideSeqData = db.nucleicMd5sToNucleicSeqs(newNucleicMd5s)
+
+    // Get all ORF sequences for relevant protein/nucleotide combinations
+    List<String> relevantProteinMd5s = []
+    newNucleicMd5s.each { nucleicMd5 ->
+        relevantProteinMd5s.addAll(nucleicToProteinMd5[nucleicMd5])
+    }
+
+    Map<String, Map<String, List>> orfSeqData = db.getOrfSeqsBulk(relevantProteinMd5s, newNucleicMd5s)
+
+    newNucleicMd5s.each { String nucleicMd5 ->
+        def ntSeqData = nucleotideSeqData[nucleicMd5]
+        Set<String> proteinMd5sForNucleic = nucleicToProteinMd5[nucleicMd5]
+        
+        ntSeqData.each { seq ->
+            String seqId = seq.id
+            String sequence = seq.sequence.trim()
+            int seqLength = sequence.length()
+            gff3Writer.writeLine("##sequence-region ${seqId} 1 ${seqLength}")
+
+            proteinMd5sForNucleic.each { String proteinMd5 ->
+                def proteinMatches = proteins[proteinMd5]
+                def proteinSeqData = orfSeqData[proteinMd5]?.get(nucleicMd5)
+                
+                proteinSeqData.each { row ->
+                    def matcher = esl_pattern.matcher(row.description)
+                    if (!matcher.matches()) return
+                    
+                    int start = matcher.group(1) as int
+                    int end = matcher.group(2) as int
+                    String strand = (matcher.group(3) as int) < 4 ? "+" : "-"
+                    String parentId = "${seqId}_${row.id}"
+
+                    String line
+                    if (strand == "+") {
+                        line = "${seqId}\tesl-translate\tCDS\t${start}\t${end}\t.\t${strand}\t0\tID=${parentId}"
+                    } else {
+                        line = "${seqId}\tesl-translate\tCDS\t${end}\t${start}\t.\t${strand}\t0\tID=${parentId}"
+                    }
+
+                    gff3Writer.writeLine(line)
+
+                    proteinMatches.each { modelAcc, matchMap ->
+                        def match = Match.fromMap(matchMap)
+                        match.locations.each { Location loc ->
+                            gff3Writer.writeLine(proteinFormatLine(seqId, match, loc, parentId, strand == "+" ? start : end, strand))
+                        }
+                    }
+                }
+            }
+
+            fastaWriter.writeLine(">${seqId}")
+            fastaWriter.writeLine("${sequence.replaceAll(/(.{60})/, '$1\n')}")  
+        }
     }
 }
 

--- a/modules/output/gff3/main.nf
+++ b/modules/output/gff3/main.nf
@@ -72,7 +72,7 @@ process WRITE_GFF3 {
 
                     if (gff3LineBuffer.size() >= BATCH_SIZE) {
                         flushGff3Buffer()
-                        System.gc() // Make the jvm tidy up to prevent running out of memory
+                        System.gc() // Make the jvm tidies up to prevent running out of memory
                     }
 
                     fastaLineBuffer << ">${row.id}"
@@ -80,7 +80,7 @@ process WRITE_GFF3 {
 
                     if (fastaLineBuffer.size() >= BATCH_SIZE) {
                         flushFastaBuffer()
-                        System.gc() // Make the jvm tidy up to prevent running out of memory
+                        System.gc() // Make the jvm tidies up to prevent running out of memory
                     }
                 }         
             }
@@ -97,7 +97,7 @@ process WRITE_GFF3 {
 
             if (gff3LineBuffer.size() >= BATCH_SIZE) {
                 flushGff3Buffer()
-                System.gc() // Make the jvm tidy up to prevent running out of memory
+                System.gc() // Make the jvm tidies up to prevent running out of memory
             }
         }
     }
@@ -108,7 +108,8 @@ process WRITE_GFF3 {
     db.close()
 }
 
-def processNucleotidesBulkGFF3(SeqDBQuery db, Map proteins, Writer gff3Writer, Writer fastaWriter) {
+def processNucleotidesBulkGFF3(SeqDBQuery db, Map proteins, Writer gff3Writer, Writer fastaWriter,
+    int batchSize, Closure flushGff3Buffer, Closure flushFastaBuffer) {
     Pattern esl_pattern = Pattern.compile(/^source=[^"]+\s+coords=(\d+)\.\.(\d+)\s+length=\d+\s+frame=(\d+)\s+desc=.*$/)
     Set<String> seenNucleicMd5s = new HashSet<>()
 
@@ -140,7 +141,8 @@ def processNucleotidesBulkGFF3(SeqDBQuery db, Map proteins, Writer gff3Writer, W
             String seqId = seq.id
             String sequence = seq.sequence.trim()
             int seqLength = sequence.length()
-            gff3Writer.writeLine("##sequence-region ${seqId} 1 ${seqLength}")
+
+            gff3LineBuffer << "##sequence-region ${seqId} 1 ${seqLength}"
 
             proteinMd5sForNucleic.each { String proteinMd5 ->
                 def proteinMatches = proteins[proteinMd5]
@@ -162,21 +164,35 @@ def processNucleotidesBulkGFF3(SeqDBQuery db, Map proteins, Writer gff3Writer, W
                         line = "${seqId}\tesl-translate\tCDS\t${end}\t${start}\t.\t${strand}\t0\tID=${parentId}"
                     }
 
-                    gff3Writer.writeLine(line)
+                    gff3LineBuffer << line
 
                     proteinMatches.each { modelAcc, matchMap ->
                         def match = Match.fromMap(matchMap)
                         match.locations.each { Location loc ->
-                            gff3Writer.writeLine(proteinFormatLine(seqId, match, loc, parentId, strand == "+" ? start : end, strand))
+                            String matchLine = proteinFormatLine(seqId, match, loc, parentId, strand == "+" ? start : end, strand)
+                            gff3LineBuffer << matchLine
+
+                            if (gff3LineBuffer.size() >= batchSize) {
+                                flushGff3Buffer()
+                                System.gc() // Make the jvm tidies up to prevent running out of memory
+                            }
                         }
                     }
                 }
             }
 
-            fastaWriter.writeLine(">${seqId}")
-            fastaWriter.writeLine("${sequence.replaceAll(/(.{60})/, '$1\n')}")  
+            fastaLineBuffer << ">${seqId}"
+            fastaLineBuffer << "${sequence.replaceAll(/(.{60})/, '$1\n')}"
+
+            if (fastaLineBuffer.size() >= batchSize) {
+                flushFastaBuffer()
+                System.gc() // Make the jvm tidies up to prevent running out of memory
+            } 
         }
     }
+
+    flushGff3Buffer()
+    flushFastaBuffer()
 }
 
 def proteinFormatLine(seqId, match, loc, parentId, cdsStart, strand) {

--- a/modules/output/gff3/main.nf
+++ b/modules/output/gff3/main.nf
@@ -14,66 +14,104 @@ process WRITE_GFF3 {
     val interproscan_version
 
     exec:
+    def db = new SeqDBQuery(seq_db_file.toString())
+    def gff3File = new File(output_file.toString())
+    gff3File.text = "" // Clear file if it exists
+
+    def tempFastaFile = new File("temp.fasta")
+    tempFastaFile.text = ""
+
+    def BATCH_SIZE = 5000
+    def gff3LineBuffer = []
+    def fastaLineBuffer = []
+
+    def flushGff3Buffer = {
+        if (gff3LineBuffer.size() > 0) {
+            gff3File.append(gff3LineBuffer.join("\n") + "\n")
+            gff3LineBuffer.clear()
+        }
+    }
+    
+    def flushFastaBuffer = {
+        if (fastaLineBuffer.size() > 0) {
+            tempFastaFile.append(fastaLineBuffer.join("\n") + "\n")
+            fastaLineBuffer.clear()
+        }
+    }
+
+    gff3File.append("##gff-version 3.1.26\n")
+    gff3File.append("##interproscan-version ${interproscan_version}\n")
+
+    matches_files.each { matchFile ->
+        Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
+
+        if (nucleic) {
+            processNucleotides(db, proteins, gff3LineBuffer, fastaLineBuffer, BATCH_SIZE, flushGff3Buffer, flushFastaBuffer)
+        } else {
+            def proteinMd5List = proteins.keySet().toList()
+            Map<String, List> seqData = db.proteinMd5sToProteinSeqs(proteinMd5List)
+
+            for (Map.Entry entry : proteins.entrySet()) {
+                String proteinMd5 = entry.key
+                Map matchesMap = entry.value
+                Map proteinSeqData = seqData[proteinMd5]
+
+                String sequence = proteinSeqData[0].sequence.trim()
+                int seqLength = sequence.length()
+
+                proteinSeqData.each { row ->
+                    gff3LineBuffer << "##sequence-region ${row.id} 1 ${seqLength}"
+
+                    matchesMap.each { String modelAcc, Map match ->
+                        Match match = Match.fromMap(matchMap)
+                        for (Location loc : match.locations) {
+                            String line = proteinFormatLine(row.id, match, loc, null, null, null)
+                            gff3LineBuffer << line
+                        }
+                    }
+
+                    if (gff3LineBuffer.size() >= BATCH_SIZE) {
+                        flushGff3Buffer()
+                        System.gc() // Make the jvm tidy up to prevent running out of memory
+                    }
+
+                    fastaLineBuffer << ">${row.id}"
+                    fastaLineBuffer << "${sequence.replaceAll(/(.{60})/, '$1\n')}"
+
+                    if (fastaLineBuffer.size() >= BATCH_SIZE) {
+                        flushFastaBuffer()
+                        System.gc() // Make the jvm tidy up to prevent running out of memory
+                    }
+                }         
+            }
+        }
+    }
+
+    flushGff3Buffer()
+    flushFastaBuffer()
+
+    gff3File.append("##FASTA\n")
+    tempFastaFile.withReader { fastaReader ->
+        fastaReader.eachLine { line ->
+            gff3LineBuffer << "${line}\n"
+
+            if (gff3LineBuffer.size() >= BATCH_SIZE) {
+                flushGff3Buffer()
+                System.gc() // Make the jvm tidy up to prevent running out of memory
+            }
+        }
+    }
+
+    flushGff3Buffer()
+
+    tempFastaFile.delete()
+    db.close()
+}
+
+def processNucleotidesBulkGFF3(SeqDBQuery db, Map proteins, Writer gff3Writer, Writer fastaWriter) {
     Pattern esl_pattern = Pattern.compile(/^source=[^"]+\s+coords=(\d+)\.\.(\d+)\s+length=\d+\s+frame=(\d+)\s+desc=.*$/)
     Set<String> seenNucleicMd5s = new HashSet<>()
 
-    def db = new SeqDBQuery(seq_db_file.toString())
-    def gff3File = new File(output_file.toString())
-
-    gff3File.withWriter { gff3Writer ->
-        gff3Writer.writeLine("##gff-version 3.1.26")
-        gff3Writer.writeLine("##interproscan-version ${interproscan_version}")
-
-        def tempFastaFile = new File("temp.fasta")
-        tempFastaFile.withWriter { fastaWriter ->
-            fastaWriter.writeLine("##FASTA")
-
-            matches_files.each { matchFile ->
-                matchFile = new File(matchFile.toString())
-                Map proteins = new ObjectMapper().readValue(matchFile, Map)
-
-                if (nucleic) {
-                    processNucleotides(db, proteins, seenNucleicMd5s, gff3Writer, fastaWriter, esl_pattern)
-                } else {
-                    def proteinMd5List = proteins.keySet().toList()
-                    Map<String, List> seqData = db.proteinMd5sToProteinSeqs(proteinMd5List)
-
-                    for (Map.Entry entry : proteins.entrySet()) {
-                        String proteinMd5 = entry.key
-                        Map matchesMap = entry.value
-                        Map proteinSeqData = seqData[proteinMd5]
-    
-                        String sequence = proteinSeqData[0].sequence.trim()
-                        int seqLength = sequence.length()
-
-                        proteinSeqData.each { row ->
-                            gff3Writer.writeLine("##sequence-region ${row.id} 1 ${seqLength}")
-
-                            matchesMap.each { String modelAcc, Map match ->
-                                for (Location loc : match.locations) {
-                                    gff3Writer.writeLine(proteinFormatLine(row.id, match, loc, null, null, null))
-                                }
-                            }
-
-                            fastaWriter.writeLine(">${row.id}")
-                            fastaWriter.writeLine("${sequence.replaceAll(/(.{60})/, '$1\n')}")   
-                        }         
-                    }
-                }
-            }
-        }
-
-        tempFastaFile.withReader { fastaReader ->
-            fastaReader.eachLine { line ->
-                gff3Writer.writeLine(line)
-            }
-        }
-        tempFastaFile.delete()
-    }
-}
-
-def processNucleotidesBulkGFF3(SeqDBQuery db, Map proteins, Set seenNucleicMd5s, 
-                               Writer gff3Writer, Writer fastaWriter, Pattern esl_pattern) {
     Set<String> allProteinMd5s = proteins.keySet().toSet()
     Map<String, Set<String>> nucleicToProteinMd5 = db.groupProteinsBulk(allProteinMd5s)
     

--- a/modules/output/gff3/main.nf
+++ b/modules/output/gff3/main.nf
@@ -14,7 +14,10 @@ process WRITE_GFF3 {
     val interproscan_version
 
     exec:
-    SeqDB db = new SeqDB(seq_db_file.toString())
+    Pattern esl_pattern = Pattern.compile(/^source=[^"]+\s+coords=(\d+)\.\.(\d+)\s+length=\d+\s+frame=(\d+)\s+desc=.*$/)
+    Set<String> seenNucleicMd5s = new HashSet<>()
+
+    def db = new SeqDBQuery(seq_db_file.toString())
     def gff3File = new File(output_file.toString())
 
     gff3File.withWriter { gff3Writer ->
@@ -24,10 +27,6 @@ process WRITE_GFF3 {
         def tempFastaFile = new File("temp.fasta")
         tempFastaFile.withWriter { fastaWriter ->
             fastaWriter.writeLine("##FASTA")
-
-            Set<String> seenNucleicMd5s = new HashSet<>()
-
-            Pattern esl_pattern = Pattern.compile(/^source=[^"]+\s+coords=(\d+)\.\.(\d+)\s+length=\d+\s+frame=(\d+)\s+desc=.*$/)
 
             matches_files.each { matchFile ->
                 matchFile = new File(matchFile.toString())
@@ -83,18 +82,22 @@ process WRITE_GFF3 {
                         }
                     }
                 } else {
-                    proteins.each { String proteinMd5, Map matchesMap ->
-                        seqData = db.proteinMd5ToProteinSeq(proteinMd5)
-                        String sequence = seqData[0].sequence.trim()
+                    def proteinMd5List = proteins.keySet().toList()
+                    Map<String, List> seqData = db.proteinMd5sToProteinSeqs(proteinMd5List)
+
+                    for (Map.Entry entry : proteins.entrySet()) {
+                        String proteinMd5 = entry.key
+                        Map matchesMap = entry.value
+                        Map proteinSeqData = seqData[proteinMd5]
+    
+                        String sequence = proteinSeqData[0].sequence.trim()
                         int seqLength = sequence.length()
 
-                        seqData.each { row ->
+                        proteinSeqData.each { row ->
                             gff3Writer.writeLine("##sequence-region ${row.id} 1 ${seqLength}")
 
-                            matchesMap.each { modelAcc, match ->
-                                match = Match.fromMap(match)
-                                
-                                match.locations.each { Location loc ->
+                            matchesMap.each { String modelAcc, Map match ->
+                                for (Location loc : match.locations) {
                                     gff3Writer.writeLine(proteinFormatLine(row.id, match, loc, null, null, null))
                                 }
                             }
@@ -128,9 +131,17 @@ def proteinFormatLine(seqId, match, loc, parentId, cdsStart, strand) {
         goTerms += match.signature.entry.goXRefs
     }
 
-    def uniqueTerms = [:]
-    goTerms.each { term -> uniqueTerms[term.id] = term }
-    goTerms = uniqueTerms.values() as List
+    def uniqueTermIds = new HashSet<String>()
+    def goTermBuilder = new StringBuilder()
+    boolean firstGo = true
+    for (term in goTerms) {
+        if (uniqueTermIds.add(term.id)) { // HashSet.add() returns false if already exists
+            if (!firstGo) goTermBuilder.append(',')
+            goTermBuilder.append(term.id)
+            firstGo = false
+        }
+    }
+    String goTermString = goTermBuilder.length() > 0 ? goTermBuilder.toString() : ""
 
     def feature_type = null
     switch (memberDb) {
@@ -196,20 +207,20 @@ def proteinFormatLine(seqId, match, loc, parentId, cdsStart, strand) {
         "Alias=${match.signature.accession}",
         parentId ? "Parent=${parentId}" : null,
         interproAccession ? "Dbxref=InterPro:${interproAccession}" : null,
-        goTerms ? "Ontology_term=${goTerms.collect{ it.id }.join(',')}" : null,
+        goTermString ? "Ontology_term=${goTermString}" : null,
         "type=${match.signature.type}",
         "representative=${loc.representative}",
     ].findAll { it }
 
-    return [
-        seqId,
-        memberDb,
-        feature_type,
-        cdsStart ? (loc.start - 1) * 3 + cdsStart : loc.start,
-        cdsStart ? loc.end * 3 + cdsStart -1 : loc.end,
-        score ?: ".",
-        strand ?: ".",
-        parentId ? "0" : ".",
-        attributes.join(";")
-    ].join("\t")
+    StringBuilder sb = new StirngBuilder(256)
+    sb.append(seqId).append("\t")
+      .append(memberDb).append("\t")
+      .append(feature_type).append("\t")
+      .append(cdsStart ? (loc.start - 1) * 3 + cdsStart : loc.start).append("\t")
+      .append(cdsStart ? loc.end * 3 + cdsStart -1 : loc.end).append("\t")
+      .append(score ?: ".").append("\t")
+      .append(strand ?: ".").append("\t")
+      .append(parentId ? "0" : ".").append("\t")
+      .append(attributes.join(";"))
+    return sb.toString()
 }

--- a/modules/output/gff3/main.nf
+++ b/modules/output/gff3/main.nf
@@ -91,18 +91,10 @@ process WRITE_GFF3 {
     flushFastaBuffer()
 
     gff3File.append("##FASTA\n")
-    tempFastaFile.withReader { fastaReader ->
-        fastaReader.eachLine { line ->
-            gff3LineBuffer << "${line}\n"
 
-            if (gff3LineBuffer.size() >= BATCH_SIZE) {
-                flushGff3Buffer()
-                System.gc() // Make the jvm tidies up to prevent running out of memory
-            }
-        }
-    }
-
-    flushGff3Buffer()
+    def command = "cat ${tempFastaFile} >> ${output_file}"
+    def process = ["bash", "-c", command].execute()
+    process.waitFor()
 
     tempFastaFile.delete()
     db.close()

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -25,112 +25,58 @@ process WRITE_XML {
     val db_releases
 
     exec:
-    def db = new SeqDBQuery(seq_db_file.toString())
-
-    MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean()
-    
-    // Use BufferedWriter with custom buffer size
     def bufferedWriter = new BufferedWriter(new FileWriter(output_file), 1024 * 1024) // 1MB buffer
-    
-    def timingFile = new File("${output_file}_timing.log")
-    timingFile.text = "timestamp,operation,duration_ms,heap_used_mb,heap_max_mb,non_heap_used_mb,details\n"
+    def db = new SeqDBQuery(seq_db_file.toString())
+    Set<String> seenNucleicMd5s = new HashSet<>()
 
     try {
         def factory = XMLOutputFactory.newInstance()
         def writer = factory.createXMLStreamWriter(bufferedWriter)
-        
-        def initialMemory = getMemoryInfo(memoryBean)
-        def startTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-        timingFile.append("${startTimestamp},xml_start,0,${initialMemory.heapUsed},${initialMemory.heapMax},${initialMemory.nonHeapUsed},\"XML generation starting\"\n")
         
         writer.writeStartDocument("UTF-8", "1.0")
         writer.writeStartElement("results")
         writer.writeAttribute("interproscan-version", interproscan_version)
         writer.writeAttribute("interpro-version", db_releases?.interpro?.version ?: "")
 
-        Set<String> seenNucleicMd5s = new HashSet<>()
+        // Flush every 5000 proteins
         def proteinCount = 0
-        def BUFFER_SIZE = 5000  // Flush every 5000 proteins
+        def BUFFER_SIZE = 5000  
 
         matches_files.each { matchFile ->
-            def jsonLoadStartTime = System.currentTimeMillis()
             Map proteins = new ObjectMapper().readValue(new File(matchFile.toString()), Map)
-            def jsonLoadEndTime = System.currentTimeMillis()
-            def jsonLoadDuration = jsonLoadEndTime - jsonLoadStartTime
 
-            def memoryAfterJson = getMemoryInfo(memoryBean)
-            def timestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-            def fileSize = new File(matchFile.toString()).length()
-            timingFile.append("${timestamp},json_load,${jsonLoadDuration},${memoryAfterJson.heapUsed},${memoryAfterJson.heapMax},${memoryAfterJson.nonHeapUsed},\"${new File(matchFile.toString()).name} (${fileSize} bytes, ${proteins.size()} proteins)\"\n")
-            
             if (nucleic) {
-                proteinCount = processNucleotidesBulkBuffered(db, proteins, seenNucleicMd5s, writer, bufferedWriter, BUFFER_SIZE, proteinCount, timingFile, memoryBean)
+                processNucleotides(db, proteins, seenNucleicMd5s, writer, bufferedWriter, BUFFER_SIZE, proteinCount)
             } else {
-                def proteinQueryStartTime = System.currentTimeMillis()
                 def proteinMd5List = proteins.keySet().toList()
                 Map<String, List> seqData = db.proteinMd5sToProteinSeqs(proteinMd5List)
-                def proteinQueryEndTime = System.currentTimeMillis()
-                def proteinQueryDuration = proteinQueryEndTime - proteinQueryStartTime
-                
-                def memoryAfterQuery = getMemoryInfo(memoryBean)
-                def proteinQueryTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-                timingFile.append("${proteinQueryTimestamp},db_query,${proteinQueryDuration},${memoryAfterQuery.heapUsed},${memoryAfterQuery.heapMax},${memoryAfterQuery.nonHeapUsed},\"${proteinMd5List.size()} proteins from ${new File(matchFile.toString()).name}\"\n")
-                
-                def proteinProcessingStartTime = System.currentTimeMillis()
-                
+
                 for (entry in proteins) {
                     String proteinMd5 = entry.key
                     Map proteinMatches = entry.value
                     List proteinSeqData = seqData[proteinMd5]
-                    
-                    def individualProteinStartTime = System.currentTimeMillis()
+        
                     addProteinNodesDirect(proteinMd5, proteinMatches, proteinSeqData, writer)
-                    def individualProteinEndTime = System.currentTimeMillis()
-                    def individualProteinDuration = individualProteinEndTime - individualProteinStartTime
-                    
                     proteinCount++
                     
                     if (proteinCount % BUFFER_SIZE == 0) {
-                        def flushStartTime = System.currentTimeMillis()
                         writer.flush()
                         bufferedWriter.flush()
-                        def flushEndTime = System.currentTimeMillis()
-                        def flushDuration = flushEndTime - flushStartTime
-                        
-                        def memoryAfterFlush = getMemoryInfo(memoryBean)
-                        def flushTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-                        timingFile.append("${flushTimestamp},buffer_flush,${flushDuration},${memoryAfterFlush.heapUsed},${memoryAfterFlush.heapMax},${memoryAfterFlush.nonHeapUsed},\"Flushed after ${proteinCount} proteins\"\n")
-                        println "Flushed buffer after processing ${proteinCount} proteins... (Heap: ${memoryAfterFlush.heapUsed}MB)"
-                    }
-                    
-                    if (proteinCount % 100 == 0) {
-                        def memoryDuringProcessing = getMemoryInfo(memoryBean)
-                        def proteinTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-                        def matchCount = proteinMatches.size()
-                        timingFile.append("${proteinTimestamp},protein_processing,${individualProteinDuration},${memoryDuringProcessing.heapUsed},${memoryDuringProcessing.heapMax},${memoryDuringProcessing.nonHeapUsed},\"${proteinMd5} with ${matchCount} matches (batch of 100)\"\n")
+                        System.gc() // Need the JVM to tidy up the rubbish otherwise we run out of memory
                     }
                 }
-                
-                def proteinLoopEndTime = System.currentTimeMillis()
-                def proteinLoopDuration = proteinLoopEndTime - proteinProcessingStartTime
-                
-                def memoryAfterLoop = getMemoryInfo(memoryBean)
-                def proteinLoopTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-                timingFile.append("${proteinLoopTimestamp},proteins_loop_total,${proteinLoopDuration},${memoryAfterLoop.heapUsed},${memoryAfterLoop.heapMax},${memoryAfterLoop.nonHeapUsed},\"${proteins.size()} proteins from ${new File(matchFile.toString()).name}\"\n")
+
+                writer.flush()
+                bufferedWriter.flush()
             }
         }
 
         writer.writeEndElement() // results
         writer.writeEndDocument()
-        
-        // Final flush
+
         writer.flush()
         bufferedWriter.flush()
         writer.close()
-
-        def finalMemory = getMemoryInfo(memoryBean)
-        def endTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-        timingFile.append("${endTimestamp},xml_complete,0,${finalMemory.heapUsed},${finalMemory.heapMax},${finalMemory.nonHeapUsed},\"XML generation complete\"\n")
 
     } finally {
         bufferedWriter.close()
@@ -138,20 +84,8 @@ process WRITE_XML {
     }
 }
 
-def getMemoryInfo(MemoryMXBean memoryBean) {
-    def heapMemory = memoryBean.getHeapMemoryUsage()
-    def nonHeapMemory = memoryBean.getNonHeapMemoryUsage()
-    
-    return [
-        heapUsed: Math.round(heapMemory.getUsed() / (1024 * 1024)),      // MB
-        heapMax: Math.round(heapMemory.getMax() / (1024 * 1024)),        // MB
-        nonHeapUsed: Math.round(nonHeapMemory.getUsed() / (1024 * 1024)) // MB
-    ]
-}
-
-// Updated nucleotide processing with memory tracking
-def processNucleotidesBulkBuffered(SeqDBQuery db, Map proteins, Set seenNucleicMd5s, XMLStreamWriter writer, 
-                                   BufferedWriter bufferedWriter, int bufferSize, int currentCount, File timingFile, MemoryMXBean memoryBean) {
+def processNucleotides(SeqDBQuery db, Map proteins, Set seenNucleicMd5s, XMLStreamWriter writer, 
+                                   BufferedWriter bufferedWriter, int bufferSize, int currentCount) {
     Set<String> allProteinMd5s = proteins.keySet().toSet()
     Map<String, Set<String>> nucleicToProteinMd5 = db.groupProteinsBulk(allProteinMd5s)
     
@@ -181,21 +115,14 @@ def processNucleotidesBulkBuffered(SeqDBQuery db, Map proteins, Set seenNucleicM
         processedCount++
         
         if (processedCount % bufferSize == 0) {
-            def flushStartTime = System.currentTimeMillis()
             writer.flush()
             bufferedWriter.flush()
-            def flushEndTime = System.currentTimeMillis()
-            def flushDuration = flushEndTime - flushStartTime
-            
-            // Get memory info for nucleotide flush
-            def memoryAfterFlush = getMemoryInfo(memoryBean)
-            def flushTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-            timingFile.append("${flushTimestamp},buffer_flush,${flushDuration},${memoryAfterFlush.heapUsed},${memoryAfterFlush.heapMax},${memoryAfterFlush.nonHeapUsed},\"Flushed after ${processedCount} nucleotides\"\n")
-            println "Flushed buffer after processing ${processedCount} nucleotides... (Heap: ${memoryAfterFlush.heapUsed}MB)"
+            System.gc() // Need the JVM to tidy up the rubbish otherwise we run out of memory
         }
     }
-    
-    return processedCount
+
+    writer.flush()
+    bufferedWriter.flush()
 }
 
 def addNucleotideNodesDirect(String nucleicMd5, Set<String> proteinMd5s, Map proteinMatches, List ntSeqData, 

--- a/modules/output/xml/main.nf
+++ b/modules/output/xml/main.nf
@@ -4,6 +4,8 @@ import java.util.regex.Pattern
 import javax.xml.stream.XMLOutputFactory
 import javax.xml.stream.XMLStreamWriter
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.lang.management.ManagementFactory
+import java.lang.management.MemoryMXBean
 
 import java.time.format.DateTimeFormatter
 import java.time.LocalDate
@@ -25,15 +27,21 @@ process WRITE_XML {
     exec:
     def db = new SeqDBQuery(seq_db_file.toString())
 
+    MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean()
+    
     // Use BufferedWriter with custom buffer size
     def bufferedWriter = new BufferedWriter(new FileWriter(output_file), 1024 * 1024) // 1MB buffer
     
     def timingFile = new File("${output_file}_timing.log")
-    timingFile.text = "timestamp,operation,duration_ms,details\n"
+    timingFile.text = "timestamp,operation,duration_ms,heap_used_mb,heap_max_mb,non_heap_used_mb,details\n"
 
     try {
         def factory = XMLOutputFactory.newInstance()
         def writer = factory.createXMLStreamWriter(bufferedWriter)
+        
+        def initialMemory = getMemoryInfo(memoryBean)
+        def startTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
+        timingFile.append("${startTimestamp},xml_start,0,${initialMemory.heapUsed},${initialMemory.heapMax},${initialMemory.nonHeapUsed},\"XML generation starting\"\n")
         
         writer.writeStartDocument("UTF-8", "1.0")
         writer.writeStartElement("results")
@@ -50,12 +58,13 @@ process WRITE_XML {
             def jsonLoadEndTime = System.currentTimeMillis()
             def jsonLoadDuration = jsonLoadEndTime - jsonLoadStartTime
 
+            def memoryAfterJson = getMemoryInfo(memoryBean)
             def timestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
             def fileSize = new File(matchFile.toString()).length()
-            timingFile.append("${timestamp},json_load,${jsonLoadDuration},\"${new File(matchFile.toString()).name} (${fileSize} bytes, ${proteins.size()} proteins)\"\n")
+            timingFile.append("${timestamp},json_load,${jsonLoadDuration},${memoryAfterJson.heapUsed},${memoryAfterJson.heapMax},${memoryAfterJson.nonHeapUsed},\"${new File(matchFile.toString()).name} (${fileSize} bytes, ${proteins.size()} proteins)\"\n")
             
             if (nucleic) {
-                proteinCount = processNucleotidesBulkBuffered(db, proteins, seenNucleicMd5s, writer, bufferedWriter, BUFFER_SIZE, proteinCount, timingFile)
+                proteinCount = processNucleotidesBulkBuffered(db, proteins, seenNucleicMd5s, writer, bufferedWriter, BUFFER_SIZE, proteinCount, timingFile, memoryBean)
             } else {
                 def proteinQueryStartTime = System.currentTimeMillis()
                 def proteinMd5List = proteins.keySet().toList()
@@ -63,8 +72,9 @@ process WRITE_XML {
                 def proteinQueryEndTime = System.currentTimeMillis()
                 def proteinQueryDuration = proteinQueryEndTime - proteinQueryStartTime
                 
+                def memoryAfterQuery = getMemoryInfo(memoryBean)
                 def proteinQueryTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-                timingFile.append("${proteinQueryTimestamp},db_query,${proteinQueryDuration},\"${proteinMd5List.size()} proteins from ${new File(matchFile.toString()).name}\"\n")
+                timingFile.append("${proteinQueryTimestamp},db_query,${proteinQueryDuration},${memoryAfterQuery.heapUsed},${memoryAfterQuery.heapMax},${memoryAfterQuery.nonHeapUsed},\"${proteinMd5List.size()} proteins from ${new File(matchFile.toString()).name}\"\n")
                 
                 def proteinProcessingStartTime = System.currentTimeMillis()
                 
@@ -87,21 +97,26 @@ process WRITE_XML {
                         def flushEndTime = System.currentTimeMillis()
                         def flushDuration = flushEndTime - flushStartTime
                         
+                        def memoryAfterFlush = getMemoryInfo(memoryBean)
                         def flushTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-                        timingFile.append("${flushTimestamp},buffer_flush,${flushDuration},\"Flushed after ${proteinCount} proteins\"\n")
-                        println "Flushed buffer after processing ${proteinCount} proteins..."
+                        timingFile.append("${flushTimestamp},buffer_flush,${flushDuration},${memoryAfterFlush.heapUsed},${memoryAfterFlush.heapMax},${memoryAfterFlush.nonHeapUsed},\"Flushed after ${proteinCount} proteins\"\n")
+                        println "Flushed buffer after processing ${proteinCount} proteins... (Heap: ${memoryAfterFlush.heapUsed}MB)"
                     }
                     
-                    def proteinTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-                    def matchCount = proteinMatches.size()
-                    timingFile.append("${proteinTimestamp},protein_processing,${individualProteinDuration},\"${proteinMd5} with ${matchCount} matches\"\n")
+                    if (proteinCount % 100 == 0) {
+                        def memoryDuringProcessing = getMemoryInfo(memoryBean)
+                        def proteinTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
+                        def matchCount = proteinMatches.size()
+                        timingFile.append("${proteinTimestamp},protein_processing,${individualProteinDuration},${memoryDuringProcessing.heapUsed},${memoryDuringProcessing.heapMax},${memoryDuringProcessing.nonHeapUsed},\"${proteinMd5} with ${matchCount} matches (batch of 100)\"\n")
+                    }
                 }
                 
                 def proteinLoopEndTime = System.currentTimeMillis()
                 def proteinLoopDuration = proteinLoopEndTime - proteinProcessingStartTime
                 
+                def memoryAfterLoop = getMemoryInfo(memoryBean)
                 def proteinLoopTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-                timingFile.append("${proteinLoopTimestamp},proteins_loop_total,${proteinLoopDuration},\"${proteins.size()} proteins from ${new File(matchFile.toString()).name}\"\n")
+                timingFile.append("${proteinLoopTimestamp},proteins_loop_total,${proteinLoopDuration},${memoryAfterLoop.heapUsed},${memoryAfterLoop.heapMax},${memoryAfterLoop.nonHeapUsed},\"${proteins.size()} proteins from ${new File(matchFile.toString()).name}\"\n")
             }
         }
 
@@ -113,14 +128,30 @@ process WRITE_XML {
         bufferedWriter.flush()
         writer.close()
 
+        def finalMemory = getMemoryInfo(memoryBean)
+        def endTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
+        timingFile.append("${endTimestamp},xml_complete,0,${finalMemory.heapUsed},${finalMemory.heapMax},${finalMemory.nonHeapUsed},\"XML generation complete\"\n")
+
     } finally {
         bufferedWriter.close()
         db.close()
     }
 }
 
+def getMemoryInfo(MemoryMXBean memoryBean) {
+    def heapMemory = memoryBean.getHeapMemoryUsage()
+    def nonHeapMemory = memoryBean.getNonHeapMemoryUsage()
+    
+    return [
+        heapUsed: Math.round(heapMemory.getUsed() / (1024 * 1024)),      // MB
+        heapMax: Math.round(heapMemory.getMax() / (1024 * 1024)),        // MB
+        nonHeapUsed: Math.round(nonHeapMemory.getUsed() / (1024 * 1024)) // MB
+    ]
+}
+
+// Updated nucleotide processing with memory tracking
 def processNucleotidesBulkBuffered(SeqDBQuery db, Map proteins, Set seenNucleicMd5s, XMLStreamWriter writer, 
-                                   BufferedWriter bufferedWriter, int bufferSize, int currentCount, File timingFile) {
+                                   BufferedWriter bufferedWriter, int bufferSize, int currentCount, File timingFile, MemoryMXBean memoryBean) {
     Set<String> allProteinMd5s = proteins.keySet().toSet()
     Map<String, Set<String>> nucleicToProteinMd5 = db.groupProteinsBulk(allProteinMd5s)
     
@@ -156,9 +187,11 @@ def processNucleotidesBulkBuffered(SeqDBQuery db, Map proteins, Set seenNucleicM
             def flushEndTime = System.currentTimeMillis()
             def flushDuration = flushEndTime - flushStartTime
             
+            // Get memory info for nucleotide flush
+            def memoryAfterFlush = getMemoryInfo(memoryBean)
             def flushTimestamp = new Date().format("yyyy-MM-dd HH:mm:ss.SSS")
-            timingFile.append("${flushTimestamp},buffer_flush,${flushDuration},\"Flushed after ${processedCount} nucleotides\"\n")
-            println "Flushed buffer after processing ${processedCount} nucleotides..."
+            timingFile.append("${flushTimestamp},buffer_flush,${flushDuration},${memoryAfterFlush.heapUsed},${memoryAfterFlush.heapMax},${memoryAfterFlush.nonHeapUsed},\"Flushed after ${processedCount} nucleotides\"\n")
+            println "Flushed buffer after processing ${processedCount} nucleotides... (Heap: ${memoryAfterFlush.heapUsed}MB)"
         }
     }
     


### PR DESCRIPTION
> [!WARNING]
> Review after the [XML writer performance PR](https://github.com/ebi-pf-team/interproscan6/pull/250) as this PR builds of code from that branch.
>
> Once the XML writer branch is merged, I'll change the base branch for this PR.

Optimisations to the GFF3 writer, which now takes ~35 minutes to write out all the output when using the SwissProt dataset and all analyses (except TMbed)

```
$ nextflow run main.nf 
Nextflow 25.04.7 is available - Please consider updating your version to it

 N E X T F L O W   ~  version 25.04.6

Launching `main.nf` [focused_sammet] DSL2 - revision: 00002ec1db

# InterProScan6 6.0.0-beta
# Genome-scale protein function classification

executor >  local (1)
[f9/41b21e] process > OUTPUT:WRITE_GFF3 (1) [100%] 1 of 1 ✔

InterProScan completed successfully
Results available at: /hps/scratch/agb/interpro/ehobbs/i6-writing-out-investigation/results/gff3.final.test.*
Completed at: 10-Sep-2025 11:31:24
Duration    : 34m 47s
CPU hours   : 0.6
Succeeded   : 1
```