### PR TITLE
Pass correct param to PREPARE_DATABASES

### DIFF
--- a/workflows/interproscan.nf
+++ b/workflows/interproscan.nf
@@ -53,7 +53,7 @@ workflow INTERPROSCAN {
         data_dir,
         interpro_version,
         interproscan_version,
-        matches_api_url,
+        no_matches_api,
         goterms,
         pathways,
         globus


### PR DESCRIPTION
One of the parameters of `PREPARE_DATABASES` is the boolean indicating whether we plan to use the Matches API. Instead, the current parameter passed is the URL of the Matches API which evaluates to true in a boolean context.

Fix #286 