### PR TITLE
Mark Phobius as licensed

### DIFF
--- a/lib/InterProScan.groovy
+++ b/lib/InterProScan.groovy
@@ -263,7 +263,6 @@ class InterProScan {
         return dirs ? dirs.last().fileName.toString() : null
     }
 
-    // BOOKMARK
     static List<String>validateApplications(String applications, String skipApplications, Map appsConfig, Boolean runML) {
         // Returns a list of (1) list of applications to run or null, (2) an error message if invalid input or null, and(3) a warning or null
         if (applications && skipApplications) {
@@ -291,7 +290,7 @@ class InterProScan {
                     it.value.containsKey('enabled') && this.LICENSED_SOFTWARE.contains(it.key) && !it.value?.dir 
                 }.keySet().toList()
                 if (invalidApps) {
-                    def warn = "The following machine learning-based analyses are unavailable and will be skipped, even though --run-ml was specified: ${invalidApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
+                    def warn = "The following machine learning-based analyses are unavailable and will be skipped, even though --run-ml was specified: ${invalidApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses for more information."
                     return [appsToRun, null, warn]
                 }
             }
@@ -369,7 +368,7 @@ class InterProScan {
             }
             if (unavailableApps) {
                 if (error) { error += "\n" }
-                error += "The following applications cannot be run: ${unavailableApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
+                error += "The following applications cannot be run: ${unavailableApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses for more information."
             }
 
             if (error) {
@@ -394,7 +393,7 @@ class InterProScan {
             }
 
             if (unavailableApps) {
-                def warn = "The following machine learning-based analyses are unavailable and will be skipped even though --run-ml was specified: ${unavailableApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses."
+                def warn = "The following machine learning-based analyses are unavailable and will be skipped even though --run-ml was specified: ${unavailableApps.join(', ')}. See https://github.com/ebi-pf-team/interproscan6#licensed-analyses for more information."
                 return [appsToRun.toSet().toList(), null, warn]
             }
         }


### PR DESCRIPTION
When the `--skip-applications` flag is used `phobius` is incorrectly included within the final list of selected applications even if it is not activated (i.e. the `dir` property in the `applications.conf` is not populated), for example using the default `conf/applications.conf`:

```bash
$ nextflow run main.nf \
    --input tests/data/sequences/test.faa \
    --outdir results/apps \
    --datadir data/ \
    -profile docker \
    --skip-applications prints
Nextflow 25.04.8 is available - Please consider updating your version to it

 N E X T F L O W   ~  version 25.04.6

Launching `main.nf` [elegant_marconi] DSL2 - revision: 3c71703ef1

# InterProScan6 6.0.0-beta
# Genome-scale protein function classification

Apps specified on the cmd-line: null
Apps specified for skipping: prints
Output of ValidatedApps: [phobius, cdd, coils, pirsr, hamap, ncbifam, 
prositeprofiles, superfamily, smart, prositepatterns, cathfunfam, cathgene3d, 
antifam, pfam, pirsf, mobidblite, panther, sfld]
```
We would expect the final statement at the end to be:
```bash
Output of ValidatedApps:  [cdd, coils, pirsr, hamap, ncbifam, prositeprofiles, 
superfamily, smart, prositepatterns, cathfunfam, cathgene3d, antifam, 
pfam, pirsf, mobidblite, panther, sfld]
```