### PR TITLE
Refactor --skip-interpro

### DIFF
--- a/lib/uk/ac/ebi/interpro/InterProScan.groovy
+++ b/lib/uk/ac/ebi/interpro/InterProScan.groovy
@@ -109,9 +109,9 @@ class InterProScan {
             description: null
         ],
         [
-            name: "skip-interpro",
+            name: "skip-repr-locations",
             description: null
-            // Used in production. Skips adding InterPro xrefs and identifying representative locations
+            // Used in production. Skips identifying representative locations
         ],
         [
             name: "apps-config",

--- a/main.nf
+++ b/main.nf
@@ -27,7 +27,7 @@ workflow {
         params.outdir,
         params.outprefix,
         params.interpro,
-        params.skipInterpro,
+        params.skipReprLocations,
         params.skipApplications,
         params.goterms,
         params.pathways,
@@ -58,7 +58,7 @@ workflow {
         params.batchSize,
         params.subBatchSize,
         params.nucleic,
-        params.skipInterpro,
+        params.skipReprLocations,
         params.goterms,
         params.pathways,
         params.globus

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@ params {
     outprefix             = null
     pathways              = false
     skipApplications      = null
-    skipInterpro          = false
+    skipReprLocations     = false
     interpro              = "latest"
     batchSize             = 5000
     subBatchSize          = 500

--- a/subworkflows/combine/main.nf
+++ b/subworkflows/combine/main.nf
@@ -9,49 +9,45 @@ workflow COMBINE {
     add_goterms
     add_pathways
     panther_paint_dir
-    skip_interpro      // boolean used in production
+    skip_repr_locations      // boolean used in production
     batch_size
 
     main:
-    parsed_matches = Channel.empty()
+    ch_xrefs = Channel.empty()
+    ch_combined = Channel.empty()
 
-    if (skip_interpro) {
-        // COMBINE_MATCHES: Aggregate matches across all members for each sequence -> single JSON with all matches for the batch
-        if (batch_size < 50000) {
-            parsed_matches = COMBINE_MATCHES_LOCAL(match_results)
-        } else {
-            parsed_matches = COMBINE_MATCHES(match_results)
-        }
+    if (batch_size < 50000) {
+        COMBINE_MATCHES_LOCAL(match_results)
+
+        ch_xrefs = XREFS_LOCAL(
+            COMBINE_MATCHES_LOCAL.out,
+            db_releases,
+            add_goterms,
+            add_pathways,
+            panther_paint_dir
+        )
     } else {
-        if (batch_size < 50000) {
-            COMBINE_MATCHES_LOCAL(match_results)
+        COMBINE_MATCHES(match_results)
 
-            XREFS_LOCAL(
-                COMBINE_MATCHES_LOCAL.out,
-                db_releases,
-                add_goterms,
-                add_pathways,
-                panther_paint_dir
-            )
+        ch_xrefs = XREFS(
+            COMBINE_MATCHES.out,
+            db_releases,
+            add_goterms,
+            add_pathways,
+            panther_paint_dir
+        )
+    }
 
-            parsed_matches = REPRESENTATIVE_LOCATIONS_LOCAL(XREFS_LOCAL.out)
-        } else {
-            COMBINE_MATCHES(match_results)
-
-            XREFS(
-                COMBINE_MATCHES.out,
-                db_releases,
-                add_goterms,
-                add_pathways,
-                panther_paint_dir
-            )
-
-            parsed_matches = REPRESENTATIVE_LOCATIONS(XREFS.out)
-        }
+    if (skip_repr_locations) {
+        ch_combined = ch_xrefs
+    } else if (batch_size < 50000) {
+        ch_combined = REPRESENTATIVE_LOCATIONS_LOCAL(ch_xrefs)
+    } else {
+        ch_combined = REPRESENTATIVE_LOCATIONS(ch_xrefs)
     }
 
     // Collect all JSON files into a single channel so we don't have cocurrent writing to the output files
-    ch_results = parsed_matches
+    ch_results = ch_combined
         .map { meta, json -> json }
         .collect()
 

--- a/tests/unit_tests/subworkflows/combine/main.nf.test
+++ b/tests/unit_tests/subworkflows/combine/main.nf.test
@@ -4,7 +4,7 @@ nextflow_workflow {
     script "subworkflows/combine/main.nf"
     workflow "COMBINE"
 
-    test("Should skip adding interpro data and run without failures") {
+    test("Should skip finding representative locations and run without failures") {
         when {
             params {
                 match_results = [
@@ -37,7 +37,7 @@ nextflow_workflow {
                 add_goterms = true
                 add_pathways = true
                 panther_paint_dir = "$baseDir/tests/data/databases/interpro/105.0"
-                skip_interpro = true
+                skip_repr_locations = true
                 batch_size = 5000
             }
             workflow {
@@ -47,7 +47,7 @@ nextflow_workflow {
                 input[2] = params.add_goterms
                 input[3] = params.add_pathways
                 input[4] = params.panther_paint_dir
-                input[5] = params.skip_interpro
+                input[5] = params.skip_repr_locations
                 input[6] = params.batch_size
                 """
             }
@@ -57,7 +57,7 @@ nextflow_workflow {
         }
     }
 
-    test("Should add interpro data and run without failures") {
+    test("Should find representative locations and run without failures") {
         when {
             params {
                 match_results = [
@@ -90,7 +90,7 @@ nextflow_workflow {
                 add_goterms = true
                 add_pathways = true
                 panther_paint_dir = "tests/data/databases/interpro/105.0"
-                skip_interpro = false
+                skip_repr_locations = false
                 batch_size = 5000
             }
             workflow {
@@ -100,7 +100,7 @@ nextflow_workflow {
                 input[2] = params.add_goterms
                 input[3] = params.add_pathways
                 input[4] = params.panther_paint_dir
-                input[5] = params.skip_interpro
+                input[5] = params.skip_repr_locations
                 input[6] = params.batch_size
                 """
             }

--- a/workflows/interproscan.nf
+++ b/workflows/interproscan.nf
@@ -28,7 +28,7 @@ workflow INTERPROSCAN {
     batch_size            // int, number of sequences to process per batch
     sub_batch_size        // int, number of sequences per subbatch
     nucleic               // boolean, input is nucleic acid sequences
-    skip_interpro         // boolean, skip adding InterPro (cross-refs and repr domains) annotations
+    skip_repr_locations   // boolean, skip indentifying representative locations
     goterms               // boolean, include GO terms in the output files
     pathways              // boolean, include pathway terms in the output files
     globus                // boolean, use Globus to download databases
@@ -142,7 +142,7 @@ workflow INTERPROSCAN {
         goterms,
         pathways,
         apps_config.panther.paint,
-        skip_interpro,
+        skip_repr_locations,
         batch_size
     )
 


### PR DESCRIPTION
The `--skip-interpro` param allows to skip the `XREFS` and `REPRESENTATIVE_LOCATIONS` processes. However, some PANTHER-specific actions are done in `XREFS`, including the family -> subfamily lookup, which we need in production.

This PR replaces `--skip-interpro` by `--skip-repr-locations`: the `XREFS` process is always called and only `REPRESENTATIVE_LOCATIONS` becomes optional.