### PR TITLE
Remove null tuples for lookup

### DIFF
--- a/subworkflows/lookup/main.nf
+++ b/subworkflows/lookup/main.nf
@@ -34,7 +34,6 @@ workflow LOOKUP {
             tuple(index, fasta, matches_api_apps, api_url, chunk_size, max_retries)
         }
     )
-    
     precalculatedMatches = LOOKUP_MATCHES.out[0]
 
     noMatchesFasta = LOOKUP_MATCHES.out[1]


### PR DESCRIPTION
Relative to [Jira ticket](https://embl.atlassian.net/browse/IBU-12317)

Removing this block (it's not necessary to return a null value to the related `meta` here)  it will avoid null failures ahead. The behaviour now its just to return an empty list when no matches lookup, then the block above will receive it and combine only the results with files returned:
```
combined             = precalculated_matches.concat(allExpandedScans)
match_results      = combined.groupTuple()
```
e.g of a `match_results.view()`:
```
[0, [/Users/lcf/IdeaProjects/interproscan6/work/db/85627e46823ba89726e0e84bb5e746/calculatedMatches.json]]
[3, [/Users/lcf/IdeaProjects/interproscan6/work/10/001dd4dc2aea2ced460e008219b76c/calculatedMatches.json, /Users/lcf/IdeaProjects/interproscan6/work/6d/db92a4b8705a2098fe89171b7f398a/sfld.json, /Users/lcf/IdeaProjects/interproscan6/work/84/afa0e390f61b422b8b6fac8c1bbbf4/no_matches.json]]
[2, [/Users/lcf/IdeaProjects/interproscan6/work/67/0f13b495f0f0d4d47faf69caede307/calculatedMatches.json]]
[1, [/Users/lcf/IdeaProjects/interproscan6/work/7e/b8acce8f63bd1f929ffb9de1cc5066/calculatedMatches.json]]
```

