### PR TITLE
Fix InterProScan version in output files

### DIFF
--- a/workflows/interproscan.nf
+++ b/workflows/interproscan.nf
@@ -59,7 +59,7 @@ workflow INTERPROSCAN {
         globus
     )
     db_releases = PREPARE_DATABASES.out.versions
-    interproscan_version = PREPARE_DATABASES.out.iprscan_major_minor
+    iprscan_major_minor = PREPARE_DATABASES.out.iprscan_major_minor
 
     PREPARE_SEQUENCES(
         fasta_file,
@@ -89,7 +89,7 @@ workflow INTERPROSCAN {
             ch_seqs,
             matches_api_apps,
             db_releases,
-            interproscan_version,
+            iprscan_major_minor,
             api_version,
             matches_api_url,
             matches_api_chunk_size,


### PR DESCRIPTION
The output files currently include the MAJOR_MINOR version of InterProScan, not the MAJOR_MINOR_PATCH one. This PR addresses it.