### PR TITLE
PANTHER-specific field from Matches API

### DIFF
--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -102,7 +102,7 @@ def Map transformMatch(Map match, String seq) {
     // * operator - spread contents of a map or collecion into another map or collection
     return [
         *            : match,
-        "treegrafter": ["ancestralNodeID": match["annotationNode"]],
+        "treegrafter": ["ancestralNodeID": match["ancestralNode"]],
         "locations"  : match["locations"].collect { loc ->
             return [
                 *          : loc,


### PR DESCRIPTION
Starting with InterPro 107.0, the Matches API no longer returns the `annotationNode` field for PANTHER matches. This field has been renamed to `ancestralNode` to be consistent with the InterProScan JSON output.

You can test using the test Matches API (https://wwwdev.ebi.ac.uk/interpro/matches/api/), which serves the InterPro 107.0 data.