### PR TITLE
Fix GFF3 output

### DIFF
--- a/lib/uk/ac/ebi/interpro/ProcessOutputGFF3.groovy
+++ b/lib/uk/ac/ebi/interpro/ProcessOutputGFF3.groovy
@@ -15,7 +15,7 @@ class ProcessOutputGFF3 {
             gff3Writer.writeLine("##gff-version 3.1.26")
             gff3Writer.writeLine("##interproscan-version ${iprscanVersion}")
 
-            def tempFastaFile = new File(outputPath + ".fasta")
+            def tempFastaFile = new File("${outputPath}.fasta")
             tempFastaFile.withWriter { fastaWriter ->
                 fastaWriter.writeLine("##FASTA")
 


### PR DESCRIPTION
Now the tempFastaFile is created based on the output GFF3 path (<outputpath>.fasta), ensuring that each run has its own isolated file to avoid errors when multiple runs execute at same time using the local executor (e.g. when running benchmark tests)