### PR TITLE
Refactoring applications selection/validation

### DIFF
--- a/lib/uk/ac/ebi/interpro/InterProScan.groovy
+++ b/lib/uk/ac/ebi/interpro/InterProScan.groovy
@@ -369,7 +369,7 @@ class InterProScan {
         if (runML && !applications) {
             // ML requested; warn if any ML is unavailable
             def unavailableML = mlAppls.findAll { label ->
-                !isAvailable(label) && appsConfig[label].enabled
+                !isAvailable(label)
             }
             if (!unavailableML.isEmpty()) {
                 def warn = "Unavailable ML analyses will be skipped: ${unavailableML.join(', ')}"


### PR DESCRIPTION
While testing the `bulk-proc` branch, I noticed I couldn't use `--run-ml` to include ML-based applications while excluding DeepTMHMM with `--skip-applications`.

I refactored the `InterProScan.validateApplications()` method so:

- `--applications` and `--run-ml` are now mutually exclusive
- `--applications` and `--skip-applications` are still mutually exclusive
- `--skip-applications` and --run-ml` can be combined

If `--applications` isn't used, we create the list of applications to include (adding ML-based apps if `--run-ml` is passed), then we remove any application passed to `--skip-applications`.