### PR TITLE
[Bug fix] Add entry point to set paths for singularity

### DIFF
--- a/utilities/docker/interproscan/Dockerfile
+++ b/utilities/docker/interproscan/Dockerfile
@@ -103,8 +103,17 @@ RUN curl -L -o cath-resolve-hits https://github.com/UCLOrengoGroup/cath-tools/re
 
 WORKDIR /opt/interproscan6
 
+# Create entrypoint script to ensure PATH is set correctly for both Docker and Singularity
+RUN echo '#!/bin/bash' > /entrypoint.sh && \
+    echo 'export PATH="/opt/hmmer3/bin:/opt/cath-tools:/opt/blast:/opt/rpsbproc/RpsbProc-x64-linux:/opt/coils:/opt/easel/miniapps:/opt/pftools:/opt/epa-ng/bin:/opt/hmmer2/bin:$PATH"' >> /entrypoint.sh && \
+    echo 'exec "$@"' >> /entrypoint.sh && \
+    chmod +x /entrypoint.sh
+
 # Add all tool directories to PATH
 ENV PATH="/opt/hmmer3/bin:/opt/cath-tools:/opt/blast:/opt/rpsbproc/RpsbProc-x64-linux:/opt/coils:/opt/easel/miniapps:/opt/pftools:/opt/epa-ng/bin:/opt/hmmer2/bin:$PATH"
+
+# Set entrypoint
+ENTRYPOINT ["/entrypoint.sh"]
 
 # remove tools not needed for running IPS6 to reduce the final image size
 RUN apt-get remove -y autoconf automake autotools-dev bison build-essential flex git libcurl3-gnutls libdivsufsort3 liblmdb0 libdw1 libnghttp2-dev libssl-dev libtool nghttp2 zlib1g-dev && \


### PR DESCRIPTION
This PR fixes the bug reported in issue #273 - `error status 127 - command not found` when using Singularity (reproducible locally and on slurm). 

The issue was due to enabling running InterProScan6 on baremetal (PR #245). The paths were set correctly for docker but the executables installed in the container are not being found when using Singularity because the `PATH` environment variable wasn't being properly inherited or set within the Singularity container. That was me, sorry about that, I hadn't realised that when using Singularity the host environment can override container environment variables, and that the `PATH` from the host system often takes precedence.

To fix this I've added an entry point to the InterProScan6 container that sets the executable paths.

A potentially alternative solution that I have not tried is altering the `singularity` profiles `containerOptions`:
```groovy
singularity {
    enabled = true
    pullTimeout = '3 hours' // the default is 20 minutes and fails with large images
    runOptions = '--cleanenv --contain'
    envWhitelist = 'PATH,TMPDIR,TMP'
}
```
However, I think my fix (with adding the entry point to add the executables to `PATH`) should work for multiple container runtimes.

## Testing
Tested locally with a couple of applications and the matches api:
1. Test using docker locally
```bash
nextflow run main.nf -profile test,docker --applications ncbifam,superfamily --datadir data
```
2. Test using singularity locally
```bash
nextflow run main.nf -profile test,singularity --applications ncbifam,superfamily --datadir data
```
And tested using singularity on slurm with all applications and no matches api:
```bash
nextflow run main.nf \
-profile test,singularity,slurm \
--outdir /hps/scratch/agb/interpro/ehobbs/i6-singularity/results \
-work-dir /hps/scratch/agb/interpro/ehobbs/i6-singularity-work \
--datadir /hps/nobackup/agb/interpro/ehobbs/i6-data/ \
--no-matches-api \
-with-report
...
InterProScan completed successfully
Results available at: /hps/scratch/agb/interpro/ehobbs/i6-singularity/results/test.faa.*
Completed at: 27-Oct-2025 09:51:29
Duration    : 24m 26s
CPU hours   : 1.3
Succeeded   : 72
```