### PR TITLE
PIRSR ignoring low confidence locations

### DIFF
--- a/modules/pirsr/main.nf
+++ b/modules/pirsr/main.nf
@@ -34,6 +34,9 @@ process PARSE_PIRSR {
             }
             List<Location> selectedLocations = []
             sortedLocations.each { location ->
+                if (!location.included) {
+                    return
+                }
                 if (!location.targetAlignment || !location.queryAlignment) {
                     return
                 }


### PR DESCRIPTION
Adapting i6 to changes made on [this i5 PR](https://github.com/ebi-pf-team/interproscan/tree/pirsr_fix).

We're already not considering matches without sites. The only necessary change was remove the matches with low confidence.