### PR TITLE
Report CDD location e-value and score in XML format

### DIFF
--- a/lib/uk/ac/ebi/interpro/ProcessOutputXML.groovy
+++ b/lib/uk/ac/ebi/interpro/ProcessOutputXML.groovy
@@ -539,8 +539,8 @@ class ProcessOutputXML {
             start          : loc.start,
             end            : loc.end,
             representative : loc.representative,
-            evalue         : match.evalue,
-            score          : match.score,
+            evalue         : loc.evalue,
+            score          : loc.score,
         ]
     }
 


### PR DESCRIPTION
The e-value and score attributes are missing from the CDD `location` property in the XML output. This PR fix it so they are reported like in the JSON output.