### PR TITLE
Strict syntax v2

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Nextflow
         uses: nf-core/setup-nextflow@v1
         with:
-          version: '26.04.0'
+          version: '26.04.3'
 
       - name: Check help message exits cleanly
         run: |

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -29,6 +29,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Nextflow
         uses: nf-core/setup-nextflow@v1
         with:
-          version: '25.04.6'
+          version: '26.04.0'
 
       - name: Check help message exits cleanly
         run: |
@@ -60,7 +60,7 @@ jobs:
 
       - name: Install nf-test
         run: |
-          wget -qO- https://get.nf-test.com | bash -s 0.9.3
+          wget -qO- https://get.nf-test.com | bash -s 0.9.4
           sudo mv nf-test /usr/local/bin/
 
       - name: Run unit tests

--- a/conf/profiles/base.config
+++ b/conf/profiles/base.config
@@ -1,8 +1,8 @@
 executor {
     name = 'local'
-    if (params.maxWorkers != null) {
-        cpus = params.maxWorkers
-    }
+    cpus = ({
+        return params.maxWorkers != null ? params.maxWorkers : null
+    }())
 }
 
 process {

--- a/conf/profiles/docker.config
+++ b/conf/profiles/docker.config
@@ -7,5 +7,4 @@ process {
 docker {
     enabled = true
     mountFlags = 'Z'
-    pullTimeout = '3 hours'  // the default is 20 minutes and fails with large images
 }

--- a/conf/profiles/lsf.config
+++ b/conf/profiles/lsf.config
@@ -3,12 +3,6 @@ executor {
     queueSize       = 1000
     exitReadTimeout = '30 min'
     submitRateLimit = '10/1sec'
-    jobName         = {
-        task.name // [] and ' ' may not be allowed in job names
-            .replace('[', '(')
-            .replace(']', ')')
-            .replace(' ', '_')
-    }
 }
 
 process {

--- a/conf/profiles/slurm.config
+++ b/conf/profiles/slurm.config
@@ -7,14 +7,6 @@ executor {
 
 process {
     executor = 'slurm'
-
-    jobName         = {
-        task.name // [] and ' ' may not be allowed in job names
-            .replace('[', '(')
-            .replace(']', ')')
-            .replace(' ', '_')
-    }
-
     withLabel: use_gpu {
         clusterOptions = '--gres=gpu:1'
     }

--- a/conf/profiles/slurm.config
+++ b/conf/profiles/slurm.config
@@ -3,16 +3,17 @@ executor {
     queueSize       = 1000
     exitReadTimeout = '30 min'
     submitRateLimit = '10/1sec'
+}
+
+process {
+    executor = 'slurm'
+
     jobName         = {
         task.name // [] and ' ' may not be allowed in job names
             .replace('[', '(')
             .replace(']', ')')
             .replace(' ', '_')
     }
-}
-
-process {
-    executor = 'slurm'
 
     withLabel: use_gpu {
         clusterOptions = '--gres=gpu:1'

--- a/conf/profiles/test.config
+++ b/conf/profiles/test.config
@@ -1,3 +1,3 @@
 params {
-    input        = params.nucleic ? "./assets/test.fna" : "./assets/test.faa"
+    input        = params.nucleic ? "./assets/test.fna" : "./assets/test.fna"}"
 }

--- a/conf/profiles/test.config
+++ b/conf/profiles/test.config
@@ -1,3 +1,3 @@
 params {
-    input        = params.nucleic ? "./assets/test.fna" : "./assets/test.fna"}"
+    input        = params.nucleic ? "./assets/test.fna" : "./assets/test.faa"
 }

--- a/conf/profiles/test.config
+++ b/conf/profiles/test.config
@@ -1,3 +1,3 @@
 params {
-    input        = params.nucleic ? "./assets/test.fna" : "./assets/test.fna"}"
+    input        = "${projectDir}/assets/test.${params.nucleic ? 'fna' : 'faa'}"
 }

--- a/conf/profiles/test.config
+++ b/conf/profiles/test.config
@@ -1,3 +1,3 @@
 params {
-    input        = "${projectDir}/assets/test.${params.nucleic ? 'fna' : 'faa'}"
+    input        = params.nucleic ? "./assets/test.fna" : "./assets/test.fna"}"
 }

--- a/lib/uk/ac/ebi/interpro/CATH.groovy
+++ b/lib/uk/ac/ebi/interpro/CATH.groovy
@@ -91,7 +91,7 @@ class CATH {
                     fragments.add(fragment)
                 }
 
-                Location location = new Location(
+                Location location = new uk.ac.ebi.interpro.Location(
                     cathDomain.getResolvedStart(),
                     cathDomain.getResolvedEnd(),
                     hmmerDomain.locations[0].hmmStart,
@@ -111,8 +111,8 @@ class CATH {
                 if (sequenceDomains.containsKey(domId)) {
                     sequenceDomains[domId].addLocation(location)
                 } else {
-                    Signature sig = new Signature(cathDomain.accession, new SignatureLibraryRelease(memberDb, null))
-                    Match domain = new Match(
+                    Signature sig = new uk.ac.ebi.interpro.Signature(cathDomain.accession, new SignatureLibraryRelease(memberDb, null))
+                    Match domain = new uk.ac.ebi.interpro.Match(
                         domId, 
                         hmmerDomain.evalue,
                         hmmerDomain.score, 

--- a/lib/uk/ac/ebi/interpro/FingerPrint.groovy
+++ b/lib/uk/ac/ebi/interpro/FingerPrint.groovy
@@ -45,7 +45,7 @@ class FingerPrint {
         Double evalueCutoff
         int minMotifCount
         boolean isDomain = false
-        String[] siblingsIds = []
+        List<String> siblingsIds = []
 
         HierarchyEntry(String modelId, String modelAccession, Double evalueCutoff, int minMotifCount) {
             this.modelId = modelId
@@ -95,8 +95,7 @@ class FingerPrint {
         }
 
         void addSiblings(String siblingsString) {
-            String[] siblingsIds = siblingsString.split("\\,")
-            this.siblingsIds = siblingsIds
+            this.siblingsIds = siblingsString.split("\\,").toList()
         }
     }
 }

--- a/lib/uk/ac/ebi/interpro/HMMER2.groovy
+++ b/lib/uk/ac/ebi/interpro/HMMER2.groovy
@@ -7,7 +7,7 @@ class HMMER2 {
         String line
         String querySequence
         def hits = [:].withDefault { [:] }
-        SignatureLibraryRelease library = new SignatureLibraryRelease(memberDb, null)
+        SignatureLibraryRelease library = new uk.ac.ebi.interpro.SignatureLibraryRelease(memberDb, null)
 
         filePath.withReader { reader ->
             while (true) {
@@ -69,8 +69,8 @@ class HMMER2 {
                     double evalue = Double.parseDouble(tail[1])
                     int numDomains = tail[2].toInteger()
 
-                    Signature signature = new Signature(modelAccession, library)
-                    Match match = new Match(modelAccession, evalue, score, signature)
+                    Signature signature = new uk.ac.ebi.interpro.Signature(modelAccession, library)
+                    Match match = new uk.ac.ebi.interpro.Match(modelAccession, evalue, score, signature)
                     sequenceHits[modelAccession] = match
                     domainsPerHit[modelAccession] = numDomains
                 }
@@ -107,7 +107,7 @@ class HMMER2 {
                         Integer hmmLength = hmmLengths[modelAccession]
                         assert hmmLength != null
                         
-                        Location loc = new Location(start, end, hmmStart, hmmEnd, hmmLength, hmmBounds,
+                        Location loc = new uk.ac.ebi.interpro.Location(start, end, hmmStart, hmmEnd, hmmLength, hmmBounds,
                                                     null, null, evalue, score, null)
                         
                         Match match = sequenceHits[modelAccession]

--- a/lib/uk/ac/ebi/interpro/HMMER3.groovy
+++ b/lib/uk/ac/ebi/interpro/HMMER3.groovy
@@ -10,7 +10,7 @@ class HMMER3 {
         Integer queryLength
         String queryAccession
         String targetId
-        SignatureLibraryRelease libraryRelease = new SignatureLibraryRelease(memberDb, null)
+        SignatureLibraryRelease libraryRelease = new uk.ac.ebi.interpro.SignatureLibraryRelease(memberDb, null)
 
         def hits = [:].withDefault { [:] }
         filePath.withReader { reader ->
@@ -62,12 +62,12 @@ class HMMER3 {
                     }
 
                     def fields = line.split(/\s+/)
-                    Match match = new Match(
+                    Match match = new uk.ac.ebi.interpro.Match(
                         queryAccession,
                         Double.parseDouble(fields[0]),
                         Double.parseDouble(fields[1]),
                         Double.parseDouble(fields[2]),
-                        new Signature(queryAccession, libraryRelease)
+                        new uk.ac.ebi.interpro.Signature(queryAccession, libraryRelease)
                     )
                     match.included = isIncluded
                     targetId = fields[8].trim()
@@ -114,7 +114,7 @@ class HMMER3 {
                     while (!(line = reader.readLine().trim()).isEmpty()) {
                         def fields = line.split(/\s+/)
                         assert fields.size() == 16
-                        Location location = new Location(
+                        Location location = new uk.ac.ebi.interpro.Location(
                             Integer.parseInt(fields[9]),
                             Integer.parseInt(fields[10]),
                             fields[6].toInteger(),
@@ -224,7 +224,7 @@ class HMMER3 {
         hmmerMatches.each { sequenceId, matches ->
             matches.values().each { m1 ->
                 m1.locations.each { loc ->
-                    Match m2 = new Match(
+                    Match m2 = new uk.ac.ebi.interpro.Match(
                         m1.modelAccession, 
                         m1.evalue,
                         m1.score, 

--- a/lib/uk/ac/ebi/interpro/InterProScan.groovy
+++ b/lib/uk/ac/ebi/interpro/InterProScan.groovy
@@ -364,24 +364,15 @@ class InterProScan {
     }
 
     static String validateInterProVersion(versionParam) {
-        String version = null
-        if (versionParam instanceof String) {
-            version = versionParam.trim()
-            if (version == "latest") {
-                return version
-            }
-            try {
-                double num = Double.parseDouble(version)
-                if (num == Math.floor(num)) {
-                    version = String.format("%.1f", num)
-                } else {
-                    version = Double.toString(num)
-                }
-            } catch (NumberFormatException e) {
-                return null
-            }
+        def version = versionParam?.toString()?.trim()
+        if (!version) return null
+        if (version == "latest") return version
+        try {
+            def num = new BigDecimal(version)
+            return num.toPlainString()
+        } catch (NumberFormatException e) {
+            return null
         }
-        return version
     }
 
     static List<String> fetchCompatibleVersions(String majorMinorVersion, boolean useGlobus = false) {

--- a/lib/uk/ac/ebi/interpro/InterProScan.groovy
+++ b/lib/uk/ac/ebi/interpro/InterProScan.groovy
@@ -365,15 +365,21 @@ class InterProScan {
 
     static String validateInterProVersion(versionParam) {
         String version = null
-        if (versionParam instanceof Number) {
-            double num = ((Number) versionParam).doubleValue();
-            if (num == Math.floor(num)) {
-                version = String.format("%.1f", num);
-            } else {
-                version = Double.toString(num);
+        if (versionParam instanceof String) {
+            version = versionParam.trim()
+            if (version == "latest") {
+                return version
             }
-        } else if (versionParam instanceof String && versionParam == "latest") {
-            version = versionParam
+            try {
+                double num = Double.parseDouble(version)
+                if (num == Math.floor(num)) {
+                    version = String.format("%.1f", num)
+                } else {
+                    version = Double.toString(num)
+                }
+            } catch (NumberFormatException e) {
+                return null
+            }
         }
         return version
     }

--- a/lib/uk/ac/ebi/interpro/Location.groovy
+++ b/lib/uk/ac/ebi/interpro/Location.groovy
@@ -168,7 +168,7 @@ class Location implements Serializable {
     }
 
     static Location fromMap(data) {
-        Location loc = new Location(
+        Location loc = new uk.ac.ebi.interpro.Location(
                 data.start,
                 data.end,
                 data.hmmStart,
@@ -244,7 +244,7 @@ class Location implements Serializable {
     }
 
     public Object clone() {
-        Location loc = new Location(
+        Location loc = new uk.ac.ebi.interpro.Location(
             start,
             end,
             hmmStart,

--- a/lib/uk/ac/ebi/interpro/Match.groovy
+++ b/lib/uk/ac/ebi/interpro/Match.groovy
@@ -80,7 +80,7 @@ class Match implements Serializable {
     }
 
     static Match fromMap(Map data) {
-        Match match = new Match(data.modelAccession)
+        Match match = new uk.ac.ebi.interpro.Match(data.modelAccession)
         match.evalue = data.evalue
         match.score = data.score
         match.bias = data.bias

--- a/lib/uk/ac/ebi/interpro/SFLD.groovy
+++ b/lib/uk/ac/ebi/interpro/SFLD.groovy
@@ -1,0 +1,115 @@
+package uk.ac.ebi.interpro
+
+import java.nio.file.Path
+import uk.ac.ebi.interpro.Location
+import uk.ac.ebi.interpro.LocationFragment
+import uk.ac.ebi.interpro.Match
+import uk.ac.ebi.interpro.Signature
+import uk.ac.ebi.interpro.SignatureLibraryRelease
+import uk.ac.ebi.interpro.Site
+
+class SFLD {
+    static Map<String, Map<String, Match>> parseOutput(
+        Path filePath, 
+        Map<String, Map> hmmerMatches
+    ) {
+        // Parse the output TSV file from the SFLD postprocess bin
+        def matches = [:]
+        filePath.withReader{ reader ->
+            while (true) {
+                String sequenceId = null
+
+                for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+                    def matcher = line.trim() =~ ~/^Sequence:\s+(\S+)$/
+                    if (matcher.find()) {
+                        sequenceId = matcher.group(1).trim()
+                        break
+                    }
+                }
+
+                if (sequenceId == null) {
+                    break
+                }
+
+                assert hmmerMatches.containsKey(sequenceId)
+                def seqHmmerMatches = hmmerMatches[sequenceId]
+                matches[sequenceId] = parseBlock(reader, sequenceId, seqHmmerMatches)
+            }
+        }
+
+        return matches
+    }
+
+    static Map<String, Match> parseBlock(
+        Reader reader,
+        String sequenceId,
+        Map<String, Map> seqHmmerMatches
+    ) {
+        SignatureLibraryRelease library = new SignatureLibraryRelease("SFLD", null)
+        boolean inDomains = false
+        def domains = [:]
+        while (true) {
+            String line = reader.readLine()?.trim()
+            if (!line) break
+            if (line == "Domains:") {
+                inDomains = true
+            } else if (line == "Sites:") {
+                inDomains = false
+            } else if (line == "//") {
+                break
+            } else if (inDomains) {
+                def fields = line.split(/\t/)
+                assert fields.length == 15
+                String modelAccession = fields[0]
+                Integer hmmStart = fields[4] as Integer
+                Integer hmmEnd = fields[5] as Integer
+                int aliStart = fields[7] as int
+                int aliEnd = fields[8] as int
+                Integer envStart = fields[9] as Integer
+                Integer envEnd = fields[10] as Integer
+                assert seqHmmerMatches.containsKey(modelAccession)
+                def hmmerMatch = seqHmmerMatches[modelAccession]
+                Location loc = hmmerMatch.locations.find { it.start == aliStart 
+                                                            && it.end == aliEnd 
+                                                            && it.hmmStart == hmmStart 
+                                                            && it.hmmEnd == hmmEnd 
+                                                            && it.envelopeStart == envStart 
+                                                            && it.envelopeEnd == envEnd }
+                assert loc != null
+                Match match = domains.computeIfAbsent(modelAccession, k -> {
+                    Signature signature = new Signature(modelAccession, library)
+                    return new Match(modelAccession, hmmerMatch.evalue, hmmerMatch.score, hmmerMatch.bias, signature)
+                });
+                match.addLocation(loc)
+            } else {
+                def fields = line.split(/\s/, 3)
+                assert fields.length == 2 || fields.length == 3
+                String modelAccession = fields[0]
+                String residues = fields[1]
+                String description = fields.length == 3 ? fields[2] : null
+
+                Match match = domains.get(modelAccession)
+                if (match != null) {
+                    Site site = new Site(description, residues)
+                    match.addSite(site)                        
+                }
+            }
+        }
+
+        return domains
+    }
+
+    static Map<String, Set<String>> getHierarchies(Path filePath) {
+        def hierarchies = [:].withDefault { [] as Set }
+        filePath.eachLine { line ->
+            def nodes = line.split(/\t/).toList()
+            nodes.eachWithIndex { node, idx ->
+                if (idx > 0) {
+                    def ancestors = nodes.subList(0, idx) as Set
+                    hierarchies[node].addAll(ancestors)
+                }
+            }
+        }
+        return hierarchies
+    }
+}

--- a/lib/uk/ac/ebi/interpro/Signature.groovy
+++ b/lib/uk/ac/ebi/interpro/Signature.groovy
@@ -6,7 +6,7 @@ class Signature implements Serializable {
     String name
     String description
     String type
-    SignatureLibraryRelease signatureLibraryRelease = new SignatureLibraryRelease(null, null)
+    SignatureLibraryRelease signatureLibraryRelease = new uk.ac.ebi.interpro.SignatureLibraryRelease(null, null)
     Entry entry = null
 
     Signature(String accession) {
@@ -52,7 +52,7 @@ class Signature implements Serializable {
         if (data == null) {
             return null
         }
-        return new Signature(
+        return new uk.ac.ebi.interpro.Signature(
                 data.accession,
                 data.name,
                 data.description,

--- a/main.nf
+++ b/main.nf
@@ -5,7 +5,7 @@ workflow {
     println "# ${workflow.manifest.name} ${workflow.manifest.version}"
     println "# ${workflow.manifest.description}\n"
 
-    if (params.help == true) {
+    if (params.help) {
         uk.ac.ebi.interpro.InterProScan.printHelp(params.appsConfig)
         exit 0
     }

--- a/main.nf
+++ b/main.nf
@@ -5,7 +5,7 @@ workflow {
     println "# ${workflow.manifest.name} ${workflow.manifest.version}"
     println "# ${workflow.manifest.description}\n"
 
-    if (params.help) {
+    if (params.help.toBoolean()) {
         uk.ac.ebi.interpro.InterProScan.printHelp(params.appsConfig)
         exit 0
     }

--- a/main.nf
+++ b/main.nf
@@ -7,7 +7,7 @@ workflow {
     println "# ${workflow.manifest.name} ${workflow.manifest.version}"
     println "# ${workflow.manifest.description}\n"
 
-    if (params.keySet().any { param -> param.equalsIgnoreCase("help") }) {
+    if (params.help) {
         uk.ac.ebi.interpro.InterProScan.printHelp(params.appsConfig)
         exit 0
     }

--- a/main.nf
+++ b/main.nf
@@ -7,7 +7,7 @@ workflow {
     println "# ${workflow.manifest.name} ${workflow.manifest.version}"
     println "# ${workflow.manifest.description}\n"
 
-    if (params.keySet().any { it.equalsIgnoreCase("help") }) {
+    if (params.keySet().any { param -> param.equalsIgnoreCase("help") }) {
         uk.ac.ebi.interpro.InterProScan.printHelp(params.appsConfig)
         exit 0
     }

--- a/main.nf
+++ b/main.nf
@@ -1,5 +1,3 @@
-nextflow.enable.dsl=2
-
 include { INIT_PIPELINE } from './subworkflows/init/pipeline'
 include { INTERPROSCAN  } from './workflows/interproscan'
 

--- a/main.nf
+++ b/main.nf
@@ -5,7 +5,7 @@ workflow {
     println "# ${workflow.manifest.name} ${workflow.manifest.version}"
     println "# ${workflow.manifest.description}\n"
 
-    if (params.help) {
+    if (params.help == true) {
         uk.ac.ebi.interpro.InterProScan.printHelp(params.appsConfig)
         exit 0
     }

--- a/main.nf
+++ b/main.nf
@@ -1,20 +1,18 @@
 nextflow.enable.dsl=2
-import java.time.format.DateTimeFormatter
-import uk.ac.ebi.interpro.InterProScan
 
-include { INIT_PIPELINE      } from "${projectDir}/subworkflows/init/pipeline"
-include { INTERPROSCAN       } from "${projectDir}/workflows/interproscan"
+include { INIT_PIPELINE } from './subworkflows/init/pipeline'
+include { INTERPROSCAN  } from './workflows/interproscan'
 
 workflow {
     println "# ${workflow.manifest.name} ${workflow.manifest.version}"
     println "# ${workflow.manifest.description}\n"
 
     if (params.keySet().any { it.equalsIgnoreCase("help") }) {
-        InterProScan.printHelp(params.appsConfig)
+        uk.ac.ebi.interpro.InterProScan.printHelp(params.appsConfig)
         exit 0
     }
 
-    InterProScan.validateParams(params, log)
+    uk.ac.ebi.interpro.InterProScan.validateParams(params, log)
 
     INIT_PIPELINE(
         params.input,
@@ -33,7 +31,7 @@ workflow {
         params.pathways,
         workflow.manifest
     )
-    fasta_file           = Channel.fromPath(INIT_PIPELINE.out.fasta.val)
+    fasta_file           = channel.fromPath(INIT_PIPELINE.out.fasta.val)
     apps                 = INIT_PIPELINE.out.apps.val
     apps_config          = INIT_PIPELINE.out.apps_config.val
     data_dir             = INIT_PIPELINE.out.datadir.val
@@ -70,7 +68,7 @@ workflow {
             println "\nInterProScan completed successfully"
             println "Results available at: ${outprefix}.*"
             if (workflow.duration.toSeconds() <= 60) {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MMM-yyyy HH:mm:ss");
+                def formatter = java.time.format.DateTimeFormatter.ofPattern("dd-MMM-yyyy HH:mm:ss");
                 println "Completed at        : ${workflow.complete.format(formatter)}"
                 println "Duration            : ${workflow.duration}"
             }

--- a/modules/add_xrefs/main.nf
+++ b/modules/add_xrefs/main.nf
@@ -26,29 +26,3 @@ process ADD_XREFS {
     chmod -R 777 outputs
     """
 }
-
-// process ADD_XREFS {
-//     label    'mem_medium', 'time_veryshort'
-//     executor 'local'
-
-//     input:
-//     tuple val(meta), val(json)
-//     val interpro_dir
-//     val panther_paint_dir
-//     val add_goterms
-//     val add_pathways
-
-//     output:
-//     tuple val(meta), path('xrefs/*.json', arity: '1..*')
-
-//     exec:
-//     def outdir = task.workDir.resolve("xrefs")
-//     uk.ac.ebi.interpro.ProcessXrefs.run(
-//         json, 
-//         interpro_dir.name == "DUMMY" ? null : interpro_dir, 
-//         panther_paint_dir.name == "DUMMY2" ? null : panther_paint_dir,
-//         add_goterms, 
-//         add_pathways, 
-//         outdir
-//     )
-// }

--- a/modules/add_xrefs/main.nf
+++ b/modules/add_xrefs/main.nf
@@ -1,5 +1,6 @@
 process ADD_XREFS {
-    label     'mem_medium', 'time_veryshort'
+    label     'mem_medium'
+    label     'time_veryshort'
     container 'interpro/groovy:4.0.27-1'
 
     input:

--- a/modules/antifam/main.nf
+++ b/modules/antifam/main.nf
@@ -1,5 +1,6 @@
 process PARSE_ANTIFAM {
-    label    'mem_min','time_veryshort'
+    label    'mem_min'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/antifam/main.nf
+++ b/modules/antifam/main.nf
@@ -1,6 +1,3 @@
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.HMMER3
-
 process PARSE_ANTIFAM {
     label    'mem_min','time_veryshort'
     executor 'local'
@@ -13,6 +10,6 @@ process PARSE_ANTIFAM {
 
     exec:
     def filepath = task.workDir.resolve("antifam.json")
-    def matches = HMMER3.parseOutput(hmmseach_out, "AntiFam")
-    filepath.text = JsonOutput.toJson(matches)
+    def matches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmseach_out, "AntiFam")
+    filepath.text = groovy.json.JsonOutput.toJson(matches)
 }

--- a/modules/cath/main.nf
+++ b/modules/cath/main.nf
@@ -1,9 +1,3 @@
-import groovy.json.JsonOutput
-import groovy.json.JsonSlurper
-import uk.ac.ebi.interpro.CATH
-import uk.ac.ebi.interpro.HMMER3
-import uk.ac.ebi.interpro.Match
-
 process SEARCH_GENE3D {
     label     'mem_min', 'time_short', 'dynamic'
     container 'interpro/cath:0.16.10'
@@ -48,11 +42,11 @@ process PARSE_CATHGENE3D {
 
     exec:
     def member_db = "CATH-Gene3D"
-    def hmmer_matches = HMMER3.parseOutput(hmmseach_out, member_db)
-    def cath_domains = CATH.parseAssignedFile(cath_tsv)
-    def matches = CATH.mergeWithHmmerMatches(cath_domains, hmmer_matches, member_db)
+    def hmmer_matches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmseach_out, member_db)
+    def cath_domains = uk.ac.ebi.interpro.CATH.parseAssignedFile(cath_tsv)
+    def matches = uk.ac.ebi.interpro.CATH.mergeWithHmmerMatches(cath_domains, hmmer_matches, member_db)
     def filepath = task.workDir.resolve("cathgene3d.json")
-    filepath.text = JsonOutput.toJson(matches)
+    filepath.text = groovy.json.JsonOutput.toJson(matches)
 }
 
 process SEARCH_FUNFAM {
@@ -93,9 +87,9 @@ process PARSE_FUNFAM {
 
     exec:
     def member_db = "CATH-FunFam"
-    def hmmer_matches = HMMER3.parseOutput(hmmseach_out, member_db)
-    def funfam_domains = CATH.parseResolvedFile(resolved_tsv)
-    def matches = CATH.mergeWithHmmerMatches(funfam_domains, hmmer_matches, member_db)
+    def hmmer_matches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmseach_out, member_db)
+    def funfam_domains = uk.ac.ebi.interpro.CATH.parseResolvedFile(resolved_tsv)
+    def matches = uk.ac.ebi.interpro.CATH.mergeWithHmmerMatches(funfam_domains, hmmer_matches, member_db)
     def filepath = task.workDir.resolve("cathfunfam.json")
-    filepath.text = JsonOutput.toJson(matches)
+    filepath.text = groovy.json.JsonOutput.toJson(matches)
 }

--- a/modules/cath/main.nf
+++ b/modules/cath/main.nf
@@ -1,5 +1,7 @@
 process SEARCH_GENE3D {
-    label     'mem_min', 'time_short', 'dynamic'
+    label     'mem_min'
+    label     'time_short'
+    label     'dynamic'
     container 'interpro/cath:0.16.10'
 
     input:
@@ -31,7 +33,8 @@ process SEARCH_GENE3D {
 }
 
 process PARSE_CATHGENE3D {
-    label    'mem_low', 'time_short'
+    label    'mem_low'
+    label    'time_short'
     executor 'local'
 
     input:
@@ -50,7 +53,9 @@ process PARSE_CATHGENE3D {
 }
 
 process SEARCH_FUNFAM {
-    label     'mem_min', 'time_medium', 'dynamic'
+    label     'mem_min'
+    label     'time_medium'
+    label     'dynamic'
     container 'interpro/cath:0.16.10'
 
     input:
@@ -76,7 +81,8 @@ process SEARCH_FUNFAM {
 
 
 process PARSE_FUNFAM {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/cdd/main.nf
+++ b/modules/cdd/main.nf
@@ -1,10 +1,3 @@
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-import uk.ac.ebi.interpro.Site
-
 process SEARCH_CDD {
     label     'mem_min', 'time_short'
     container 'interpro/cdd:1.0'
@@ -50,11 +43,11 @@ process PARSE_CDD {
     tuple val(meta), path("cdd.json")
 
     exec:
-    SignatureLibraryRelease library = new SignatureLibraryRelease("CDD", null)
-    String sessionId = null
-    String sequenceId = null
-    boolean inDomains = false
-    boolean inSites = false
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("CDD", null)
+    def sessionId = null
+    def sequenceId = null
+    def inDomains = false
+    def inSites = false
     def hits = [:]
     def pssmHits = [:]
     def pssmSites = [:]
@@ -84,25 +77,25 @@ process PARSE_CDD {
                 // #<session-ordinal>      <query-id[readingframe]>        <hit-type>      <PSSM-ID>       <from>  <to>    <E-Value>       <bitscore>      <accession>     <short-name>    <incomplete>    <superfamily PSSM-ID>
                 def fields = line.split("\t")
                 assert fields.size() == 12
-                String hitType = fields[2]
+                def hitType = fields[2]
                 if (hitType.toUpperCase() == "SPECIFIC") {
-                    String pssmId = fields[3]
-                    int start = fields[4].toInteger()
-                    int end = fields[5].toInteger()
-                    Double evalue = Double.parseDouble(fields[6])
-                    Double bitscore = Double.parseDouble(fields[7])
-                    String modelAccession = fields[8]
+                    def pssmId = fields[3]
+                    def start = fields[4].toInteger()
+                    def end = fields[5].toInteger()
+                    def evalue = Double.parseDouble(fields[6])
+                    def bitscore = Double.parseDouble(fields[7])
+                    def modelAccession = fields[8]
 
                     // We need to use the PSSM ID to link domains and sites
-                    Match match
+                    def match
                     if (pssmHits.containsKey(pssmId)) {
                         match = pssmHits[pssmId]
                     } else {
-                        Signature signature = new Signature(modelAccession, library)
-                        match = new Match(modelAccession, signature)
+                        def signature = new uk.ac.ebi.interpro.Signature(modelAccession, library)
+                        match = new uk.ac.ebi.interpro.Match(modelAccession, signature)
                         pssmHits[pssmId] = match
                     }
-                    match.addLocation(new Location(start, end, evalue, bitscore))
+                    match.addLocation(new uk.ac.ebi.interpro.Location(start, end, evalue, bitscore))
                 }
             } else {
                 // #<session-ordinal>      <query-id[readingframe]>        <annot-type>    <title> <residue(coordinates)>  <complete-size> <mapped-size>   <source-domain>
@@ -133,7 +126,7 @@ process PARSE_CDD {
                 def match = pssmHits[pssmId]
                 if (match != null) {
                     descriptionToResidues.each { description, residues ->
-                        match.addSite(new Site(description, residues.join(",")))  // codenarc-disable-line JoinMismatchRule, JoinDuplicateRule
+                        match.addSite(new uk.ac.ebi.interpro.Site(description, residues.join(",")))  // codenarc-disable-line JoinMismatchRule, JoinDuplicateRule
                     }
                 }
             }
@@ -159,5 +152,5 @@ process PARSE_CDD {
     }
 
     def filepath = task.workDir.resolve("cdd.json")
-    filepath.text = JsonOutput.toJson(hits)
+    filepath.text = groovy.json.JsonOutput.toJson(hits)
 }

--- a/modules/cdd/main.nf
+++ b/modules/cdd/main.nf
@@ -136,7 +136,7 @@ process PARSE_CDD {
             assert sequenceId != null
             
             def cddHits = [:]
-            pssmHits.each { key, match ->
+            pssmHits.each { _key, match ->
                 def modelAccession = match.modelAccession
                 assert !cddHits.containsKey(modelAccession)
                 cddHits[modelAccession] = match

--- a/modules/cdd/main.nf
+++ b/modules/cdd/main.nf
@@ -1,5 +1,6 @@
 process SEARCH_CDD {
-    label     'mem_min', 'time_short'
+    label     'mem_min'
+    label     'time_short'
     container 'interpro/cdd:1.0'
 
     input:
@@ -33,7 +34,8 @@ process SEARCH_CDD {
 }
 
 process PARSE_CDD {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/coils/main.nf
+++ b/modules/coils/main.nf
@@ -48,5 +48,7 @@ process PARSE_COILS {
     }
 
     def filepath = task.workDir.resolve("coils.json")
-    filepath.text = groovy.json.JsonOutput.toJson(matches.findAll { it.value["Coil"].locations.size() > 0 })
+    filepath.text = groovy.json.JsonOutput.toJson(
+        matches.findAll { m -> m.value["Coil"].locations.size() > 0 }
+    )
 }

--- a/modules/coils/main.nf
+++ b/modules/coils/main.nf
@@ -1,5 +1,6 @@
 process RUN_COILS {
-    label     'mem_min', 'time_veryshort'
+    label     'mem_min'
+    label     'time_veryshort'
     container 'interpro/ncoils:2.2.1'
 
     input:
@@ -16,7 +17,8 @@ process RUN_COILS {
 
 
 process PARSE_COILS {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/coils/main.nf
+++ b/modules/coils/main.nf
@@ -1,9 +1,3 @@
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.Location  
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-
 process RUN_COILS {
     label     'mem_min', 'time_veryshort'
     container 'interpro/ncoils:2.2.1'
@@ -34,7 +28,7 @@ process PARSE_COILS {
     exec:
     def matches = [:]
     def sequenceId = null
-    SignatureLibraryRelease library = new SignatureLibraryRelease("COILS", "2.2.1")
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("COILS", "2.2.1")
 
     coils_out.eachLine { line ->
         line = line.trim()
@@ -43,16 +37,16 @@ process PARSE_COILS {
             sequenceId = line.substring(1).split()[0]
             matches[sequenceId] = [:]
 
-            Match match = new Match("Coil", new Signature("Coil", "Coil", null, library, null))
+            def match = new uk.ac.ebi.interpro.Match("Coil", new uk.ac.ebi.interpro.Signature("Coil", "Coil", null, library, null))
             matches[sequenceId]["Coil"] = match
         } else if (line != "//" && sequenceId) {
             def fields = line.split(/\s+/)
             def start = fields[0].toInteger()
             def end = fields[1].toInteger()
-            matches[sequenceId]["Coil"].addLocation(new Location(start, end))
+            matches[sequenceId]["Coil"].addLocation(new uk.ac.ebi.interpro.Location  (start, end))
         }
     }
 
     def filepath = task.workDir.resolve("coils.json")
-    filepath.text = JsonOutput.toJson(matches.findAll { it.value["Coil"].locations.size() > 0 })
+    filepath.text = groovy.json.JsonOutput.toJson(matches.findAll { it.value["Coil"].locations.size() > 0 })
 }

--- a/modules/combine/main.nf
+++ b/modules/combine/main.nf
@@ -1,5 +1,6 @@
 process COMBINE_MATCHES {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/deeptmhmm/Dockerfile
+++ b/modules/deeptmhmm/Dockerfile
@@ -1,5 +1,5 @@
 # This image contains only dependencies for DeepTMHMM. It does not include a copy of DeepTMHMM
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 LABEL name="interpro/deeptmhmm"
 LABEL tag="1.0"
@@ -31,7 +31,7 @@ RUN pip install --no-cache-dir \
     Pillow==12.2.0 \
     pyparsing==3.0.9 \
     python-dateutil==2.8.2 \
-    requests==2.33.0 \
+    requests==2.32.5 \
     six==1.16.0 \
     tqdm==4.64.1 \
     urllib3==2.7.0

--- a/modules/deeptmhmm/Dockerfile
+++ b/modules/deeptmhmm/Dockerfile
@@ -31,7 +31,7 @@ RUN pip install --no-cache-dir \
     Pillow==9.3.0 \
     pyparsing==3.0.9 \
     python-dateutil==2.8.2 \
-    requests==2.28.1 \
+    requests==2.33.0 \
     six==1.16.0 \
     tqdm==4.64.1 \
     urllib3==1.26.12

--- a/modules/deeptmhmm/Dockerfile
+++ b/modules/deeptmhmm/Dockerfile
@@ -22,16 +22,16 @@ RUN pip install --no-cache-dir \
     fonttools==4.38.0 \
     future==0.18.2 \
     h5py==3.7.0 \
-    idna==3.4 \
+    idna==3.15 \
     kiwisolver==1.4.4 \
     matplotlib==3.5.2 \
     numpy==1.23.4 \
     packaging==21.3 \
     PeptideBuilder==1.1.0 \
-    Pillow==9.3.0 \
+    Pillow==12.2.0 \
     pyparsing==3.0.9 \
     python-dateutil==2.8.2 \
     requests==2.33.0 \
     six==1.16.0 \
     tqdm==4.64.1 \
-    urllib3==1.26.12
+    urllib3==2.7.0

--- a/modules/deeptmhmm/main.nf
+++ b/modules/deeptmhmm/main.nf
@@ -1,5 +1,6 @@
 process RUN_DEEPTMHMM_CPU {
-    label       'mem_high', 'time_medium'
+    label       'mem_high'
+    label       'time_medium'
     container   'interpro/deeptmhmm:1.0'
     stageInMode 'copy'
 
@@ -24,7 +25,9 @@ process RUN_DEEPTMHMM_CPU {
 }
 
 process RUN_DEEPTMHMM_GPU {
-    label       'mem_high', 'time_short', 'use_gpu'
+    label       'mem_high'
+    label       'time_short'
+    label       'use_gpu'
     container   'interpro/deeptmhmm:26.04'
     stageInMode 'copy'
 
@@ -49,7 +52,8 @@ process RUN_DEEPTMHMM_GPU {
 }
 
 process PARSE_DEEPTMHMM {
-    label    'mem_low', 'time_short'
+    label    'mem_low'
+    label    'time_short'
     executor 'local'
 
     input:

--- a/modules/deeptmhmm/main.nf
+++ b/modules/deeptmhmm/main.nf
@@ -1,10 +1,3 @@
-import groovy.json.JsonSlurper
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.Location  
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-
 process RUN_DEEPTMHMM_CPU {
     label       'mem_high', 'time_medium'
     container   'interpro/deeptmhmm:1.0'
@@ -66,15 +59,15 @@ process PARSE_DEEPTMHMM {
     tuple val(meta), path("tmhmm.json")
 
     exec:
-    SignatureLibraryRelease library = new SignatureLibraryRelease("DeepTMHMM", "1.0")
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("DeepTMHMM", "1.0")
     def MODEL_TYPES = [
-        "Beta sheet": ["Transmembrane beta barrel", new Signature("Transmembrane beta barrel", library)],
-        "periplasm": ["Periplasmic Domain", new Signature("Periplasmic Domain", library)],
-        "signal": ["Signalp Peptide", new Signature("Signal Peptide", library)],
-        "TMhelix": ["Transmembrane alpha helix", new Signature("Transmembrane alpha helix", library)],
+        "Beta sheet": ["Transmembrane beta barrel", new uk.ac.ebi.interpro.Signature("Transmembrane beta barrel", library)],
+        "periplasm": ["Periplasmic Domain", new uk.ac.ebi.interpro.Signature("Periplasmic Domain", library)],
+        "signal": ["Signalp Peptide", new uk.ac.ebi.interpro.Signature("Signal Peptide", library)],
+        "TMhelix": ["Transmembrane alpha helix", new uk.ac.ebi.interpro.Signature("Transmembrane alpha helix", library)],
     ]
-    Map<String, Match> hits = [:]
-    String seqId
+    def hits = [:]
+    def seqId
     file("${tmhmm_output}/TMRs.gff3").eachLine { line ->
         def lineData = line.split("\t")
         if (line.startsWith("//") || line.startsWith("#")) {  // stops '##gff-version 3' line breaking assert
@@ -84,17 +77,17 @@ process PARSE_DEEPTMHMM {
         if (MODEL_TYPES.containsKey(lineData[1])) { // e.g. tr_A0A009GMU8_A0A009GMU8_9GAMM periplasm 30 184
             seqId = lineData[0]
             hits.computeIfAbsent(seqId) { [:] }
-            (modelAcc, modelSig) = MODEL_TYPES[lineData[1]]
+            def (modelAcc, modelSig) = MODEL_TYPES[lineData[1]]
             hits[seqId].computeIfAbsent(modelAcc) {
-                Match match = new Match(modelAcc, modelSig)
+                def match = new uk.ac.ebi.interpro.Match(modelAcc, modelSig)
                 match
             }
-            int start = lineData[2].toInteger()
-            int end = lineData[3].toInteger()
-            hits[seqId][modelAcc].addLocation(new Location(start, end))
+            def start = lineData[2].toInteger()
+            def end = lineData[3].toInteger()
+            hits[seqId][modelAcc].addLocation(new uk.ac.ebi.interpro.Location(start, end))
         }
     }
 
     def filepath = task.workDir.resolve("tmhmm.json")
-    filepath.text = JsonOutput.toJson(hits)
+    filepath.text = groovy.json.JsonOutput.toJson(hits)
 }

--- a/modules/download/main.nf
+++ b/modules/download/main.nf
@@ -1,6 +1,7 @@
 process DOWNLOAD {
     maxForks  1
-    label     'mem_min', 'time_veryshort'
+    label     'mem_min'
+    label     'time_veryshort'
     executor  'local'
     container 'interpro/download:1.0'
 
@@ -32,7 +33,8 @@ process DOWNLOAD {
 }
 
 process FIND_DATABASES {
-    label    'mem_min', 'time_veryshort'
+    label    'mem_min'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/download/main.nf
+++ b/modules/download/main.nf
@@ -1,10 +1,3 @@
-import java.io.File
-import java.nio.file.*
-import groovy.json.JsonSlurper
-import groovy.json.JsonOutput
-
-import uk.ac.ebi.interpro.InterProScan
-
 process DOWNLOAD {
     maxForks  1
     label     'mem_min', 'time_veryshort'
@@ -25,7 +18,7 @@ process DOWNLOAD {
         """
         """
     } else {
-        def base_url = use_globus ? InterProScan.GLOBUS_URL : InterProScan.FTP_URL
+        def base_url = use_globus ? uk.ac.ebi.interpro.InterProScan.GLOBUS_URL : uk.ac.ebi.interpro.InterProScan.FTP_URL
         """
         curl -OJ ${base_url}/${iprscan_version}/${arcname}/${arcname}-${version}.tar.gz
         curl -OJ ${base_url}/${iprscan_version}/${arcname}/${arcname}-${version}.tar.gz.md5
@@ -54,7 +47,7 @@ process FIND_DATABASES {
     val missing,  emit: missing
 
     exec:
-    def json = new JsonSlurper().parse(databases_json)
+    def json = new groovy.json.JsonSlurper().parse(databases_json)
     def normalised_json = [:]
     json.each { key, value ->
         normalised_json[key.replaceAll(/[\s\-]+/, '').toLowerCase()] = value

--- a/modules/esl_translate/main.nf
+++ b/modules/esl_translate/main.nf
@@ -1,5 +1,6 @@
 process ESL_TRANSLATE {
-    label     'mem_low', 'time_short'
+    label     'mem_low'
+    label     'time_short'
     container 'interpro/esl-translate:0.46'
 
     input:

--- a/modules/hmmer/main.nf
+++ b/modules/hmmer/main.nf
@@ -1,5 +1,3 @@
-import groovy.json.JsonOutput
-
 process RUN_HMMER {
     label     'mem_min', 'time_medium', 'dynamic'
     container 'interpro/hmmer:3.3'

--- a/modules/hmmer/main.nf
+++ b/modules/hmmer/main.nf
@@ -1,5 +1,7 @@
 process RUN_HMMER {
-    label     'mem_min', 'time_medium', 'dynamic'
+    label     'mem_min'
+    label     'time_medium'
+    label     'dynamic'
     container 'interpro/hmmer:3.3'
 
     input:

--- a/modules/interpro_n/main.nf
+++ b/modules/interpro_n/main.nf
@@ -145,7 +145,7 @@ process PARSE_INTERPRO_N {
     // Merge matches for each full sequence
     def results = [:]
     resultsBySeq.each { seqId, chunks ->
-        chunks.sort { it.id }
+        chunks.sort { chunk -> chunk.id }
 
         // Collect all matched with global coordinates
         def allMatches = []
@@ -175,14 +175,14 @@ process PARSE_INTERPRO_N {
         }
 
         // Group by signature
-        def bySig = allMatches.groupBy {
-            def sig = it.signature
+        def bySig = allMatches.groupBy { match ->
+            def sig = match.signature
             def lib = sig.signatureLibraryRelease
             "${sig.accession}::${lib.library}::${lib.version}"
          }
 
         def merged = []
-        bySig.each { sigKey, matches ->
+        bySig.each { _key, matches ->
             // Sort by descending score, then ascending start
             matches.sort { a, b ->
                 def cmp = b.score <=> a.score
@@ -236,7 +236,7 @@ process PARSE_INTERPRO_N {
                 // transform to LocationFragment objects
                 def fragments = []
                 if (loc.fragments.size() > 1) {
-                    loc.fragments.sort { it.start }
+                    loc.fragments.sort { f -> f.start }
                     loc.fragments.eachWithIndex { f, i ->
                         def status
                         if (i == 0) {
@@ -270,7 +270,7 @@ process PARSE_INTERPRO_N {
 
 
 def mergeFragments(fragments) {
-    fragments.sort { it.start }.inject([]) { merged, current ->
+    fragments.sort { f -> f.start }.inject([]) { merged, current ->
         if (merged.isEmpty()) {
             merged << current.clone()
             return merged

--- a/modules/interpro_n/main.nf
+++ b/modules/interpro_n/main.nf
@@ -1,5 +1,6 @@
 process PREPARE_INTERPRO_N {
-    label    'mem_low', 'time_short'
+    label    'mem_low'
+    label    'time_short'
     executor 'local'
 
     input:
@@ -35,7 +36,8 @@ process PREPARE_INTERPRO_N {
 }
 
 process RUN_INTERPRO_N_CPU {
-    label     'mem_high', 'time_medium'
+    label     'mem_high'
+    label     'time_medium'
     container 'interpro/interpro-n:1.0'
 
     input:
@@ -61,7 +63,9 @@ process RUN_INTERPRO_N_CPU {
 }
 
 process RUN_INTERPRO_N_GPU {
-    label     'mem_high', 'time_short', 'use_gpu'
+    label     'mem_high'
+    label     'time_short'
+    label     'use_gpu'
     container 'interpro/interpro-n:1.0'
 
     input:
@@ -87,7 +91,8 @@ process RUN_INTERPRO_N_GPU {
 }
 
 process PARSE_INTERPRO_N {
-    label    'mem_low', 'time_short'
+    label    'mem_low'
+    label    'time_short'
     executor 'local'
 
     input:

--- a/modules/interpro_n/main.nf
+++ b/modules/interpro_n/main.nf
@@ -1,32 +1,3 @@
-// codenarc-disable AllowedDirectivesRule
-import groovy.json.JsonSlurper
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.FastaFile
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.LocationFragment
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-
-def MAX_LENGTH    = 2047  // Maximum sequence length
-def CHUNK_OVERLAP = 1000  // Number of overlapping residues between consecutive chunks
-def MATCH_OVERLAP = 0.25  // Fractional overlap threshold for merging matches
-def DATABASES = [         // Databases supported by InterPro-N
-    cathgene3d     : "CATH-Gene3D",
-    cdd            : "CDD",
-    hamap          : "HAMAP",
-    ncbifam        : "NCBIFAM",
-    panther        : "PANTHER",
-    pfam           : "Pfam",
-    pirsf          : "PIRSF",
-    prints         : "PRINTS",
-    prositeprofiles: "PROSITE profiles",
-    prositepatterns: "PROSITE patterns",
-    sfld           : "SFLD",
-    smart          : "SMART",
-    ssf            : "SUPERFAMILY",
-]
-
 process PREPARE_INTERPRO_N {
     label    'mem_low', 'time_short'
     executor 'local'
@@ -34,36 +5,33 @@ process PREPARE_INTERPRO_N {
     input:
     tuple val(meta), val(fasta)
     val batch_size    // max number of sequences in output fasta files
+    val max_length
+    val chunk_overlap
 
     output:
     tuple val(meta), path("sequences_*.tsv", arity: '1..*')
 
     exec:
-    def sequences = FastaFile.chunkSequences(fasta, MAX_LENGTH, CHUNK_OVERLAP)
+    def sequences = uk.ac.ebi.interpro.FastaFile.chunkSequences(fasta, max_length, chunk_overlap)
     def fileIndex = 1
     def seqCount = 0
-    def writer = null
-    def openNewFile = {
-        if (writer) writer.close()
-        writer = task.workDir.resolve("sequences_${fileIndex}.tsv").newWriter("UTF-8")
-        writer.writeLine("accession\tsequence")
-        fileIndex++
-        seqCount = 0
-        return writer
-    }
-
-    writer = openNewFile()
+    def writer = task.workDir.resolve("sequences_${fileIndex}.tsv").newWriter("UTF-8")
+    writer.writeLine("accession\tsequence")
     sequences.each { seq ->
         if (batch_size > 0 && seqCount >= batch_size) {
-            writer = openNewFile()
+            writer.close()
+            fileIndex += 1
+            seqCount = 0
+            writer = task.workDir.resolve("sequences_${fileIndex}.tsv").newWriter("UTF-8")
+            writer.writeLine("accession\tsequence")
         }
         seq.chunks.eachWithIndex { chunk, idx ->
             writer.writeLine("${seq.id}_${idx + 1}\t${chunk}")
-            seqCount++
+            seqCount += 1
         }
     }
 
-    if (writer) writer.close()
+    writer.close()
 }
 
 process RUN_INTERPRO_N_CPU {
@@ -125,27 +93,43 @@ process PARSE_INTERPRO_N {
     input:
     tuple val(meta), val(json_files)
     val applications
+    val max_length
+    val chunk_overlap
+    val match_overlap
 
     output:
     tuple val(meta), path("interpro-n.json")
 
     exec:
+    def supported_databases = [
+        cathgene3d     : "CATH-Gene3D",
+        cdd            : "CDD",
+        hamap          : "HAMAP",
+        ncbifam        : "NCBIFAM",
+        panther        : "PANTHER",
+        pfam           : "Pfam",
+        pirsf          : "PIRSF",
+        prints         : "PRINTS",
+        prositeprofiles: "PROSITE profiles",
+        prositepatterns: "PROSITE patterns",
+        sfld           : "SFLD",
+        smart          : "SMART",
+        ssf            : "SUPERFAMILY",
+    ]
+
     // User-requested applications
     def requested = applications.collect { name ->
-        switch(name) {
-            case "superfamily": return "ssf"
-            default           : return name
-        }
+        return name == "superfamily" ? "ssf" : name
     } as Set
 
     // Compute overlap
-    def overlappingApps = DATABASES.keySet().intersect(requested)
+    def overlappingApps = supported_databases.keySet().intersect(requested)
 
     // If none overlap, fallback to all supported applications
-    def selectedApps = overlappingApps ?: DATABASES.keySet()
+    def selectedApps = overlappingApps ?: supported_databases.keySet()
 
     // Parse all JSON files and group by sequence ID
-    def jsonSlurper = new JsonSlurper()
+    def jsonSlurper = new groovy.json.JsonSlurper()
     def resultsBySeq = [:].withDefault { [] }
     json_files.each { jsonFile ->
         def data = jsonSlurper.parse(jsonFile)
@@ -166,12 +150,12 @@ process PARSE_INTERPRO_N {
         // Collect all matched with global coordinates
         def allMatches = []
         chunks.each { chunk ->
-            def offset = chunk.id * (MAX_LENGTH - CHUNK_OVERLAP)
+            def offset = chunk.id * (max_length - chunk_overlap)
             chunk.matches.each { match ->
                 def sigLib = match.signature.signatureLibraryRelease
                 def sigLibName = sigLib.library.toLowerCase().replaceAll(/[-\s]/, "")
                 if (sigLibName in selectedApps) {
-                    sigLib.library = DATABASES[sigLibName]
+                    sigLib.library = supported_databases[sigLibName]
                 } else {
                     return
                 }
@@ -201,35 +185,29 @@ process PARSE_INTERPRO_N {
         bySig.each { sigKey, matches ->
             // Sort by descending score, then ascending start
             matches.sort { a, b ->
-                int cmp = b.score <=> a.score
+                def cmp = b.score <=> a.score
                 (cmp != 0) ? cmp : (a.start <=> b.start)
             }
 
             def locations = []
             matches.each { match ->
-                boolean isMerged = false
-
-                for (other in locations) {
+                def matchLen = match.end - match.start + 1
+                def mergedLoc = locations.find { other ->
                     def overlapStart = Math.max(other.start, match.start)
                     def overlapEnd = Math.min(other.end, match.end)
                     def overlapLength = overlapEnd - overlapStart + 1
-                    if (overlapLength <= 0) continue
+                    if (overlapLength <= 0) return false
 
-                    def lenA = other.end - other.start + 1
-                    def lenB = match.end - match.start + 1
-                    def fracA = overlapLength / lenA
-                    def fracB = overlapLength / lenB
-
-                    if (fracA >= MATCH_OVERLAP || fracB >= MATCH_OVERLAP) {
-                        other.start = Math.min(other.start, match.start)
-                        other.end = Math.max(other.end, match.end)
-                        other.fragments.addAll(match.fragments)
-                        other.fragments = mergeFragments(other.fragments)
-                        isMerged = true
-                        break
-                    }
+                    def otherLen = other.end - other.start + 1
+                    overlapLength >= (match_overlap * otherLen) || overlapLength >= (match_overlap * matchLen)
                 }
-                if (!isMerged) {
+
+                if (mergedLoc) {
+                    mergedLoc.start = Math.min(mergedLoc.start, match.start)
+                    mergedLoc.end = Math.max(mergedLoc.end, match.end)
+                    mergedLoc.fragments.addAll(match.fragments)
+                    mergedLoc.fragments = mergeFragments(mergedLoc.fragments)
+                } else {
                     match.fragments = mergeFragments(match.fragments)
                     locations << match
                 }
@@ -248,19 +226,19 @@ process PARSE_INTERPRO_N {
             def sigLib = sig.signatureLibraryRelease
             def accession = sig.accession
 
-            SignatureLibraryRelease library = new SignatureLibraryRelease(sigLib.library, sigLib.version)
-            Signature signature = new Signature(accession, library)
-            Match match = new Match(accession, signature)
+            def library = new uk.ac.ebi.interpro.SignatureLibraryRelease(sigLib.library, sigLib.version)
+            def signature = new uk.ac.ebi.interpro.Signature(accession, library)
+            def match = new uk.ac.ebi.interpro.Match(accession, signature)
             // Override source set in Match constructor
             match.source = "InterPro-N"
 
             rawMatch.locations.each { loc ->
                 // transform to LocationFragment objects
-                List<LocationFragment> fragments = []
+                def fragments = []
                 if (loc.fragments.size() > 1) {
                     loc.fragments.sort { it.start }
                     loc.fragments.eachWithIndex { f, i ->
-                        String status
+                        def status
                         if (i == 0) {
                             status = "C_TERMINAL_DISC"
                         } else if (i + 1 < loc.fragments.size()) {
@@ -268,15 +246,15 @@ process PARSE_INTERPRO_N {
                         } else {
                             status = "N_TERMINAL_DISC"
                         }
-                        fragments << new LocationFragment(f.start, f.end, status)
+                        fragments << new uk.ac.ebi.interpro.LocationFragment(f.start, f.end, status)
                     }
                 } else {
                     def f = loc.fragments[0]
-                    fragments << new LocationFragment(f.start, f.end, "CONTINUOUS")
+                    fragments << new uk.ac.ebi.interpro.LocationFragment(f.start, f.end, "CONTINUOUS")
                 }
 
                 match.addLocation(
-                    new Location(loc.start, loc.end, loc.score, fragments)
+                    new uk.ac.ebi.interpro.Location(loc.start, loc.end, loc.score, fragments)
                 )
             }
 
@@ -287,21 +265,25 @@ process PARSE_INTERPRO_N {
     }
 
     def filepath = task.workDir.resolve("interpro-n.json")
-    filepath.text = JsonOutput.toJson(results)
+    filepath.text = groovy.json.JsonOutput.toJson(results)
 }
 
 
 def mergeFragments(fragments) {
-    def sorted = fragments.sort { it.start }
-    def merged = [sorted[0].clone()]
-    for (int i = 1; i < sorted.size(); i++) {
-        def current = sorted[i]
+    fragments.sort { it.start }.inject([]) { merged, current ->
+        if (merged.isEmpty()) {
+            merged << current.clone()
+            return merged
+        }
+
         def last = merged[-1]
         if (current.start <= last.end + 1) {
-            last.end = Math.max(last.end, current.end)
+            if (current.end > last.end) {
+                last.end = current.end
+            }
         } else {
             merged << current.clone()
         }
+        merged
     }
-    return merged
 }

--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -1,18 +1,9 @@
-import com.fasterxml.jackson.core.JsonFactory
-import com.fasterxml.jackson.databind.ObjectMapper
-import groovy.json.JsonOutput
-import groovy.json.JsonSlurper
-import java.net.URL
-import uk.ac.ebi.interpro.FastaFile
-import uk.ac.ebi.interpro.HTTPRequest
-
-
 def check_matches_api(applications, api_url, version) {
-    appls_in_api     = []
-    appls_not_in_api = []
-    def sanitized_url = HTTPRequest.sanitizeURL(api_url)
+    def appls_in_api     = []
+    def appls_not_in_api = []
+    def sanitized_url = uk.ac.ebi.interpro.HTTPRequest.sanitizeURL(api_url)
     def url = "${sanitized_url}/info".toString()
-    def info = HTTPRequest.fetch(url, null, 0)
+    def info = uk.ac.ebi.interpro.HTTPRequest.fetch(url, null, 0)
     if (info) {
         def api_version = info.api ?: "X.Y.Z"
         def major_version = api_version.split("\\.")[0]
@@ -66,15 +57,15 @@ process GET_MATCHES {
     exec:
     def matches = [:]
     def fasta_sb = new StringBuilder()
-    def sequences = FastaFile.parse(fasta)  // [md5: sequence]
+    def sequences = uk.ac.ebi.interpro.FastaFile.parse(fasta)  // [md5: sequence]
     def md5s = sequences.keySet().toList().sort()
     def request_chunk_size = chunk_size > 100 ? 100 : chunk_size // API set max to 100
     def chunks = md5s.collate(request_chunk_size)
-    def base_url = HTTPRequest.sanitizeURL(api_url.toString())
+    def base_url = uk.ac.ebi.interpro.HTTPRequest.sanitizeURL(api_url.toString())
     def response = null
     def success = chunks.every { chunk ->
-        def data = JsonOutput.toJson([md5: chunk])
-        response = HTTPRequest.fetch("${base_url}/matches", data, max_retries, true)
+        def data = groovy.json.JsonOutput.toJson([md5: chunk])
+        response = uk.ac.ebi.interpro.HTTPRequest.fetch("${base_url}/matches", data, max_retries, true)
         if (response == null) {
             return false
         }
@@ -104,10 +95,10 @@ process GET_MATCHES {
     def fasta_file = task.workDir.resolve("unknown.fasta")
 
     if (success) {
-        def jf = new JsonFactory()
+        def jf = new com.fasterxml.jackson.core.JsonFactory()
         json_file.withWriter { writer ->
             def gen = jf.createGenerator(writer)
-            new ObjectMapper().writeValue(gen, matches)
+            new com.fasterxml.jackson.databind.ObjectMapper().writeValue(gen, matches)
             gen.close()
         }
         if (fasta_sb.length() != 0) {
@@ -115,28 +106,25 @@ process GET_MATCHES {
         }
     } else {
         log.warn "An error occurred while querying the Matches API -- '${response}'"
-        json_file.text = JsonOutput.toJson([:])
+        json_file.text = groovy.json.JsonOutput.toJson([:])
         fasta_file.text = fasta.text
     }
 }
 
 def Map transformMatch(Map match, String seq) {
-    // * operator - spread contents of a map or collecion into another map or collection
-    return [
-        *                : match,
-        "modelAccession" : match["model-ac"],
-        "treegrafter"    : ["ancestralNodeID": match["ancestralNode"]],
-        "locations"      : match["locations"].collect { loc ->
-            return [
-                *                 : loc,
-                "sequenceFeature" : loc["sequence-feature"],
-                "hmmBounds"       : loc["hmmBounds"] ? getReverseHmmBounds(loc["hmmBounds"]) : null,
-                "fragments"       : loc["location-fragments"].collect { tranformFragment(it) },
-                "sites"           : loc["sites"] ?: [],
-                "targetAlignment" : loc["cigarAlignment"] ? decodeAlignment(loc["cigarAlignment"], seq, loc["start"]) : null
-            ]
-        },
-    ]
+    def transformedMatch = match.clone()
+    transformedMatch["modelAccession"] = match["model-ac"]
+    transformedMatch["treegrafter"] = ["ancestralNodeID": match["ancestralNode"]]
+    transformedMatch["locations"] = match["locations"].collect { loc ->
+        def transformedLocation = loc.clone()
+        transformedLocation["sequenceFeature"] = loc["sequence-feature"]
+        transformedLocation["hmmBounds"] = loc["hmmBounds"] ? getReverseHmmBounds(loc["hmmBounds"]) : null
+        transformedLocation["fragments"] = loc["location-fragments"].collect { tranformFragment(it) }
+        transformedLocation["sites"] = loc["sites"] ?: []
+        transformedLocation["targetAlignment"] = loc["cigarAlignment"] ? decodeAlignment(loc["cigarAlignment"], seq, loc["start"]) : null
+        return transformedLocation
+    }
+    return transformedMatch
 }
 
 def getReverseHmmBounds(hmmBounds) {
@@ -155,22 +143,16 @@ def decodeAlignment(cigarAlignment, sequence, startIndex) {
     matcher.each { match ->
         def len = match[1].toInteger()
         def op = match[2]
-        switch(op) {
-            case 'M':
-            case '=':
-            case 'X':
-                targetAlign << sequence.substring(index, index + len)
-                index += len
-                break
-            case 'I':
-                targetAlign << sequence.substring(index, index + len).toLowerCase()
-                index += len
-                break
-            case 'D':
-                targetAlign << '-' * len
-                break
-            default:
-                throw new IllegalArgumentException("Unsupported CIGAR operation: $op")
+        if (op == 'M' || op == '=' || op == 'X') {
+            targetAlign << sequence.substring(index, index + len)
+            index += len
+        } else if (op == 'I') {
+            targetAlign << sequence.substring(index, index + len).toLowerCase()
+            index += len
+        } else if (op == 'D') {
+            targetAlign << '-' * len
+        } else {
+            throw new IllegalArgumentException("Unsupported CIGAR operation: $op")
         }
     }
     return targetAlign.toString()

--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -39,7 +39,8 @@ def check_matches_api(applications, api_url, _version) {
 
 process GET_MATCHES {
     maxForks 1
-    label    'mem_low', 'time_short'
+    label    'mem_low'
+    label    'time_short'
     executor 'local'
 
     input:

--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -110,7 +110,7 @@ process GET_MATCHES {
     }
 }
 
-def Map transformMatch(Map match, String seq) {
+def Map transformMatch(match, seq) {
     def transformedMatch = match.clone()
     transformedMatch["modelAccession"] = match["model-ac"]
     transformedMatch["treegrafter"] = ["ancestralNodeID": match["ancestralNode"]]

--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -110,7 +110,7 @@ process GET_MATCHES {
     }
 }
 
-def Map transformMatch(match, seq) {
+def transformMatch(match, seq) {
     def transformedMatch = match.clone()
     transformedMatch["modelAccession"] = match["model-ac"]
     transformedMatch["treegrafter"] = ["ancestralNodeID": match["ancestralNode"]]
@@ -157,7 +157,7 @@ def decodeAlignment(cigarAlignment, sequence, startIndex) {
     return targetAlign.toString()
 }
 
-def Map tranformFragment(Map fragment) {
+def tranformFragment(fragment) {
     return [
         "start"   : fragment["start"],
         "end"     : fragment["end"],

--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -1,4 +1,4 @@
-def check_matches_api(applications, api_url, version) {
+def check_matches_api(applications, api_url, _version) {
     def appls_in_api     = []
     def appls_not_in_api = []
     def sanitized_url = uk.ac.ebi.interpro.HTTPRequest.sanitizeURL(api_url)
@@ -10,7 +10,6 @@ def check_matches_api(applications, api_url, version) {
         if (major_version != "0") {
             log.warn "This version of InterProScan is not compatible with the Matches API at ${sanitized_url}; pre-calculated annotations will not be retrieved."
         } else {
-            def api_interpro_version = info.release
             if (info.analyses) {
                 def all_appls_in_api = info.analyses*.name.collect { n -> 
                     n.toLowerCase().replaceAll("[-\\s]", "") 
@@ -70,11 +69,11 @@ process GET_MATCHES {
             return false
         }
 
-        response.results.each {
-            def seq_md5 = it.md5.toUpperCase()
-            if (it.found) {
+        response.results.each { item ->
+            def seq_md5 = item.md5.toUpperCase()
+            if (item.found) {
                 matches[seq_md5] = [:]
-                it.matches.each { match ->
+                item.matches.each { match ->
                     def library = match.signature.signatureLibraryRelease.library
                     def app_name = library.toLowerCase().replaceAll("[-\\s]", "")
                     if (applications.contains(app_name)) {
@@ -119,7 +118,7 @@ def Map transformMatch(Map match, String seq) {
         def transformedLocation = loc.clone()
         transformedLocation["sequenceFeature"] = loc["sequence-feature"]
         transformedLocation["hmmBounds"] = loc["hmmBounds"] ? getReverseHmmBounds(loc["hmmBounds"]) : null
-        transformedLocation["fragments"] = loc["location-fragments"].collect { tranformFragment(it) }
+        transformedLocation["fragments"] = loc["location-fragments"].collect { f -> tranformFragment(f) }
         transformedLocation["sites"] = loc["sites"] ?: []
         transformedLocation["targetAlignment"] = loc["cigarAlignment"] ? decodeAlignment(loc["cigarAlignment"], seq, loc["start"]) : null
         return transformedLocation

--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -111,11 +111,11 @@ process GET_MATCHES {
 }
 
 def transformMatch(match, seq) {
-    def transformedMatch = match.clone()
+    def transformedMatch = [:] + match
     transformedMatch["modelAccession"] = match["model-ac"]
     transformedMatch["treegrafter"] = ["ancestralNodeID": match["ancestralNode"]]
     transformedMatch["locations"] = match["locations"].collect { loc ->
-        def transformedLocation = loc.clone()
+        def transformedLocation = [:] + loc
         transformedLocation["sequenceFeature"] = loc["sequence-feature"]
         transformedLocation["hmmBounds"] = loc["hmmBounds"] ? getReverseHmmBounds(loc["hmmBounds"]) : null
         transformedLocation["fragments"] = loc["location-fragments"].collect { f -> tranformFragment(f) }

--- a/modules/mobidblite/main.nf
+++ b/modules/mobidblite/main.nf
@@ -1,5 +1,7 @@
 process RUN_MOBIDBLITE {
-    label     'mem_min', 'time_veryshort', 'dynamic'
+    label     'mem_min'
+    label     'time_veryshort'
+    label     'dynamic'
     container 'interpro/idrpred:1.0.3'
 
     input:
@@ -16,7 +18,8 @@ process RUN_MOBIDBLITE {
 
 
 process PARSE_MOBIDBLITE {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/mobidblite/main.nf
+++ b/modules/mobidblite/main.nf
@@ -1,9 +1,3 @@
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-
 process RUN_MOBIDBLITE {
     label     'mem_min', 'time_veryshort', 'dynamic'
     container 'interpro/idrpred:1.0.3'
@@ -45,16 +39,16 @@ process PARSE_MOBIDBLITE {
         if (matches.containsKey(sequenceId)) {
             match = matches[sequenceId]["mobidb-lite"]
         } else {
-            def library = new SignatureLibraryRelease("MobiDB-lite", "4.0")
-            def signature = new Signature("mobidb-lite", "disorder_prediction", "consensus disorder prediction", library, null)
-            match = new Match("mobidb-lite", signature)
+            def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("MobiDB-lite", "4.0")
+            def signature = new uk.ac.ebi.interpro.Signature("mobidb-lite", "disorder_prediction", "consensus disorder prediction", library, null)
+            match = new uk.ac.ebi.interpro.Match("mobidb-lite", signature)
             matches[sequenceId] = [:]
             matches[sequenceId]["mobidb-lite"] = match
         }
 
-        match.addLocation(new Location(start, end, feature))
+        match.addLocation(new uk.ac.ebi.interpro.Location(start, end, feature))
     }
 
     def filepath = task.workDir.resolve("mobidblite.json")
-    filepath.text = JsonOutput.toJson(matches)
+    filepath.text = groovy.json.JsonOutput.toJson(matches)
 }

--- a/modules/ncbifam/main.nf
+++ b/modules/ncbifam/main.nf
@@ -1,6 +1,3 @@
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.HMMER3
-
 process PARSE_NCBIFAM {
     label    'mem_low', 'time_veryshort'
     executor 'local'
@@ -12,7 +9,7 @@ process PARSE_NCBIFAM {
     tuple val(meta), path("ncbifam.json")
 
     exec:
-    def hmmer_matches = HMMER3.parseOutput(hmmseach_out, "NCBIFAM")
+    def hmmer_matches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmseach_out, "NCBIFAM")
     hmmer_matches = hmmer_matches.collectEntries { seqId, matches ->
         [seqId, matches.collectEntries { modelAccession, match ->
             def updatedModelAccession = modelAccession.split("\\.")[0]
@@ -23,5 +20,5 @@ process PARSE_NCBIFAM {
     }
 
     def filepath = task.workDir.resolve("ncbifam.json")
-    filepath.text = JsonOutput.toJson(hmmer_matches)
+    filepath.text = groovy.json.JsonOutput.toJson(hmmer_matches)
 }

--- a/modules/ncbifam/main.nf
+++ b/modules/ncbifam/main.nf
@@ -1,5 +1,6 @@
 process PARSE_NCBIFAM {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/no_matches/main.nf
+++ b/modules/no_matches/main.nf
@@ -1,7 +1,3 @@
-import com.fasterxml.jackson.databind.ObjectMapper
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.FastaFile
-
 process REPORT_NO_MATCHES {
     label    'mem_low', 'time_veryshort'
     executor 'local'
@@ -16,14 +12,14 @@ process REPORT_NO_MATCHES {
     def seqs_with_matches = [] as Set
     jsons.each { json ->
         def matches = json.newReader().withCloseable { reader ->
-            new ObjectMapper().readValue(reader, Map)
+            new com.fasterxml.jackson.databind.ObjectMapper().readValue(reader, Map)
         }
         matches.each { seq_md5, seq_matches ->
             seqs_with_matches.add(seq_md5)
         }
     }
 
-    def sequences = FastaFile.parse(fasta)
+    def sequences = uk.ac.ebi.interpro.FastaFile.parse(fasta)
     def no_matches = [:]
     sequences.each { seq_md5, sequence ->
         if (!seqs_with_matches.contains(seq_md5)) {
@@ -31,5 +27,5 @@ process REPORT_NO_MATCHES {
         }
     }
     def filepath = task.workDir.resolve("no_matches.json")
-    filepath.text = JsonOutput.toJson(no_matches)
+    filepath.text = groovy.json.JsonOutput.toJson(no_matches)
 }

--- a/modules/no_matches/main.nf
+++ b/modules/no_matches/main.nf
@@ -1,5 +1,6 @@
 process REPORT_NO_MATCHES {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/no_matches/main.nf
+++ b/modules/no_matches/main.nf
@@ -14,14 +14,14 @@ process REPORT_NO_MATCHES {
         def matches = json.newReader().withCloseable { reader ->
             new com.fasterxml.jackson.databind.ObjectMapper().readValue(reader, Map)
         }
-        matches.each { seq_md5, seq_matches ->
+        matches.each { seq_md5, _seq_matches ->
             seqs_with_matches.add(seq_md5)
         }
     }
 
     def sequences = uk.ac.ebi.interpro.FastaFile.parse(fasta)
     def no_matches = [:]
-    sequences.each { seq_md5, sequence ->
+    sequences.each { seq_md5, _sequence ->
         if (!seqs_with_matches.contains(seq_md5)) {
             no_matches[seq_md5] = [:]
         }

--- a/modules/panther/main.nf
+++ b/modules/panther/main.nf
@@ -1,5 +1,7 @@
 process SEARCH_PANTHER {
-    label     'mem_low', 'time_short', 'dynamic'
+    label     'mem_low'
+    label     'time_short'
+    label     'dynamic'
     container 'interpro/panther:1.0'
 
     input:
@@ -19,7 +21,8 @@ process SEARCH_PANTHER {
 }
 
 process PREPARE_TREEGRAFTER {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:
@@ -68,7 +71,9 @@ process PREPARE_TREEGRAFTER {
 
 
 process RUN_TREEGRAFTER {
-    label     'mem_medium', 'time_short', 'dynamic'
+    label     'mem_medium'
+    label     'time_short'
+    label     'dynamic'
     container 'interpro/panther:1.0'
     
     input:
@@ -85,7 +90,8 @@ process RUN_TREEGRAFTER {
 }
 
 process PARSE_PANTHER {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/panther/main.nf
+++ b/modules/panther/main.nf
@@ -1,15 +1,3 @@
-import groovy.json.JsonOutput
-import groovy.json.JsonSlurper
-import java.nio.file.Files
-import java.nio.file.Path
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
-import uk.ac.ebi.interpro.FastaFile
-import uk.ac.ebi.interpro.HMMER3
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.TreeGrafter
-
 process SEARCH_PANTHER {
     label     'mem_low', 'time_short', 'dynamic'
     container 'interpro/panther:1.0'
@@ -41,7 +29,7 @@ process PREPARE_TREEGRAFTER {
     tuple val(meta), val(meta2), path("panther.json")
     
     exec:
-    def hmmer_matches = HMMER3.parseOutput(hmmseach_out, "PANTHER")
+    def hmmer_matches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmseach_out, "PANTHER")
 
     hmmer_matches = hmmer_matches.collectEntries { seqId, matches ->
         // Filter matches to only those with locations that have a score > 100
@@ -60,12 +48,12 @@ process PREPARE_TREEGRAFTER {
                 // Rename model accession (PTHR23076.orig.30.pir -> PTHR23076)
                 def familyId = (m1.modelAccession =~ /^(PTHR\d+)/)[0][1]
                 m1.signature.accession = familyId
-                def m2 = new Match(familyId, m1.evalue, m1.score, m1.bias, m1.signature)
+                def m2 = new uk.ac.ebi.interpro.Match(familyId, m1.evalue, m1.score, m1.bias, m1.signature)
                 m2.included = m1.included
                 // Only keep the domain with the highest score
                 m2.locations = [locations.max { it.score }]
                 // Init empty TreeGrafter attribute
-                m2.treegrafter = new TreeGrafter(null)
+                m2.treegrafter = new uk.ac.ebi.interpro.TreeGrafter(null)
                 return m2
             }
             .findAll { it != null }
@@ -75,7 +63,7 @@ process PREPARE_TREEGRAFTER {
     }
 
     def jsonFile = task.workDir.resolve("panther.json")
-    jsonFile.text = JsonOutput.toJson(hmmer_matches)
+    jsonFile.text = groovy.json.JsonOutput.toJson(hmmer_matches)
 }
 
 
@@ -107,9 +95,9 @@ process PARSE_PANTHER {
     tuple val(meta), val(meta2), path("panther.json")
 
     exec:
-    def matches = new JsonSlurper().parse(hmmseach_json).collectEntries { seqId, jsonMatches ->
+    def matches = new groovy.json.JsonSlurper().parse(hmmseach_json).collectEntries { seqId, jsonMatches ->
         [(seqId): jsonMatches.collectEntries { matchId, jsonMatch ->
-            [(matchId): Match.fromMap(jsonMatch)]
+            [(matchId): uk.ac.ebi.interpro.Match.fromMap(jsonMatch)]
         }]
     }
 
@@ -123,9 +111,9 @@ process PARSE_PANTHER {
         
         def match = matches[seqId]?.get(familyId)
         assert match != null
-        match.treegrafter = new TreeGrafter(nodeId)
+        match.treegrafter = new uk.ac.ebi.interpro.TreeGrafter(nodeId)
     }
 
     def filepath = task.workDir.resolve("panther.json")
-    filepath.text = JsonOutput.toJson(matches)
+    filepath.text = groovy.json.JsonOutput.toJson(matches)
 }

--- a/modules/panther/main.nf
+++ b/modules/panther/main.nf
@@ -40,7 +40,7 @@ process PREPARE_TREEGRAFTER {
                     return null
                 }
 
-                def locations = m1.locations.findAll { it.included }
+                def locations = m1.locations.findAll { loc -> loc.included }
                 if (!locations) {
                     return null
                 }
@@ -51,14 +51,14 @@ process PREPARE_TREEGRAFTER {
                 def m2 = new uk.ac.ebi.interpro.Match(familyId, m1.evalue, m1.score, m1.bias, m1.signature)
                 m2.included = m1.included
                 // Only keep the domain with the highest score
-                m2.locations = [locations.max { it.score }]
+                m2.locations = [locations.max { loc -> loc.score }]
                 // Init empty TreeGrafter attribute
                 m2.treegrafter = new uk.ac.ebi.interpro.TreeGrafter(null)
                 return m2
             }
-            .findAll { it != null }
+            .findAll { m -> m != null }
 
-        def bestMatch = filteredMatches.max { it.score }
+        def bestMatch = filteredMatches.max { m -> m.score }
         return bestMatch ? [(seqId): [(bestMatch.modelAccession): bestMatch]] : [:]
     }
 

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -1,6 +1,7 @@
 // codenarc-disable AllowedDirectivesRule
 process PARSE_PFAM {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -22,7 +22,7 @@ process PARSE_PFAM {
     filepath.text = groovy.json.JsonOutput.toJson(processed_matches)
 }
 
-def stockholmDatParser(Path pfamADatFile) {
+def stockholmDatParser(pfamADatFile) {
     /* Retrieve nested models and clan classifications.
     E.g. [ PF00026:[nested:[PF03489, PF05184], clan:CL0129], PF06826:[clan:CL0064, nested:[]] ]
     */
@@ -65,7 +65,7 @@ def stockholmDatParser(Path pfamADatFile) {
     return parsedDat
 }
 
-def decode(byte[] b) {
+def decode(b) {
     try {
         return new String(b, "UTF-8").trim()
     } catch (Exception _e) {

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -1,9 +1,4 @@
 // codenarc-disable AllowedDirectivesRule
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.HMMER3
-import uk.ac.ebi.interpro.LocationFragment
-import uk.ac.ebi.interpro.Match
-
 process PARSE_PFAM {
     label    'mem_low', 'time_veryshort'
     executor 'local'
@@ -17,24 +12,24 @@ process PARSE_PFAM {
 
     exec:
     def min_length = 8  // minimum length of a fragment
-    def hmmer_matches = HMMER3.parseOutput(hmmsearch_out, "Pfam")
+    def hmmer_matches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmsearch_out, "Pfam")
     def dat = stockholmDatParser(datfile)  // [modelAcc: [clan: str, nested: [str]]]
 
     def filtered_matches = filterMatches(hmmer_matches, dat, min_length)
     def processed_matches = buildFragments(filtered_matches, dat)
 
     def filepath = task.workDir.resolve("pfam.json")
-    filepath.text = JsonOutput.toJson(processed_matches)
+    filepath.text = groovy.json.JsonOutput.toJson(processed_matches)
 }
 
 def stockholmDatParser(Path pfamADatFile) {
     /* Retrieve nested models and clan classifications.
     E.g. [ PF00026:[nested:[PF03489, PF05184], clan:CL0129], PF06826:[clan:CL0064, nested:[]] ]
     */
-    Map<String, String> name2acc = [:]
-    Map<String, List<String>> parsedDat = [:]
-    String name = null
-    String accession = null
+    def name2acc = [:]
+    def parsedDat = [:]
+    def name = null
+    def accession = null
     pfamADatFile.eachLine { rawLine ->
         def line = decode(rawLine.bytes)
         if (line.startsWith("#=GF ID")) {
@@ -43,10 +38,20 @@ def stockholmDatParser(Path pfamADatFile) {
             accession = line.split()[2].split("\\.")[0]
             name2acc[name] = accession
         } else if (line.startsWith("#=GF NE")) {
-            String nestedAcc = line.split()[2]
-            parsedDat[accession]?.nested?.add(nestedAcc) ?: (parsedDat[accession] = [nested: [nestedAcc]])
+            def nestedAcc = line.split()[2]
+            def family = parsedDat[accession]
+            if (family == null) {
+                parsedDat[accession] = [nested: [nestedAcc]]
+            } else {
+                def nested = family.nested
+                if (nested == null) {
+                    nested = []
+                    family.nested = nested
+                }
+                nested.add(nestedAcc)
+            }
         } else if (line.startsWith("#=GF CL")) {
-            String claAcc = line.split()[2]
+            def claAcc = line.split()[2]
             parsedDat.computeIfAbsent(accession, { [clan: claAcc] }).clan = claAcc
         }
     }
@@ -68,18 +73,16 @@ def decode(byte[] b) {
     }
 }
 
-def filterMatches(Map<String, Map<String, Match>> hmmerMatches, 
-                  Map<String, Map<String, Object>> dat,
-                  int minLength) {
+def filterMatches(hmmerMatches, dat, minLength) {
     /*
         Remove overlapping matches, only keeping the one with the best e-value or score.
         Pfam matches are not supposed to overlap, but some families can be evolutionary related,
         especially those belonging to the same clan, so curators can whitelist overlaps using the
         NE (nested) flag.
     */
-    Map<String, List<Match>> filteredMatches = [:]
+    def filteredMatches = [:]
     hmmerMatches.each { seqId, matches ->
-        List<Match> allMatches = flattenMatchLocations(matches).findAll{ m ->
+        def allMatches = flattenMatchLocations(matches).findAll{ m ->
             m.locations[0].end - m.locations[0].start + 1 >= minLength 
         }
 
@@ -94,14 +97,14 @@ def filterMatches(Map<String, Map<String, Match>> hmmerMatches,
 
         filteredMatches[seqId] = []
         allMatches.each { match ->
-            boolean keep = true
+            def keep = true
 
-            Map<String, List<String>> candidateFamily = dat[match.modelAccession] ?: [:]
-            List<String> candidateNested = candidateFamily?.nested ?: []
+            def candidateFamily = dat[match.modelAccession] ?: [:]
+            def candidateNested = candidateFamily?.nested ?: []
 
             // Compare the current match with matches already accepted
             filteredMatches[seqId].each { filteredMatch ->
-                boolean overlapped = isOverlapping(
+                def overlapped = isOverlapping(
                         match.locations[0].start, 
                         match.locations[0].end,
                         filteredMatch.locations[0].start, 
@@ -111,12 +114,12 @@ def filterMatches(Map<String, Map<String, Match>> hmmerMatches,
                 if (overlapped) {
                     // Matches are overlapping
 
-                    Map<String, List<String>> filteredFamily = dat[filteredMatch.modelAccession] ?: [:]
-                    List<String> filteredNested = filteredFamily?.nested ?: []
+                    def filteredFamily = dat[filteredMatch.modelAccession] ?: [:]
+                    def filteredNested = filteredFamily?.nested ?: []
 
-                    boolean canBeNested = (candidateNested.contains(filteredMatch.modelAccession)
+                    def canBeNested = (candidateNested.contains(filteredMatch.modelAccession)
                                            || filteredNested.contains(match.modelAccession))
-                    boolean fullyEnclosed = isFullyEnclosed(
+                    def fullyEnclosed = isFullyEnclosed(
                             match.locations[0].start,
                             match.locations[0].end,
                             filteredMatch.locations[0].start,
@@ -142,7 +145,7 @@ def flattenMatchLocations(matches) {
     matches.collectMany { modelAccession, match ->
         modelAccession = modelAccession.split("\\.")[0]
         match.locations.collect { location ->
-            Match matchInfo = new Match(
+            def matchInfo = new uk.ac.ebi.interpro.Match(
                     modelAccession,
                     match.evalue,
                     match.score,
@@ -165,23 +168,22 @@ def isFullyEnclosed(location1Start, location1End, location2Start, location2End) 
            || (location2Start <= location1Start && location2End >= location1End)
 }
 
-def buildFragments(Map<String, Map<String, Match>> filteredMatches,
-                   Map<String, Map<String, Object>> dat) {
-    Map<String, Map<String, Match>> processedMatches = [:]
-    filteredMatches.each { String seqId, List<Match> matches ->
+def buildFragments(filteredMatches, dat) {
+    def processedMatches = [:]
+    filteredMatches.each { seqId, matches ->
         def aggregatedMatches = [:]
-        matches.each { Match match ->
+        matches.each { match ->
             // We flattened matches and locations so one location only per match here
             def location = match.locations[0]
 
-            List<String> nestedModels = dat[match.modelAccession]?.nested ?: []
+            def nestedModels = dat[match.modelAccession]?.nested ?: []
             if (nestedModels) {
                 /*
                     Find all locations belonging to matches that:
                     - overlap the current location
                     - belong to models that can be nested within the model of the current match
                 */
-                List<Map<String, Integer>> overlappingLocations = matches
+                def overlappingLocations = matches
                     .findAll { otherMatch ->
                         otherMatch.modelAccession in nestedModels 
                         && isFullyEnclosed(
@@ -199,20 +201,20 @@ def buildFragments(Map<String, Map<String, Match>> filteredMatches,
                 overlappingLocations.sort { a, b -> a.start <=> b.start ?: a.end <=> b.end }
 
                 def fragments = []
-                int start = location.start
+                def start = location.start
 
                 overlappingLocations.each { otherLocation ->
                     if (otherLocation.start > start && otherLocation.end < location.end) {
-                        String status = fragments.isEmpty() ? "C_TERMINAL_DISC" : "NC_TERMINAL_DISC"
-                        fragments.add(new LocationFragment(start, otherLocation.start - 1, status))
+                        def status = fragments.isEmpty() ? "C_TERMINAL_DISC" : "NC_TERMINAL_DISC"
+                        fragments.add(new uk.ac.ebi.interpro.LocationFragment(start, otherLocation.start - 1, status))
                         start = otherLocation.end + 1
                     }
                 }
 
                 if (fragments) {
-                    fragments.add(new LocationFragment(start, location.end, "N_TERMINAL_DISC"))
+                    fragments.add(new uk.ac.ebi.interpro.LocationFragment(start, location.end, "N_TERMINAL_DISC"))
                 } else {
-                    fragments.add(new LocationFragment(location.start, location.end, "CONTINUOUS"))
+                    fragments.add(new uk.ac.ebi.interpro.LocationFragment(location.start, location.end, "CONTINUOUS"))
                 }
 
                 location.fragments = fragments

--- a/modules/pfam/main.nf
+++ b/modules/pfam/main.nf
@@ -56,9 +56,9 @@ def stockholmDatParser(Path pfamADatFile) {
         }
     }
     // convert nested 'names' to 'acc'
-    parsedDat.each { acc, info ->
+    parsedDat.each { _acc, info ->
         def nestedNames = info.nested ?: []
-        def nestedAccessions = nestedNames.collect { name2acc[it] }.findAll { it != null }
+        def nestedAccessions = nestedNames.collect { n -> name2acc[n] }.findAll { acc -> acc != null }
         info.nested = nestedAccessions.unique()
     }
 
@@ -68,7 +68,7 @@ def stockholmDatParser(Path pfamADatFile) {
 def decode(byte[] b) {
     try {
         return new String(b, "UTF-8").trim()
-    } catch (Exception e) {
+    } catch (Exception _e) {
         return new String(b, "ISO-8859-1").trim()
     }
 }

--- a/modules/pftools/main.nf
+++ b/modules/pftools/main.nf
@@ -54,7 +54,8 @@ process PARSE_PSSCAN {
         def end = matchInfo[4].toInteger()
 
         def matchDetails = matchInfo[8].split(';')
-        def name = matchDetails[0].trim()
+        // Example of matchDetails:
+        // Name "EGF_CA" ; LevelTag "(0)" ; Sequence "DkDECskdngg........Cqqd....CvNtfgsYeC" ; SequenceDescription "EE9CDDCA84C66D7FB465CC609FD0DCCD"
         def level = matchDetails[1].trim()
         if (!level.startsWith("LevelTag") || !level.contains("0")) {
             return // skipping non-strong matches

--- a/modules/pftools/main.nf
+++ b/modules/pftools/main.nf
@@ -4,7 +4,8 @@ process RUN_PSSCAN {
     pftools developers. It automates running pfscan for all provided patterns and
     includes post-processing of the hits.
     */
-    label     'mem_min', 'time_medium'
+    label     'mem_min'
+    label     'time_medium'
     container 'interpro/pftools:3.2.12'
 
     input:
@@ -27,7 +28,8 @@ process RUN_PSSCAN {
 
 
 process PARSE_PSSCAN {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:
@@ -96,7 +98,8 @@ process RUN_PFSEARCH {
 }
 
 process PARSE_PFSEARCH {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/pftools/main.nf
+++ b/modules/pftools/main.nf
@@ -1,12 +1,3 @@
-import groovy.io.FileType
-import groovy.json.JsonOutput
-import groovy.json.JsonSlurper
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-
-
 process RUN_PSSCAN {
     /*
     The ps_scan.pl script is a wrapper for the pfscan tool that is provided by the
@@ -46,42 +37,42 @@ process PARSE_PSSCAN {
         tuple val(meta), path("ps_scan.json")
 
     exec:
-    Map<String, Map<String, Match>> patternsMatches = [:]
-    SignatureLibraryRelease library = new SignatureLibraryRelease("PROSITE patterns", null)
+    def patternsMatches = [:]
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("PROSITE patterns", null)
     ps_scan_out.eachLine { line ->
         line = line.trim()
         if (!line || line.startsWith("pfscanV3 is not meant to be used with a single profile")) {
             return
         }
-        List<String> matchInfo = line.split('\t')
+        def matchInfo = line.split('\t')
         if (matchInfo.size() < 9) {
             return
         }
-        String seqId = matchInfo[0]
-        String modelAccession = matchInfo[2]
-        int start = matchInfo[3].toInteger()
-        int end = matchInfo[4].toInteger()
+        def seqId = matchInfo[0]
+        def modelAccession = matchInfo[2]
+        def start = matchInfo[3].toInteger()
+        def end = matchInfo[4].toInteger()
 
-        List<String> matchDetails = matchInfo[8].split(';')
-        String name = matchDetails[0].trim()
-        String level = matchDetails[1].trim()
+        def matchDetails = matchInfo[8].split(';')
+        def name = matchDetails[0].trim()
+        def level = matchDetails[1].trim()
         if (!level.startsWith("LevelTag") || !level.contains("0")) {
             return // skipping non-strong matches
         } else {
             level = "STRONG"
         }
-        String alignment = matchDetails[2].replaceAll('Sequence ', '').replaceAll('"', '').replaceAll('\\.', '').trim()
-        String cigarAlignment = Match.encodeCigarAlignment(alignment)
+        def alignment = matchDetails[2].replaceAll('Sequence ', '').replaceAll('"', '').replaceAll('\\.', '').trim()
+        def cigarAlignment = uk.ac.ebi.interpro.Match.encodeCigarAlignment(alignment)
         patternsMatches.computeIfAbsent(seqId) { [:] }
-        Match matchObj = patternsMatches[seqId].computeIfAbsent(modelAccession) {
-            new Match(modelAccession, new Signature(modelAccession, library))
+        def matchObj = patternsMatches[seqId].computeIfAbsent(modelAccession) {
+            new uk.ac.ebi.interpro.Match(modelAccession, new uk.ac.ebi.interpro.Signature(modelAccession, library))
         }
-        Location location = new Location(start, end, level, alignment, cigarAlignment)
+        def location = new uk.ac.ebi.interpro.Location(start, end, level, alignment, cigarAlignment)
         matchObj.addLocation(location)
     }
 
     def filepath = task.workDir.resolve("ps_scan.json")
-    filepath.text = JsonOutput.toJson(patternsMatches)
+    filepath.text  = groovy.json.JsonOutput.toJson(patternsMatches)
 }
 
 process RUN_PFSEARCH {
@@ -116,8 +107,8 @@ process PARSE_PFSEARCH {
     tuple val(meta), path("pfsearch.json")
 
     exec:
-    Map matches = [:]
-    SignatureLibraryRelease library = new SignatureLibraryRelease(signature_library, null)
+    def matches = [:]
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease(signature_library, null)
     def toSkip = []
     if (blacklist_file) {
         toSkip = blacklist_file.readLines()
@@ -126,26 +117,26 @@ process PARSE_PFSEARCH {
     pfsearch_out.eachLine { line ->
         def fields = line.split()
         assert fields.size() == 10
-        String modelAccession = fields[0].split("\\|")[0]
+        def modelAccession = fields[0].split("\\|")[0]
         if (toSkip && (modelAccession in toSkip)) {
             return // skip flagged accessions
         }
 
-        String seqId = fields[3]
-        int start = fields[4].toInteger()
-        int end = fields[5].toInteger()
-        Double score = Double.parseDouble(fields[7])
-        String alignment = fields[9]
-        String cigarAlignment = Match.encodeCigarAlignment(alignment)
+        def seqId = fields[3]
+        def start = fields[4].toInteger()
+        def end = fields[5].toInteger()
+        def score = Double.parseDouble(fields[7])
+        def alignment = fields[9]
+        def cigarAlignment = uk.ac.ebi.interpro.Match.encodeCigarAlignment(alignment)
 
         matches.computeIfAbsent(seqId) { [:] }
-        Match matchObj = matches[seqId].computeIfAbsent(modelAccession) {
-            new Match(modelAccession, new Signature(modelAccession, library))
+        def matchObj = matches[seqId].computeIfAbsent(modelAccession) {
+            new uk.ac.ebi.interpro.Match(modelAccession, new uk.ac.ebi.interpro.Signature(modelAccession, library))
         }
-        Location location = new Location(start, end, score, alignment, cigarAlignment)
+        def location = new uk.ac.ebi.interpro.Location(start, end, score, alignment, cigarAlignment)
         matchObj.addLocation(location)
     }
     def filepath = task.workDir.resolve("pfsearch.json")
-    filepath.text = JsonOutput.toJson(matches)
+    filepath.text  = groovy.json.JsonOutput.toJson(matches)
 }
 

--- a/modules/phobius/main.nf
+++ b/modules/phobius/main.nf
@@ -1,5 +1,6 @@
 process WRITE_FASTA {
-    label    'mem_min', 'time_veryshort'
+    label    'mem_min'
+    label    'time_veryshort'
     executor 'local'
 
     input:
@@ -18,7 +19,8 @@ process WRITE_FASTA {
 }
 
 process SEARCH_PHOBIUS {
-    label       'mem_min', 'time_short'
+    label       'mem_min'
+    label       'time_short'
     stageInMode 'copy'
     container   'interpro/phobius:1.01'
 
@@ -38,7 +40,8 @@ process SEARCH_PHOBIUS {
 }
 
 process PARSE_PHOBIUS {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/phobius/main.nf
+++ b/modules/phobius/main.nf
@@ -1,10 +1,3 @@
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.FastaFile
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-
 process WRITE_FASTA {
     label    'mem_min', 'time_veryshort'
     executor 'local'
@@ -16,7 +9,7 @@ process WRITE_FASTA {
     tuple val(meta), path("sequences.fasta")
 
     exec:
-    FastaFile.write(
+    uk.ac.ebi.interpro.FastaFile.write(
         fasta,
         task.workDir.resolve("sequences.fasta"),
         "BJOZ",
@@ -58,23 +51,22 @@ process PARSE_PHOBIUS {
     def matches = [:]
     def tmpMatches = [:]
     def sequenceId = null
-    boolean isSignalPeptide = false
-    boolean isTransmembrane = false
-
-    SignatureLibraryRelease library = new SignatureLibraryRelease("Phobius", "1.01")
+    def isSignalPeptide = false
+    def isTransmembrane = false
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("Phobius", "1.01")
     def signatures = [
-        "CYTOPLASMIC_DOMAIN"     : new Signature("CYTOPLASMIC_DOMAIN", "Cytoplasmic domain", 
+        "CYTOPLASMIC_DOMAIN"     : new uk.ac.ebi.interpro.Signature("CYTOPLASMIC_DOMAIN", "Cytoplasmic domain", 
                                                  "Region of a membrane-bound protein predicted to be outside the membrane, in the cytoplasm", library, null),
-        "NON_CYTOPLASMIC_DOMAIN" : new Signature("NON_CYTOPLASMIC_DOMAIN", "Non cytoplasmic domain", 
+        "NON_CYTOPLASMIC_DOMAIN" : new uk.ac.ebi.interpro.Signature("NON_CYTOPLASMIC_DOMAIN", "Non cytoplasmic domain", 
                                                  "Region of a membrane-bound protein predicted to be outside the membrane, in the extracellular region", library, null),
-        "SIGNAL_PEPTIDE"         : new Signature("SIGNAL_PEPTIDE", "Signal Peptide", "Signal Peptide region", library, null),
-        "SIGNAL_PEPTIDE_C_REGION": new Signature("SIGNAL_PEPTIDE_C_REGION", "Signal peptide C-region", 
+        "SIGNAL_PEPTIDE"         : new uk.ac.ebi.interpro.Signature("SIGNAL_PEPTIDE", "Signal Peptide", "Signal Peptide region", library, null),
+        "SIGNAL_PEPTIDE_C_REGION": new uk.ac.ebi.interpro.Signature("SIGNAL_PEPTIDE_C_REGION", "Signal peptide C-region", 
                                                  "C-terminal region of a signal peptide", library, null),
-        "SIGNAL_PEPTIDE_H_REGION": new Signature("SIGNAL_PEPTIDE_H_REGION", "Signal peptide H-region", 
+        "SIGNAL_PEPTIDE_H_REGION": new uk.ac.ebi.interpro.Signature("SIGNAL_PEPTIDE_H_REGION", "Signal peptide H-region", 
                                                  "Hydrophobic region of a signal peptide", library, null),
-        "SIGNAL_PEPTIDE_N_REGION": new Signature("SIGNAL_PEPTIDE_N_REGION", "Signal peptide N-region", 
+        "SIGNAL_PEPTIDE_N_REGION": new uk.ac.ebi.interpro.Signature("SIGNAL_PEPTIDE_N_REGION", "Signal peptide N-region", 
                                                  "N-terminal region of a signal peptide", library, null),
-        "TRANSMEMBRANE"          : new Signature("TRANSMEMBRANE", "Transmembrane region", 
+        "TRANSMEMBRANE"          : new uk.ac.ebi.interpro.Signature("TRANSMEMBRANE", "Transmembrane region", 
                                                  "Region of a membrane-bound protein predicted to be embedded in the membrane", library, null),
     ]
 
@@ -95,7 +87,7 @@ process PARSE_PHOBIUS {
             return
         }
         def fields = line.trim().split(/\s+/, 5)
-        String field = fields[0];
+        def field = fields[0];
         if (field == "ID") {
             assert sequenceId == null
             assert fields.size() == 2
@@ -103,38 +95,32 @@ process PARSE_PHOBIUS {
         } else {
             assert field == "FT"
             assert fields.size() == 4 || fields.size() == 5
-            String type = fields[1]
-            int start = fields[2].toInteger()
-            int end = fields[3].toInteger()
-            String qualifier = null
+            def type = fields[1]
+            def start = fields[2].toInteger()
+            def end = fields[3].toInteger()
+            def qualifier = null
             if (fields.size() == 5 && !fields[4].trim().isEmpty()) {
                 qualifier = fields[4].trim()
             }
 
-            String modelAccession = null
-            if (type == "SIGNAL") {
+            def modelAccession = null
+                        if (type == "SIGNAL") {
                 modelAccession = "SIGNAL_PEPTIDE"
                 isSignalPeptide = true
             } else if (type == "DOMAIN") {
-                switch (qualifier) {
-                    case "CYTOPLASMIC.":
-                        modelAccession = "CYTOPLASMIC_DOMAIN"
-                        break
-                    case "NON CYTOPLASMIC.":
-                        modelAccession = "NON_CYTOPLASMIC_DOMAIN"
-                        break
-                    case "N-REGION.":
-                        modelAccession = "SIGNAL_PEPTIDE_N_REGION"
-                        isSignalPeptide = true
-                        break
-                    case "H-REGION.":
-                        modelAccession = "SIGNAL_PEPTIDE_H_REGION"
-                        isSignalPeptide = true
-                        break
-                    case "C-REGION.":
-                        modelAccession = "SIGNAL_PEPTIDE_C_REGION"
-                        isSignalPeptide = true
-                        break
+                if (qualifier == "CYTOPLASMIC.") {
+                    modelAccession = "CYTOPLASMIC_DOMAIN"
+                } else if (qualifier == "NON CYTOPLASMIC.") {
+                    modelAccession = "NON_CYTOPLASMIC_DOMAIN"
+                } else if (qualifier == "N-REGION.") {
+                    modelAccession = "SIGNAL_PEPTIDE_N_REGION"
+                    isSignalPeptide = true
+                } else if (qualifier == "H-REGION.") {
+                    modelAccession = "SIGNAL_PEPTIDE_H_REGION"
+                    isSignalPeptide = true
+                } else if (qualifier == "C-REGION.") {
+                    modelAccession = "SIGNAL_PEPTIDE_C_REGION"
+                    isSignalPeptide = true
                 }
             } else if (type == "TRANSMEM") {
                 modelAccession = "TRANSMEMBRANE"
@@ -146,19 +132,19 @@ process PARSE_PHOBIUS {
                 return
             }
 
-            Match match
+            def match
             if (tmpMatches.containsKey(modelAccession)) {
                 match = tmpMatches[modelAccession]
             } else {
-                Signature signature = signatures[modelAccession]
-                match = new Match(modelAccession, signature)
+                def signature = signatures[modelAccession]
+                match = new uk.ac.ebi.interpro.Match(modelAccession, signature)
                 tmpMatches[modelAccession] = match
             }
 
-            match.addLocation(new Location(start, end))            
+            match.addLocation(new uk.ac.ebi.interpro.Location(start, end))            
         }
     }
 
     def filepath = task.workDir.resolve("phobius.json")
-    filepath.text = JsonOutput.toJson(matches)
+    filepath.text  = groovy.json.JsonOutput.toJson(matches)
 }

--- a/modules/pirsf/main.nf
+++ b/modules/pirsf/main.nf
@@ -30,9 +30,7 @@ process PARSE_PIRSF {
     tuple val(meta), path("pirsf.json")
 
     exec:
-    def parsed = { -> parseDatFile(datfile) }()
-    def models = parsed[0]
-    def subfamilies = parsed[1]
+    def (models, subfamilies) = parseDatFile(datfile)
     def hmmerMatches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmsearch_out, "PIRSF")
     def sequences = uk.ac.ebi.interpro.FastaFile.parse(fasta)
 

--- a/modules/pirsf/main.nf
+++ b/modules/pirsf/main.nf
@@ -156,14 +156,14 @@ process PARSE_PIRSF {
 }
 
 def createMatch(
-    Match match,
-    int seqStart,
-    int seqEnd,
-    int hmmStart,
-    int hmmEnd,
-    int envStart,
-    int envEnd,
-    double locationScore) {
+    match,
+    seqStart,
+    seqEnd,
+    hmmStart,
+    hmmEnd,
+    envStart,
+    envEnd,
+    locationScore) {
     def processedMatch = new uk.ac.ebi.interpro.Match(
         match.modelAccession,
         match.evalue,

--- a/modules/pirsf/main.nf
+++ b/modules/pirsf/main.nf
@@ -1,10 +1,3 @@
-// codenarc-disable AllowedDirectivesRule
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.FastaFile
-import uk.ac.ebi.interpro.HMMER3
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Match
-
 process SEARCH_PIRSF {
     label     'mem_low', 'time_short', 'dynamic'
     container 'interpro/hmmer:3.3'
@@ -38,30 +31,30 @@ process PARSE_PIRSF {
 
     exec:
     def (models, subfamilies) = parseDatFile(datfile)
-    def hmmerMatches = HMMER3.parseOutput(hmmsearch_out, "PIRSF")
-    Map<String, String> sequences = FastaFile.parse(fasta)
+    def hmmerMatches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmsearch_out, "PIRSF")
+    def sequences = uk.ac.ebi.interpro.FastaFile.parse(fasta)
 
-    double LENGTH_RATIO_THRESHOLD = 0.67
-    double OVERLAP_THRESHOLD = 0.8
-    double LENGTH_DEVIATION_THRESHOLD = 3.5
-    int MINIMUM_LENGTH_DEVIATION = 50
+    def LENGTH_RATIO_THRESHOLD = 0.67
+    def OVERLAP_THRESHOLD = 0.8
+    def LENGTH_DEVIATION_THRESHOLD = 3.5
+    def MINIMUM_LENGTH_DEVIATION = 50
 
     def results = [:] // proteinAccession -> modelAccession -> Match
 
     hmmerMatches.each { proteinAccession, modelMatches ->
-        int sequenceLength = sequences[proteinAccession].length()
+        def sequenceLength = sequences[proteinAccession].length()
 
         def familyMatches = []
         def subfamilyMatches = []
 
         modelMatches.each { modelAccession, rawMatch ->
-            int seqStart = Integer.MAX_VALUE
-            int seqEnd = Integer.MIN_VALUE
-            int hmmStart = Integer.MAX_VALUE
-            int hmmEnd = Integer.MIN_VALUE
-            int envStart = 0
-            int envEnd = 0
-            double locationScore = 0.0
+            def seqStart = Integer.MAX_VALUE
+            def seqEnd = Integer.MIN_VALUE
+            def hmmStart = Integer.MAX_VALUE
+            def hmmEnd = Integer.MIN_VALUE
+            def envStart = 0
+            def envEnd = 0
+            def locationScore = 0.0
             rawMatch.locations.each { location ->
                 if (location.included) {
                     locationScore += location.score
@@ -95,16 +88,16 @@ process PARSE_PIRSF {
         def filteredFamilyMatches = familyMatches.findAll { match ->
             def (meanL, stdL, minS, meanS, stdS) = models[match.modelAccession]
 
-            Location location = match.locations[0]
+            def location = match.locations[0]
             
             // Overall length
-            double ovl = (location.end - location.start + 1) / sequenceLength
+            def ovl = (location.end - location.start + 1) / sequenceLength
 
             // Length deviation
-            double ld = Math.abs(sequenceLength - meanL)
+            def ld = Math.abs(sequenceLength - meanL)
 
             // Ratio over coverage of sequence and profile hmm
-            double r = (location.hmmEnd - location.hmmStart + 1) / (location.end - location.start + 1)
+            def r = (location.hmmEnd - location.hmmStart + 1) / (location.end - location.start + 1)
 
             return r > LENGTH_RATIO_THRESHOLD
                 && ovl >= OVERLAP_THRESHOLD
@@ -134,8 +127,8 @@ process PARSE_PIRSF {
             def (meanL, stdL, minS, meanS, stdS) = models[match.modelAccession]
             
             // Ratio over coverage of sequence and profile hmm
-            Location location = match.locations[0]
-            double r = (location.hmmEnd - location.hmmStart + 1) / (location.end - location.start + 1)
+            def location = match.locations[0]
+            def r = (location.hmmEnd - location.hmmStart + 1) / (location.end - location.start + 1)
             return r > LENGTH_RATIO_THRESHOLD && match.score >= minS
         }
 
@@ -159,7 +152,7 @@ process PARSE_PIRSF {
     }
 
     def filepath = task.workDir.resolve("pirsf.json")
-    filepath.text = JsonOutput.toJson(results)
+    filepath.text  = groovy.json.JsonOutput.toJson(results)
 }
 
 def createMatch(
@@ -171,17 +164,17 @@ def createMatch(
     int envStart,
     int envEnd,
     double locationScore) {
-    Match processedMatch = new Match(
+    def processedMatch = new uk.ac.ebi.interpro.Match(
         match.modelAccession,
         match.evalue,
         locationScore,
         match.bias,
         match.signature
     )
-    String hmmBoundStart = hmmStart == 1 ? "[" : "."
-    String hmmBoundEnd = hmmEnd == match.locations[0].hmmLength ? "]" : "."
+    def hmmBoundStart = hmmStart == 1 ? "[" : "."
+    def hmmBoundEnd = hmmEnd == match.locations[0].hmmLength ? "]" : "."
     processedMatch.addLocation(
-        new Location(
+        new uk.ac.ebi.interpro.Location(
             seqStart,
             seqEnd,
             hmmStart,

--- a/modules/pirsf/main.nf
+++ b/modules/pirsf/main.nf
@@ -1,5 +1,7 @@
 process SEARCH_PIRSF {
-    label     'mem_low', 'time_short', 'dynamic'
+    label     'mem_low'
+    label     'time_short'
+    label     'dynamic'
     container 'interpro/hmmer:3.3'
 
     input:
@@ -19,7 +21,8 @@ process SEARCH_PIRSF {
 }
 
 process PARSE_PIRSF {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/pirsf/main.nf
+++ b/modules/pirsf/main.nf
@@ -24,12 +24,13 @@ process PARSE_PIRSF {
 
     input:
     tuple val(meta), val(fasta), val(hmmsearch_out)
-    tuple val(models), val(subfamilies)
+    val datfile
 
     output:
     tuple val(meta), path("pirsf.json")
 
     exec:
+    def models, subfamilies = parseDatFile(datfile)
     def hmmerMatches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmsearch_out, "PIRSF")
     def sequences = uk.ac.ebi.interpro.FastaFile.parse(fasta)
 
@@ -188,4 +189,32 @@ def createMatch(
         )
     )
     return processedMatch
+}
+
+def parseDatFile(datFile) {
+    def models = [:]    // PIRSF -> list of 5 doubles (meanL, stdL, minS, meanS, stdS)
+    def subfamilies = [:]   // child PIRSF -> parent PIRSF
+
+    datFile.withReader { reader ->
+        def accession = null
+        reader.eachLine { line ->
+            if (line.startsWith('>')) {
+                def parts = line.split(/\s+/)
+                accession = parts[0].replace('>', '')
+
+                def match = (line =~ /^>PIRSF\d+\schild:\s(.+)$/)
+                if (match) {
+                    match[0][1].trim().split(/\s+/).each { child ->
+                        subfamilies[child] = accession
+                    }
+                }
+
+            } else if (line ==~ /\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*/) {
+                def values = line.split(/\s+/)*.toDouble()
+                models[accession] = values
+            }
+        }
+    }
+
+    return [models, subfamilies]
 }

--- a/modules/pirsf/main.nf
+++ b/modules/pirsf/main.nf
@@ -24,13 +24,12 @@ process PARSE_PIRSF {
 
     input:
     tuple val(meta), val(fasta), val(hmmsearch_out)
-    val datfile
+    tuple val(models), val(subfamilies)
 
     output:
     tuple val(meta), path("pirsf.json")
 
     exec:
-    def (models, subfamilies) = parseDatFile(datfile)
     def hmmerMatches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmsearch_out, "PIRSF")
     def sequences = uk.ac.ebi.interpro.FastaFile.parse(fasta)
 
@@ -189,31 +188,4 @@ def createMatch(
         )
     )
     return processedMatch
-}
-
-def parseDatFile(Path datFile) {
-    def models = [:]    // PIRSF -> list of 5 doubles (meanL, stdL, minS, meanS, stdS)
-    def subfamilies = [:]   // child PIRSF -> parent PIRSF
-    datFile.withReader { reader ->
-        def accession = null
-        reader.eachLine { line ->
-            if (line.startsWith('>')) {
-                def parts = line.split(/\s+/)
-                accession = parts[0].replace('>', '')
-
-                def match = (line =~ /^>PIRSF\d+\schild:\s(.+)$/)
-                if (match) {
-                    match[0][1].trim().split(/\s+/).each { child ->
-                        subfamilies[child] = accession
-                    }
-                }
-
-            } else if (line ==~ /\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*/) {
-                def values = line.split(/\s+/)*.toDouble()
-                models[accession] = values
-            }
-        }
-    }
-
-    return [models, subfamilies]
 }

--- a/modules/pirsf/main.nf
+++ b/modules/pirsf/main.nf
@@ -86,7 +86,7 @@ process PARSE_PIRSF {
 
         // Filter family matches
         def filteredFamilyMatches = familyMatches.findAll { match ->
-            def (meanL, stdL, minS, meanS, stdS) = models[match.modelAccession]
+            def (meanL, stdL, minS, _meanS, _stdS) = models[match.modelAccession]
 
             def location = match.locations[0]
             
@@ -106,7 +106,7 @@ process PARSE_PIRSF {
         }
 
         // Select best family match
-        def familyMatch = filteredFamilyMatches ? filteredFamilyMatches.max { it.score } : null
+        def familyMatch = filteredFamilyMatches ? filteredFamilyMatches.max { m -> m.score } : null
 
         // Filter subfamily matches and select the best one
         def filteredSubfamilyMatches = subfamilyMatches.findAll { match ->
@@ -118,13 +118,13 @@ process PARSE_PIRSF {
                 return false
             }
 
-            def parentMatch = familyMatches.find { it.modelAccession == parentFamily }
+            def parentMatch = familyMatches.find { m -> m.modelAccession == parentFamily }
             if (!parentMatch) {
                 // We don't want a subfamily match if the parent family doesn't hit the sequence
                 return false
             }
 
-            def (meanL, stdL, minS, meanS, stdS) = models[match.modelAccession]
+            def (_meanL, _stdL, minS, _meanS, _stdS) = models[match.modelAccession]
             
             // Ratio over coverage of sequence and profile hmm
             def location = match.locations[0]
@@ -132,21 +132,21 @@ process PARSE_PIRSF {
             return r > LENGTH_RATIO_THRESHOLD && match.score >= minS
         }
 
-        def subfamilyMatch = filteredSubfamilyMatches ? filteredSubfamilyMatches.max { it.score } : null
+        def subfamilyMatch = filteredSubfamilyMatches ? filteredSubfamilyMatches.max { m -> m.score } : null
         
         if (subfamilyMatch && !familyMatch) {
             // Promote parent family (even if it didn't pass the cutoffs)
             def parentFamily = subfamilies[subfamilyMatch.modelAccession]
-            familyMatch = familyMatches.find { it.modelAccession == parentFamily }
+            familyMatch = familyMatches.find { m -> m.modelAccession == parentFamily }
         }
 
         if (familyMatch) {
-            results[proteinAccession] = [:].with {
-                it[familyMatch.modelAccession] = familyMatch
-                if (subfamilyMatch) {
-                    it[subfamilyMatch.modelAccession] = subfamilyMatch
-                }
-                it
+            results[proteinAccession] = [
+                (familyMatch.modelAccession): familyMatch
+            ]
+
+            if (subfamilyMatch) {
+                results[proteinAccession][subfamilyMatch.modelAccession] = subfamilyMatch
             }
         }
     }

--- a/modules/pirsf/main.nf
+++ b/modules/pirsf/main.nf
@@ -30,7 +30,9 @@ process PARSE_PIRSF {
     tuple val(meta), path("pirsf.json")
 
     exec:
-    def models, subfamilies = parseDatFile(datfile)
+    def parsed = { -> parseDatFile(datfile) }()
+    def models = parsed[0]
+    def subfamilies = parsed[1]
     def hmmerMatches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmsearch_out, "PIRSF")
     def sequences = uk.ac.ebi.interpro.FastaFile.parse(fasta)
 

--- a/modules/pirsr/main.nf
+++ b/modules/pirsr/main.nf
@@ -121,12 +121,12 @@ process PARSE_PIRSR {
     filepath.text  = groovy.json.JsonOutput.toJson(validMatches)
 }
 
-def mapHMMToSeq(int hmmStart, String querySeq, String targetSeq) {
+def mapHMMToSeq(hmmStart, querySeq, targetSeq) {
     def seqPos = 0
     def currentHmmStart = hmmStart
     def map = ([0] + (1..hmmStart).collect { -1 }) as List<Integer>
 
-    querySeq.eachWithIndex { char queryChar, int index ->
+    querySeq.eachWithIndex { queryChar, index ->
         map[currentHmmStart] = seqPos
         if (queryChar != '.') {
             currentHmmStart += 1

--- a/modules/pirsr/main.nf
+++ b/modules/pirsr/main.nf
@@ -34,7 +34,7 @@ process PARSE_PIRSR {
                 def ruleSites = [] as Set
                 def rule = rules.get(modelAccession, null)
                 if (rule) {
-                    rule.Groups.each { grp, positions ->
+                    rule.Groups.each { _grp, positions ->
                         def passCount = 0
                         def positionsParsed = [] as Set
                         positions.each { pos ->

--- a/modules/pirsr/main.nf
+++ b/modules/pirsr/main.nf
@@ -1,5 +1,6 @@
 process PARSE_PIRSR {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/pirsr/main.nf
+++ b/modules/pirsr/main.nf
@@ -1,11 +1,3 @@
-import groovy.json.JsonOutput
-import groovy.json.JsonSlurper
-import java.util.regex.Pattern
-import uk.ac.ebi.interpro.HMMER3
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Site
-import uk.ac.ebi.interpro.SiteLocation
-
 process PARSE_PIRSR {
     label    'mem_low', 'time_veryshort'
     executor 'local'
@@ -18,8 +10,8 @@ process PARSE_PIRSR {
     tuple val(meta), path("pirsr.json")
 
     exec:
-    def hmmerMatches = HMMER3.parseOutput(hmmsearch_out, "PIRSR")
-    def rules = new JsonSlurper().parse(rulesfile)
+    def hmmerMatches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmsearch_out, "PIRSR")
+    def rules = new groovy.json.JsonSlurper().parse(rulesfile)
     def validMatches = [:]
     hmmerMatches.each { seqId, matches ->
         def filteredSeqMatches = [:]
@@ -47,23 +39,25 @@ process PARSE_PIRSR {
                         def positionsParsed = [] as Set
                         positions.each { pos ->
                             def condition = pos.condition.replaceAll(/[-()]/) { m ->
-                                switch (m[0]) {
-                                    case '-': return ''
-                                    case '(': return '{'
-                                    case ')': return '}'
+                                if (m[0] == '-') {
+                                    return ''
+                                } else if (m[0] == '(') {
+                                    return '{'
+                                } else if (m[0] == ')') {
+                                    return '}'
                                 }
                             }.replace('x', '.')
 
                             def querySeq = location.targetAlignment.replaceAll('-', '')
+                            def targetSeq
                             if (pos.hmmStart < map.size() && pos.hmmEnd < map.size()) {
                                 targetSeq = querySeq[map[pos.hmmStart]..<map[pos.hmmEnd] + 1]
-                                residue = location.targetAlignment[map[pos.hmmStart]..<map[pos.hmmEnd] + 1]
                             } else {
                                 targetSeq = ''
                             }
 
                             if (targetSeq ==~ condition) {
-                                passCount++
+                                passCount += 1
                                 if (pos.start == 'Nter') pos.start = location.start
                                 if (pos.end == 'Cter') pos.end = location.end
                             }
@@ -102,11 +96,11 @@ process PARSE_PIRSR {
                     def groupedPositions = [:]
                     ruleSites.each { desc, residue, residueStart, residueEnd ->
                         def siteLocations = groupedPositions.computeIfAbsent(desc) { [] }
-                        siteLocations << new SiteLocation(residue, residueStart, residueEnd)
+                        siteLocations << new uk.ac.ebi.interpro.SiteLocation(residue, residueStart, residueEnd)
                     }
                     groupedPositions.each { description, siteLocations ->
                         siteLocations.sort { a, b -> a.start <=> b.start ?: a.end <=> b.end }
-                        location.addSite(new Site(description, siteLocations))
+                        location.addSite(new uk.ac.ebi.interpro.Site(description, siteLocations))
                     }
                     selectedLocations << location
                 }
@@ -124,33 +118,34 @@ process PARSE_PIRSR {
     }
 
     def filepath = task.workDir.resolve("pirsr.json")
-    filepath.text = JsonOutput.toJson(validMatches)
+    filepath.text  = groovy.json.JsonOutput.toJson(validMatches)
 }
 
 def mapHMMToSeq(int hmmStart, String querySeq, String targetSeq) {
-    int seqPos = 0
-    def map = [0]
-    for (int i = 1; i <= hmmStart; i++) {
-        map << -1
-    }
-    for (int i = 0; i < querySeq.length(); i++) {
-        map = map[0..hmmStart - 1] + [seqPos]
-        if (querySeq[i] != '.') {
-            hmmStart += 1
+    def seqPos = 0
+    def currentHmmStart = hmmStart
+    def map = ([0] + (1..hmmStart).collect { -1 }) as List<Integer>
+
+    querySeq.eachWithIndex { char queryChar, int index ->
+        map[currentHmmStart] = seqPos
+        if (queryChar != '.') {
+            currentHmmStart += 1
+            map << -1
         }
-        if (targetSeq[i] != '-') {
+        if (targetSeq[index] != '-') {
             seqPos += 1
         }
     }
+
     return map
 }
 
 def getPositionMap(alignment, position) {
-    Map<Integer, Integer> positionMap = [:]
+    def positionMap = [:]
     alignment.eachWithIndex { character, index ->
         if (Character.isLetter(character as char)) {
             positionMap[position] = index
-            position++
+            position += 1
         }
     }
     return positionMap

--- a/modules/prepare_sequences/main.nf
+++ b/modules/prepare_sequences/main.nf
@@ -1,6 +1,7 @@
 process VALIDATE_FASTA {
     // check the formating of the intput FASTA, i.e. look for illegal characters
-    label         'mem_low', 'time_short'
+    label         'mem_low'
+    label         'time_short'
     executor      'local'
     errorStrategy 'terminate'
 
@@ -18,7 +19,8 @@ process VALIDATE_FASTA {
 
 process LOAD_SEQUENCES {
     // Populate a native sqlite3 database with sequences from the pipeline's input FASTA file.
-    label         'mem_low', 'time_short'
+    label         'mem_low'
+    label         'time_short'
     executor      'local'
     errorStrategy 'terminate'
 
@@ -38,7 +40,8 @@ process LOAD_SEQUENCES {
 
 process LOAD_ORFS {
     // add protein seqs translated from ORFS in the nt seqs to the database
-    label         'mem_low', 'time_short'
+    label         'mem_low'
+    label         'time_short'
     executor      'local'
     errorStrategy 'terminate'
 
@@ -57,7 +60,8 @@ process LOAD_ORFS {
 
 process SPLIT_FASTA {
     // Build the FASTA file batches of unique protein sequences for the sequence analysis
-    label         'mem_low', 'time_short'
+    label         'mem_low'
+    label         'time_short'
     executor      'local'
     errorStrategy 'terminate'
 

--- a/modules/prepare_sequences/main.nf
+++ b/modules/prepare_sequences/main.nf
@@ -1,6 +1,3 @@
-import uk.ac.ebi.interpro.FastaFile
-import uk.ac.ebi.interpro.SeqDB
-
 process VALIDATE_FASTA {
     // check the formating of the intput FASTA, i.e. look for illegal characters
     label         'mem_low', 'time_short'
@@ -16,7 +13,7 @@ process VALIDATE_FASTA {
     val seq_id
 
     exec:
-    seq_id = FastaFile.validate(fasta, is_nucleic)
+    seq_id = uk.ac.ebi.interpro.FastaFile.validate(fasta, is_nucleic)
 }
 
 process LOAD_SEQUENCES {
@@ -34,7 +31,7 @@ process LOAD_SEQUENCES {
 
     exec:
     def outputFilePath = task.workDir.resolve("sequences.db")
-    def db = new SeqDB(outputFilePath)
+    def db = new uk.ac.ebi.interpro.SeqDB(outputFilePath)
     db.loadFastaFile(fasta, nucleic, false)
     db.close()
 }
@@ -53,7 +50,7 @@ process LOAD_ORFS {
     val db_path // ensure SPLIT_FASTA runs after LOAD_ORFS
 
     exec:
-    def db = new SeqDB(db_path)
+    def db = new uk.ac.ebi.interpro.SeqDB(db_path)
     db.loadFastaFile(translated_fasta, false, true)
     db.close()
 }
@@ -73,7 +70,7 @@ process SPLIT_FASTA {
     path "*.fasta"
 
     exec:
-    def db = new SeqDB(db_path)
+    def db = new uk.ac.ebi.interpro.SeqDB(db_path)
     db.splitFasta(task.workDir, batch_size, nucleic)
     db.close()
 }

--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -211,16 +211,16 @@ process PARSE_PRINTS {
 def sortMatches(matches) {
     // This comparator is CRITICAL to the working of PRINTS post-processing
     return matches.sort { matchA, matchB ->
-        int evalueComparison = matchA.evalue <=> matchB.evalue
+        def evalueComparison = matchA.evalue <=> matchB.evalue
         if (evalueComparison != 0) return evalueComparison
 
-        int modelAccessionComparison = matchA.modelId <=> matchB.modelId
+        def modelAccessionComparison = matchA.modelId <=> matchB.modelId
         if (modelAccessionComparison != 0) return modelAccessionComparison
 
-        int motifNumberComparison = matchA.motifNumber <=> matchB.motifNumber
+        def motifNumberComparison = matchA.motifNumber <=> matchB.motifNumber
         if (motifNumberComparison != 0) return motifNumberComparison
 
-        int startLocationComparison = matchA.locationStart <=> matchB.locationStart
+        def startLocationComparison = matchA.locationStart <=> matchB.locationStart
         if (startLocationComparison != 0) return startLocationComparison
 
         return matchA.locationEnd <=> matchB.locationEnd

--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -1,5 +1,6 @@
 process RUN_PRINTS {
-    label     'mem_medium', 'time_short'
+    label     'mem_medium'
+    label     'time_short'
     container 'interpro/fingerprintscan:3.597.ebiftp'
 
     input:
@@ -19,7 +20,8 @@ process RUN_PRINTS {
 }
 
 process PARSE_PRINTS {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/prints/main.nf
+++ b/modules/prints/main.nf
@@ -1,11 +1,3 @@
-import groovy.json.JsonOutput
-
-import uk.ac.ebi.interpro.FingerPrint
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-
 process RUN_PRINTS {
     label     'mem_medium', 'time_short'
     container 'interpro/fingerprintscan:3.597.ebiftp'
@@ -38,67 +30,59 @@ process PARSE_PRINTS {
     tuple val(meta), path("prints.json")
 
     exec:
-    SignatureLibraryRelease library = new SignatureLibraryRelease("PRINTS", null)
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("PRINTS", null)
     // Build up a map of the Model ID to fingerprint hierarchies
-    Map<String, FingerPrint.HierarchyEntry> hierarchyMap = FingerPrint.HierarchyEntry.parseHierarchyDbFile(hierarchydb)
+    def hierarchyMap = uk.ac.ebi.interpro.FingerPrint.HierarchyEntry.parseHierarchyDbFile(hierarchydb)
 
     // Parse the prints output into simple raw prints matches
     // Each location is represented by its own Print object
-    String queryAccession = null                        // protein seq ID
-    Map<String, FingerPrint> thisProteinsMatches = [:]  // modelName: FingerPrint()
-    Map<String, List<FingerPrint>> rawMatches = [:]     // <protein ID <FingerPrint()>>
+    def queryAccession = null                        // protein seq ID
+    def thisProteinsMatches = [:]  // modelName: FingerPrint()
+    def rawMatches = [:]     // <protein ID <FingerPrint()>>
     prints_output.withReader { reader ->
-        String line
-        while ((line = reader.readLine()) != null) {
-
+        reader.eachLine { line ->
             if (line.startsWith("Sn;")) { // Start the new protein: Get the query sequence id
                 queryAccession = line.split(/\s+/)[1]
-                thisProteinsMatches = new LinkedHashMap<>()
-            }
-
-            else if (line.startsWith("1TBH")) {
+                thisProteinsMatches = [:]
+            } else if (line.startsWith("1TBH")) {
                 // Line: 1TBH 4DISULPHCORE    1.4e-07        4-disulphide core signature       PR00003
                 // we retrieve the model description during the XREFs stage of IPS6
                 def lineData1TBH = line.split(/\s+/)
                 assert lineData1TBH.length >= 5
 
-                String modelName = lineData1TBH[1]
+                def modelName = lineData1TBH[1]
                 assert hierarchyMap[modelName] != null  // the model must be in the Hierarchy DB
-                double evalue = lineData1TBH[2] as double
-                String modelId = lineData1TBH[-1]
+                def evalue = lineData1TBH[2] as double
+                def modelId = lineData1TBH[-1]
 
-                FingerPrint printMatch = new FingerPrint(modelName, modelId, evalue)
+                def printMatch = new uk.ac.ebi.interpro.FingerPrint(modelName, modelId, evalue)
                 thisProteinsMatches.computeIfAbsent(modelName, {printMatch})
-            }
-
-            else if (line.startsWithAny("2TBH", "2TBN")) {
+            } else if (line.startsWithAny("2TBH", "2TBN")) {
                 // Line: 2TBH|N  modelId  NumMotifs  SumId  AveId  ProfScore  Ppvalue  Evalue  graphscan
                 // Retrieve the graphscan value
                 def lineData2TBHN = line.split(/\s+/)
                 assert lineData2TBHN.length == 11
-                String modelName = lineData2TBHN[1]
-                String graphscan = lineData2TBHN[-1]
+                def modelName = lineData2TBHN[1]
+                def graphscan = lineData2TBHN[-1]
                 if (thisProteinsMatches.containsKey(modelName)) {
                     thisProteinsMatches[modelName].graphscan = graphscan
                 }
-            }
-
-            else if (line.startsWithAny("3TBH", "3TBN")) {
+            } else if (line.startsWithAny("3TBH", "3TBN")) {
                 // For the post processing create one Match per location, so each Match obj has one Location obj
                 // Line: 3TBH|N modelId NoOfMotifs IdScore PfScore Pvalue Sequence Len Low Pos High
                 def lineData3TBHN = line.split(/\s+/)
                 assert lineData3TBHN.length == 13
 
-                String modelName = lineData3TBHN[1]
+                def modelName = lineData3TBHN[1]
                 if (thisProteinsMatches.containsKey(modelName)) {
-                    int motifNumber = lineData3TBHN[2] as int  // number of this motif 'X' of Y -- take the X
-                    int motifCount = lineData3TBHN[4] as int // X of 'Y' -- take the Y
-                    double score = lineData3TBHN[5] as double
-                    double pvalue = lineData3TBHN[7] as double
-                    String motifSequence = lineData3TBHN[8]
-                    int motifLength = lineData3TBHN[9] as int
+                    def motifNumber = lineData3TBHN[2] as int  // number of this motif 'X' of Y -- take the X
+                    def motifCount = lineData3TBHN[4] as int // X of 'Y' -- take the Y
+                    def score = lineData3TBHN[5] as double
+                    def pvalue = lineData3TBHN[7] as double
+                    def motifSequence = lineData3TBHN[8]
+                    def motifLength = lineData3TBHN[9] as int
 
-                    String locationStartString
+                    def locationStartString
                     if (lineData3TBHN[11].length() > 5) {
                         // A starting position that is more than 5 figures merges into the high column
                         locationStartString = lineData3TBHN[11].take(5)
@@ -106,22 +90,19 @@ process PARSE_PRINTS {
                         locationStartString = lineData3TBHN[11]
                     }
 
-                    int locationStart = locationStartString as int
-                    int locationEnd = locationStart + motifLength - 1
+                    def locationStart = locationStartString as int
+                    def locationEnd = locationStart + motifLength - 1
 
                     // Adjust the locationStart if the motif starts before the sequence
                     locationStart = Math.max(1, locationStart) 
 
-                    if (motifSequence.endsWith("#")) { // it overhangs the protein seq so adjust locationEnd
-                        int motifSeqLength = motifSequence.length()
-                        int indexCheck = motifSeqLength - 1
-                        while (motifSequence[indexCheck] == "#") {
-                            indexCheck -= 1
-                        }
-                        locationEnd = locationEnd - (motifSeqLength - indexCheck) + 1
+                    if (motifSequence.endsWith("#")) { 
+                        // it overhangs the protein seq so adjust locationEnd
+                        def trailingHashCount = motifSequence.length() - motifSequence.replaceFirst(/#+$/, "").length()
+                        locationEnd -= trailingHashCount
                     }
 
-                    FingerPrint matchLocation = FingerPrint.buildLocationMatch(
+                    def matchLocation = uk.ac.ebi.interpro.FingerPrint.buildLocationMatch(
                             thisProteinsMatches[modelName],
                             locationStart,
                             locationEnd,
@@ -134,7 +115,7 @@ process PARSE_PRINTS {
                         .computeIfAbsent(queryAccession, {[]})
                         .add(matchLocation)
                 }
-            }
+            }        
         }
     }
 
@@ -149,18 +130,18 @@ process PARSE_PRINTS {
     4. If a domain pass
     5. Apply the hierarchy constraints to see if the match passes
     */
-    Map<String, Map<String, Match>> matches = [:]
+    def matches = [:]
     rawMatches.each { proteinAccession, proteinMatches ->
-        List<FingerPrint> sortedMatches = sortMatches(proteinMatches)
-        List<FingerPrint> filteredMatches = []
-        String currentModelAcc = null
-        List<FingerPrint> motifMatchesForCurrentModel = []
-        boolean currentMatchesPass = true
-        boolean passed = false
-        FingerPrint.HierarchyEntry currentHierarchyEntry = null
-        Set<String> hierarchyEntryIdLimitation = hierarchyMap.keySet() // initialise with all models
+        def sortedMatches = sortMatches(proteinMatches)
+        def filteredMatches = []
+        def currentModelAcc = null
+        def motifMatchesForCurrentModel = []
+        def currentMatchesPass = true
+        def passed = false
+        def currentHierarchyEntry = null
+        def hierarchyEntryIdLimitation = hierarchyMap.keySet() // initialise with all models
 
-        for (FingerPrint rawMatch in sortedMatches) {
+        sortedMatches.each { rawMatch ->
             if (currentModelAcc == null || currentModelAcc != rawMatch.modelName) {
                 // just started or moved onto a match for a different model
                 if (currentModelAcc != null && currentMatchesPass) {
@@ -170,15 +151,16 @@ process PARSE_PRINTS {
                     )
                     if (passed) {
                         filteredMatches.addAll(motifMatchesForCurrentModel)
-                        if (currentHierarchyEntry.siblingsIds.length < hierarchyEntryIdLimitation.size() && !currentHierarchyEntry.isDomain) {
-                            hierarchyEntryIdLimitation = new HashSet<>(Arrays.asList(currentHierarchyEntry.siblingsIds))
+                        if (currentHierarchyEntry.siblingsIds.size() < hierarchyEntryIdLimitation.size() 
+                                && !currentHierarchyEntry.isDomain) {
+                            hierarchyEntryIdLimitation = currentHierarchyEntry.siblingsIds.toSet()
                         }
                     }
                 }
 
                 // reset the values
                 currentMatchesPass = true
-                motifMatchesForCurrentModel = []  as List<FingerPrint>
+                motifMatchesForCurrentModel = []
                 currentModelAcc = rawMatch.modelName
                 assert hierarchyMap[currentModelAcc] != null
                 currentHierarchyEntry = hierarchyMap[currentModelAcc]
@@ -198,15 +180,19 @@ process PARSE_PRINTS {
         // add the filteredMatches to matches
         if (!filteredMatches.isEmpty()) {
             def finalMatches = matches.computeIfAbsent(proteinAccession, { [:] })
-            for (FingerPrint filteredMatch: filteredMatches) {
+            filteredMatches.each { filteredMatch ->
                 // the modelName has been used up to this point, but we need to convert to the model ID
-                Match match = finalMatches.computeIfAbsent(
+                def match = finalMatches.computeIfAbsent(
                     filteredMatch.modelId,
                     {
-                        new Match(filteredMatch.modelId, filteredMatch.evalue, filteredMatch.graphscan, new Signature(filteredMatch.modelId, library))
+                        new uk.ac.ebi.interpro.Match(
+                            filteredMatch.modelId, 
+                            filteredMatch.evalue, 
+                            filteredMatch.graphscan, 
+                            new uk.ac.ebi.interpro.Signature(filteredMatch.modelId, library))
                     }
                 )
-                Location location = new Location(
+                def location = new uk.ac.ebi.interpro.Location(
                     filteredMatch.locationStart,
                     filteredMatch.locationEnd,
                     filteredMatch.pvalue,
@@ -219,10 +205,10 @@ process PARSE_PRINTS {
     }
 
     def filepath = task.workDir.resolve("prints.json")
-    filepath.text = JsonOutput.toJson(matches)
+    filepath.text  = groovy.json.JsonOutput.toJson(matches)
 }
 
-List<FingerPrint> sortMatches(List<FingerPrint> matches) {
+def sortMatches(matches) {
     // This comparator is CRITICAL to the working of PRINTS post-processing
     return matches.sort { matchA, matchB ->
         int evalueComparison = matchA.evalue <=> matchB.evalue
@@ -241,12 +227,7 @@ List<FingerPrint> sortMatches(List<FingerPrint> matches) {
     }
 }
 
-boolean selectMatches(  // check if the matches should be selected. Returns a boolean
-        List<Match> motifMatchesForCurrentModel,
-        String modelName,
-        FingerPrint.HierarchyEntry hierarchy,
-        Set<String> hierarchyEntryIdLimitation
-) {
+def selectMatches(motifMatchesForCurrentModel, modelName, hierarchy, hierarchyEntryIdLimitation) {
     // Belt and braces check
     if (motifMatchesForCurrentModel.size() == 0) { return false }
     // Check that enough motifs for the current model passed the previous filtering criteria

--- a/modules/representative_locations/main.nf
+++ b/modules/representative_locations/main.nf
@@ -18,18 +18,3 @@ process REPRESENTATIVE_LOCATIONS {
     chmod -R 777 outputs
     """
 }
-
-// process REPRESENTATIVE_LOCATIONS {
-//     label    'mem_medium', 'time_short'
-//     executor 'local'
-
-//     input:
-//     tuple val(meta), val(json)
-
-//     output:
-//     tuple val(meta), path('repr_locs/*json', arity: '1..*')
-
-//     exec:
-//     def outdir = task.workDir.resolve("repr_locs")
-//     uk.ac.ebi.interpro.ProcessReprLocations.run(json, outdir)
-// }

--- a/modules/representative_locations/main.nf
+++ b/modules/representative_locations/main.nf
@@ -1,5 +1,6 @@
 process REPRESENTATIVE_LOCATIONS {
-    label     'mem_medium', 'time_short'
+    label     'mem_medium'
+    label     'time_short'
     container 'interpro/groovy:4.0.27-1'
 
     input:

--- a/modules/sfld/main.nf
+++ b/modules/sfld/main.nf
@@ -1,5 +1,7 @@
 process SEARCH_SFLD {
-    label     'mem_min', 'time_veryshort', 'dynamic'
+    label     'mem_min'
+    label     'time_veryshort'
+    label     'dynamic'
     container 'interpro/sfld:ebiftp'
 
     input:
@@ -30,7 +32,8 @@ process SEARCH_SFLD {
 }
 
 process PARSE_SFLD {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/sfld/main.nf
+++ b/modules/sfld/main.nf
@@ -48,7 +48,7 @@ process PARSE_SFLD {
 
     sequences = sequences.collectEntries { seqId, matches -> 
         // Flatten matches (one location per match)
-        matches = matches.collectMany { key, match ->
+        matches = matches.collectMany { _key, match ->
             return match.locations.collect { location ->
                 def signature = new uk.ac.ebi.interpro.Signature(match.modelAccession, library)
                 def newMatch = new uk.ac.ebi.interpro.Match(match.modelAccession, match.evalue, match.score, match.bias, signature)
@@ -100,7 +100,7 @@ process PARSE_SFLD {
 
                     return match
                 }
-                .findAll { it != null }
+                .findAll { m -> m != null }
         }
 
         def matchesWithPromoted = matches.clone()
@@ -135,7 +135,7 @@ process PARSE_SFLD {
         }
 
         // Remove nested locations
-        matches.each { modelAccession, match ->
+        matches.each { _modelAccession, match ->
             def locations = []
             match.locations
                 .sort { a, b ->

--- a/modules/sfld/main.nf
+++ b/modules/sfld/main.nf
@@ -1,13 +1,3 @@
-// codenarc-disable AllowedDirectivesRule
-import groovy.json.JsonOutput
-import java.nio.file.Path
-import uk.ac.ebi.interpro.HMMER3
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-import uk.ac.ebi.interpro.Site
-
 process SEARCH_SFLD {
     label     'mem_min', 'time_veryshort', 'dynamic'
     container 'interpro/sfld:ebiftp'
@@ -51,17 +41,17 @@ process PARSE_SFLD {
     tuple val(meta), path("sfld.json")
 
     exec:
-    def hmmerMatches = HMMER3.parseOutput(hmmsearch_out, "SFLD")
-    def sequences = parseOutput(postprocess_out, hmmerMatches)
-    def hierarchies = getHierarchies(hierarchydb)
-    SignatureLibraryRelease library = new SignatureLibraryRelease("SFLD", null)
+    def hmmerMatches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmsearch_out, "SFLD")
+    def sequences = uk.ac.ebi.interpro.SFLD.parseOutput(postprocess_out, hmmerMatches)
+    def hierarchies = uk.ac.ebi.interpro.SFLD.getHierarchies(hierarchydb)
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("SFLD", null)
 
     sequences = sequences.collectEntries { seqId, matches -> 
         // Flatten matches (one location per match)
         matches = matches.collectMany { key, match ->
             return match.locations.collect { location ->
-                Signature signature = new Signature(match.modelAccession, library)
-                Match newMatch = new Match(match.modelAccession, match.evalue, match.score, match.bias, signature)
+                def signature = new uk.ac.ebi.interpro.Signature(match.modelAccession, library)
+                def newMatch = new uk.ac.ebi.interpro.Match(match.modelAccession, match.evalue, match.score, match.bias, signature)
                 newMatch.addLocation(location.clone())
                 return newMatch
             }
@@ -69,7 +59,7 @@ process PARSE_SFLD {
 
         if (matches.size() > 1) {
             // Remove overlapping matches from models in the same hierarchy (keep the most specific)
-            Set<Integer> ignored = [] as Set
+            def ignored = [] as Set
             matches = matches
                 .collect { match ->
                     if (match.modelAccession.startsWith("SFLDF")) {
@@ -77,32 +67,29 @@ process PARSE_SFLD {
                         return match
                     }
 
-                    boolean ignore = false
-                    for (Match otherMatch: matches) {
-                        if (match.modelAccession == otherMatch.modelAccession) {
+                    def matchAccession = match.modelAccession
+                    def l1 = match.locations[0]
+                    def ignore = matches.any { otherMatch ->
+                        if (matchAccession == otherMatch.modelAccession) {
                             // Two matches/locations from the same mode: keep
-                            continue
-                        } else if (ignored.contains(otherMatch)) {
+                            return false
+                        }
+                        if (ignored.contains(otherMatch)) {
                             // otherMatch has previously been flagged as to be ignored
-                            continue
+                            return false
                         }
 
-                        Location l1 = match.locations[0]
-                        Location l2 = otherMatch.locations[0]
-
-                        if (!(l1.start > l2.end || l2.start > l1.end)) {
-                            // Matches overlap
-                            
-                            def otherParents = hierarchies.get(otherMatch.modelAccession)
-                            if (otherParents != null && otherParents.contains(match.modelAccession)) {
-                                /*
-                                    The current match overlaps a match from a more specific model:
-                                    we want to keep the most specific match, so we ignore the current match
-                                */
-                                ignore = true
-                                break
-                            }    
+                        def l2 = otherMatch.locations[0]
+                        if (l1.start > l2.end || l2.start > l1.end) {
+                            return false
                         }
+
+                        /*
+                            The current match overlaps a match from a more specific model:
+                            we want to keep the most specific match, so we ignore the current match
+                        */
+                        def otherParents = hierarchies.get(otherMatch.modelAccession)
+                        return otherParents != null && otherParents.contains(matchAccession)
                     }
 
                     if (ignore) {
@@ -126,9 +113,9 @@ process PARSE_SFLD {
                     and a sequence matches F, it should inherit the S and G annotations
                 */
                 parents.each { parent ->
-                    Signature signature = new Signature(parent, library)
-                    Match promotedMatch = new Match(parent, match.evalue, match.score, match.bias, signature)
-                    Location location = match.locations[0].clone()
+                    def signature = new uk.ac.ebi.interpro.Signature(parent, library)
+                    def promotedMatch = new uk.ac.ebi.interpro.Match(parent, match.evalue, match.score, match.bias, signature)
+                    def location = match.locations[0].clone()
                     location.sites.clear()
                     promotedMatch.addLocation(location)
                     matchesWithPromoted.add(promotedMatch)
@@ -139,7 +126,7 @@ process PARSE_SFLD {
         // Merge locations from the same model together
         matches = [:]
         matchesWithPromoted.each { match ->
-            Match mergedMatch = matches.get(match.modelAccession)
+            def mergedMatch = matches.get(match.modelAccession)
             if (mergedMatch) {
                 mergedMatch.addLocation(match.locations[0])
             } else {
@@ -155,7 +142,7 @@ process PARSE_SFLD {
                     a.start <=> b.start ?: b.end <=> a.end
                 }
                 .each { location ->
-                    boolean isContained = locations.any { loc ->
+                    def isContained = locations.any { loc ->
                         loc.start <= location.start && loc.end >= location.end
                     }
                     if (!isContained) {
@@ -170,111 +157,5 @@ process PARSE_SFLD {
     }
 
     def filepath = task.workDir.resolve("sfld.json")
-    filepath.text = JsonOutput.toJson(sequences)
-}
-
-Map<String, Set<String>> getHierarchies(Path filePath) {
-    def hierarchies = [:].withDefault { [] as Set }
-    filePath.eachLine { line ->
-        def nodes = line.split(/\t/).toList()
-        nodes.eachWithIndex { node, idx ->
-            if (idx > 0) {
-                def ancestors = nodes.subList(0, idx) as Set
-                hierarchies[node].addAll(ancestors)
-            }
-        }
-    }
-    return hierarchies
-}
-
-Map<String, Map<String, Match>> parseOutput(
-    Path filePath,
-    Map<String, Map> hmmerMatches
-) {
-    // Parse the output TSV file from the SFLD postprocess bin
-    def matches = [:]
-    filePath.withReader{ reader ->
-        while (true) {
-            String sequenceId = null
-
-            for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-                def matcher = line.trim() =~ ~/^Sequence:\s+(\S+)$/
-                if (matcher.find()) {
-                    sequenceId = matcher.group(1).trim()
-                    break
-                }
-            }
-
-            if (sequenceId == null) {
-                break
-            }
-
-            assert hmmerMatches.containsKey(sequenceId)
-            def seqHmmerMatches = hmmerMatches[sequenceId]
-            matches[sequenceId] = parseBlock(reader, sequenceId, seqHmmerMatches)
-        }
-    }
-
-    return matches
-}
-
-Map<String, Match> parseBlock(
-    Reader reader,
-    String sequenceId,
-    Map<String, Map> seqHmmerMatches
-) {
-    SignatureLibraryRelease library = new SignatureLibraryRelease("SFLD", null)
-    boolean inDomains = false
-    def domains = [:]
-    while (true) {
-        String line = reader.readLine()?.trim()
-        if (!line) break
-        if (line == "Domains:") {
-            inDomains = true
-        } else if (line == "Sites:") {
-            inDomains = false
-        } else if (line == "//") {
-            break
-        } else if (inDomains) {
-            def fields = line.split(/\t/)
-            assert fields.length == 15
-            String modelAccession = fields[0]
-            Integer hmmStart = fields[4] as Integer
-            Integer hmmEnd = fields[5] as Integer
-            int aliStart = fields[7] as int
-            int aliEnd = fields[8] as int
-            Integer envStart = fields[9] as Integer
-            Integer envEnd = fields[10] as Integer
-            assert seqHmmerMatches.containsKey(modelAccession)
-            def hmmerMatch = seqHmmerMatches[modelAccession]
-            Location loc = hmmerMatch.locations.find { it.start == aliStart 
-                                                        && it.end == aliEnd 
-                                                        && it.hmmStart == hmmStart 
-                                                        && it.hmmEnd == hmmEnd 
-                                                        && it.envelopeStart == envStart 
-                                                        && it.envelopeEnd == envEnd }
-            assert loc != null
-            Match match = domains.computeIfAbsent(modelAccession, k -> {
-                Signature signature = new Signature(modelAccession, library)
-                return new Match(modelAccession, hmmerMatch.evalue, hmmerMatch.score, hmmerMatch.bias, signature)
-            });
-            match.addLocation(loc)
-        } else {
-            def fields = line.split(/\s/, 3)
-            assert fields.length == 2 || fields.length == 3
-            if (fields.length == 3) {
-                String modelAccession = fields[0]
-                String residues = fields[1]
-                String description = fields[2]
-                Match match = domains.get(modelAccession)
-                if (match != null) {
-                    Site site = new Site(description, residues)
-                    match.addSite(site)                        
-                }
-            }
-            
-        }
-    }
-
-    return domains
+    filepath.text = groovy.json.JsonOutput.toJson(sequences)
 }

--- a/modules/signalp/main.nf
+++ b/modules/signalp/main.nf
@@ -1,10 +1,3 @@
-import groovy.json.JsonSlurper
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-
 process RUN_SIGNALP_CPU {
     label     'mem_medium', 'time_medium'
     container 'interpro/signalp:6.0i'
@@ -77,17 +70,16 @@ process PARSE_SIGNALP {
 
     exec:
     def jsonPath = signalp_out.resolve("output.json")
-    def jsonSlurper = new JsonSlurper()
-    def jsonOutput = jsonSlurper.parse(jsonPath)
+    def jsonOutput = new groovy.json.JsonSlurper().parse(jsonPath)
 
-    String modelAcc = "SignalP_${mode}_${organism}"
-    SignatureLibraryRelease library = new SignatureLibraryRelease("SignalP", "6.0i")
+    def modelAcc = "SignalP_${mode}_${organism}"
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("SignalP", "6.0i")
     def signatures = [
-        "Sec/SPI"  : new Signature("SignalP-Sec-SPI", "Sec/SPI", "Sec signal peptide", library, null),
-        "Sec/SPII" : new Signature("SignalP-Sec-SPII", "Sec/SPII", "Lipoprotein signal peptide", library, null),
-        "Tat/SPI"  : new Signature("SignalP-Tat-SPI", "Tat/SPI", "Tat signal peptide", library, null),
-        "Tat/SPII" : new Signature("SignalP-Tat-SPII", "Tat/SPII", "Tat lipoprotein signal peptide", library, null),
-        "Sec/SPIII": new Signature("SignalP-Sec-SPIII", "Sec/SPIII", "Pilin signal peptide", library, null),
+        "Sec/SPI"  : new uk.ac.ebi.interpro.Signature("SignalP-Sec-SPI", "Sec/SPI", "Sec signal peptide", library, null),
+        "Sec/SPII" : new uk.ac.ebi.interpro.Signature("SignalP-Sec-SPII", "Sec/SPII", "Lipoprotein signal peptide", library, null),
+        "Tat/SPI"  : new uk.ac.ebi.interpro.Signature("SignalP-Tat-SPI", "Tat/SPI", "Tat signal peptide", library, null),
+        "Tat/SPII" : new uk.ac.ebi.interpro.Signature("SignalP-Tat-SPII", "Tat/SPII", "Tat lipoprotein signal peptide", library, null),
+        "Sec/SPIII": new uk.ac.ebi.interpro.Signature("SignalP-Sec-SPIII", "Sec/SPIII", "Pilin signal peptide", library, null),
     ]
 
     def gff3Path = signalp_out.resolve("output.gff3")
@@ -99,27 +91,27 @@ process PARSE_SIGNALP {
 
         def fields = line.split(/\t/)
         assert fields.size() == 9
-        String seqHeader = fields[0]
-        String seqId = seqHeader.split(/\s+/)[0]
-        int start = fields[3].toInteger()
-        int end = fields[4].toInteger()
+        def seqHeader = fields[0]
+        def seqId = seqHeader.split(/\s+/)[0]
+        def start = fields[3].toInteger()
+        def end = fields[4].toInteger()
         if (start < 0 || end < 0) {
             return
         }
-        Double score = Double.parseDouble(fields[5])
-        String prediction = jsonOutput["SEQUENCES"][seqHeader]["Prediction"]
+        def score = Double.parseDouble(fields[5])
+        def prediction = jsonOutput["SEQUENCES"][seqHeader]["Prediction"]
 
         def matcher = prediction =~ /\(([a-zA-Z]+\/[a-zA-Z]+)\)/
-        String spType = matcher.find() ? matcher.group(1) : null
-        Signature signature = signatures.get(spType)
+        def spType = matcher.find() ? matcher.group(1) : null
+        def signature = signatures.get(spType)
         assert signature != null
-        Match match = new Match(modelAcc, signature)
-        Location location = new Location(start, end)
+        def match = new uk.ac.ebi.interpro.Match(modelAcc, signature)
+        def location = new uk.ac.ebi.interpro.Location(start, end)
         location.score = score
         match.addLocation(location)
         hits[seqId] = [(modelAcc) : match]
     }
 
     def outputFile = task.workDir.resolve("signalp.json")
-    outputFile.text = JsonOutput.toJson(hits)
+    outputFile.text  = groovy.json.JsonOutput.toJson(hits)
 }

--- a/modules/signalp/main.nf
+++ b/modules/signalp/main.nf
@@ -1,5 +1,6 @@
 process RUN_SIGNALP_CPU {
-    label     'mem_medium', 'time_medium'
+    label     'mem_medium'
+    label     'time_medium'
     container 'interpro/signalp:6.0i'
 
     input:
@@ -29,7 +30,9 @@ process RUN_SIGNALP_CPU {
 }
 
 process RUN_SIGNALP_GPU {
-    label     'mem_medium', 'time_medium', 'use_gpu'
+    label     'mem_medium'
+    label     'time_medium'
+    label     'use_gpu'
     container 'interpro/signalp:6.0i'
 
     input:
@@ -59,7 +62,8 @@ process RUN_SIGNALP_GPU {
 }
 
 process PARSE_SIGNALP {
-    label    'mem_low', 'time_short'
+    label    'mem_low'
+    label    'time_short'
     executor 'local'
 
     input:

--- a/modules/smart/main.nf
+++ b/modules/smart/main.nf
@@ -1,15 +1,3 @@
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
-import java.nio.file.StandardCopyOption
-import java.util.zip.ZipEntry
-import java.util.zip.ZipFile
-import java.util.zip.ZipOutputStream
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.FastaFile
-import uk.ac.ebi.interpro.HMMER2
-import uk.ac.ebi.interpro.HMMER3
-
 process PREFILTER_SMART {
     label     'mem_min', 'time_veryshort', 'dynamic'
     container 'interpro/smart:1.0'
@@ -40,20 +28,20 @@ process PREPARE_SMART {
     tuple val(meta), path("sequences.zip")
 
     exec:
-    def sequences = FastaFile.parse(fasta)  // [md5: sequence]
-    def matches = HMMER3.parseOutput(hmmseach_out, "SMART")
+    def sequences = uk.ac.ebi.interpro.FastaFile.parse(fasta)  // [md5: sequence]
+    def matches = uk.ac.ebi.interpro.HMMER3.parseOutput(hmmseach_out, "SMART")
 
     // Map model accessions to seq Ids -> [modelAcc: [seqIds]]
     def model2seqs = [:].withDefault { [] }
     matches.each { seqId, seqMatches ->
-        seqMatches.each { modelAcc, _ ->
+        seqMatches.each { modelAcc, match ->
             model2seqs[modelAcc] << seqId
         }
     }
 
     def zipFile = task.workDir.resolve("sequences.zip")
-    Files.newOutputStream(zipFile).withCloseable { os ->
-        new ZipOutputStream(os).withCloseable { zip ->
+    java.nio.file.Files.newOutputStream(zipFile).withCloseable { os ->
+        new java.util.zip.ZipOutputStream(os).withCloseable { zip ->
             // Create a FASTA file for each profile to search with
             model2seqs.sort().each { modelAcc, seqIds ->
                 def fastaFile = task.workDir.resolve("${modelAcc}.faa")
@@ -65,11 +53,11 @@ process PREPARE_SMART {
                     }
                 }
 
-                ZipEntry entry = new ZipEntry(fastaFile.fileName.toString())
+                def entry = new java.util.zip.ZipEntry(fastaFile.fileName.toString())
                 zip.putNextEntry(entry)
-                Files.copy(fastaFile, zip)
+                java.nio.file.Files.copy(fastaFile, zip)
                 zip.closeEntry()
-                Files.delete(fastaFile);
+                java.nio.file.Files.delete(fastaFile);
             }
         }
     }
@@ -127,64 +115,64 @@ process PARSE_SMART {
     def hmmpfam_out = null
 
     def tmp_zip = task.workDir.resolve("temp.zip")
-    Files.newInputStream(fasta_zip).withCloseable { is ->
-        Files.copy(is, tmp_zip, StandardCopyOption.REPLACE_EXISTING)
+    java.nio.file.Files.newInputStream(fasta_zip).withCloseable { is ->
+        java.nio.file.Files.copy(is, tmp_zip, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
     }
 
-    new ZipFile(tmp_zip.toFile()).withCloseable { zip ->
+    new java.util.zip.ZipFile(tmp_zip.toFile()).withCloseable { zip ->
         zip.entries().each { entry ->
             if (entry.isDirectory()) {
                 // Should never happen
                 return
             }
 
-            def fileName = Paths.get(entry.name).fileName.toString()
-            Path extracted = task.workDir.resolve(fileName)
+            def fileName = java.nio.file.Paths.get(entry.name).fileName.toString()
+            def extracted = task.workDir.resolve(fileName)
 
             zip.getInputStream(entry).withCloseable { input ->
-                Files.copy(input, extracted, StandardCopyOption.REPLACE_EXISTING)
+                java.nio.file.Files.copy(input, extracted, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
             }
 
-            sequences = sequences + FastaFile.parse(extracted)
-            Files.deleteIfExists(extracted)
+            sequences = sequences + uk.ac.ebi.interpro.FastaFile.parse(extracted)
+            java.nio.file.Files.deleteIfExists(extracted)
         }
     }
 
-    Files.newInputStream(search_zip).withCloseable { is ->
-        Files.copy(is, tmp_zip, StandardCopyOption.REPLACE_EXISTING)
+    java.nio.file.Files.newInputStream(search_zip).withCloseable { is ->
+        java.nio.file.Files.copy(is, tmp_zip, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
     }
 
-    new ZipFile(tmp_zip.toFile()).withCloseable { zip ->
+    new java.util.zip.ZipFile(tmp_zip.toFile()).withCloseable { zip ->
         zip.entries().each { entry ->
             if (entry.isDirectory()) {
                 // Should never happen
                 return
             }
 
-            def fileName = Paths.get(entry.name).fileName.toString()
-            Path extracted = task.workDir.resolve(fileName)
+            def fileName = java.nio.file.Paths.get(entry.name).fileName.toString()
+            def extracted = task.workDir.resolve(fileName)
 
             zip.getInputStream(entry).withCloseable { input ->
-                Files.copy(input, extracted, StandardCopyOption.REPLACE_EXISTING)
+                java.nio.file.Files.copy(input, extracted, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
             }
 
             if (fileName == "hmmpfam.out") {
                 hmmpfam_out = extracted
             } else {
-                def (accession, length) = HMMER2.parseHMM(extracted)
+                def (accession, length) = uk.ac.ebi.interpro.HMMER2.parseHMM(extracted)
                 hmm_lengths[accession] = length
-                Files.deleteIfExists(extracted)
+                java.nio.file.Files.deleteIfExists(extracted)
             }
         }
     }
 
-    Files.deleteIfExists(tmp_zip)
+    java.nio.file.Files.deleteIfExists(tmp_zip)
    
-    def matches = HMMER2.parseOutput(hmmpfam_out, hmm_lengths, "SMART")
+    def matches = uk.ac.ebi.interpro.HMMER2.parseOutput(hmmpfam_out, hmm_lengths, "SMART")
 
-    String tyrKinaseAccession = "SM00219"
+    def tyrKinaseAccession = "SM00219"
     def tyrKinasePattern = ~/.*HRD[LIV][AR]\w\wN.*/
-    String serThrKinaseAccession = "SM00220"
+    def serThrKinaseAccession = "SM00220"
     def serThrKinasePattern = ~/.*D[LIVM]K\w\wN.*/
 
     def filteredMatches = matches.collectEntries { seqId, models ->
@@ -196,9 +184,9 @@ process PARSE_SMART {
                 have a hit against the same sequence,
                 we need to perform an additional check before selecting them
             */
-            String sequence = sequences[seqId]
-            boolean tyrKinaseOK = (sequence ==~ tyrKinasePattern)
-            boolean serThrKinaseOK = (sequence ==~ serThrKinasePattern)
+            def sequence = sequences[seqId]
+            def tyrKinaseOK = (sequence ==~ tyrKinasePattern)
+            def serThrKinaseOK = (sequence ==~ serThrKinasePattern)
 
             models.each { modelAccession, match ->
                 if (modelAccession != tyrKinaseAccession &&
@@ -218,5 +206,5 @@ process PARSE_SMART {
     }
 
     def outputFilePath = task.workDir.resolve("smart.json")
-    outputFilePath.text = JsonOutput.toJson(filteredMatches)
+    outputFilePath.text  = groovy.json.JsonOutput.toJson(filteredMatches)
 }

--- a/modules/smart/main.nf
+++ b/modules/smart/main.nf
@@ -1,5 +1,7 @@
 process PREFILTER_SMART {
-    label     'mem_min', 'time_veryshort', 'dynamic'
+    label     'mem_min'
+    label     'time_veryshort'
+    label     'dynamic'
     container 'interpro/smart:1.0'
 
     input:
@@ -18,7 +20,8 @@ process PREFILTER_SMART {
 }
 
 process PREPARE_SMART {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:
@@ -64,7 +67,9 @@ process PREPARE_SMART {
 }
 
 process SEARCH_SMART {
-    label     'mem_min', 'time_veryshort', 'dynamic'
+    label     'mem_min'
+    label     'time_veryshort'
+    label     'dynamic'
     container 'interpro/smart:1.0'
 
     input:
@@ -100,7 +105,8 @@ process SEARCH_SMART {
 }
 
 process PARSE_SMART {
-    label    'mem_low', 'time_short'
+    label    'mem_low'
+    label    'time_short'
     executor 'local'
 
     input:

--- a/modules/smart/main.nf
+++ b/modules/smart/main.nf
@@ -34,7 +34,7 @@ process PREPARE_SMART {
     // Map model accessions to seq Ids -> [modelAcc: [seqIds]]
     def model2seqs = [:].withDefault { [] }
     matches.each { seqId, seqMatches ->
-        seqMatches.each { modelAcc, match ->
+        seqMatches.each { modelAcc, _match ->
             model2seqs[modelAcc] << seqId
         }
     }
@@ -49,7 +49,7 @@ process PREPARE_SMART {
                     seqIds.sort().each { seqId ->
                         def seq = sequences[seqId]
                         writer.writeLine(">${seqId}")
-                        seq.eachMatch(/.{1,60}/) { writer.writeLine(it) }
+                        seq.eachMatch(/.{1,60}/) { m -> writer.writeLine(m) }
                     }
                 }
 

--- a/modules/superfamily/main.nf
+++ b/modules/superfamily/main.nf
@@ -1,5 +1,7 @@
 process SEARCH_SUPERFAMILY {
-    label     'mem_min', 'time_short', 'dynamic'
+    label     'mem_min'
+    label     'time_short'
+    label     'dynamic'
     container 'interpro/hmmer:3.3'
 
     input:
@@ -29,7 +31,8 @@ process SEARCH_SUPERFAMILY {
 }
 
 process PARSE_SUPERFAMILY {
-    label    'mem_low', 'time_veryshort'
+    label    'mem_low'
+    label    'time_veryshort'
     executor 'local'
 
     input:

--- a/modules/superfamily/main.nf
+++ b/modules/superfamily/main.nf
@@ -1,10 +1,3 @@
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.LocationFragment
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-
 process SEARCH_SUPERFAMILY {
     label     'mem_min', 'time_short', 'dynamic'
     container 'interpro/hmmer:3.3'
@@ -47,25 +40,26 @@ process PARSE_SUPERFAMILY {
     tuple val(meta), val(meta2), path("superfamily.json")
 
     exec:
-    SignatureLibraryRelease library = new SignatureLibraryRelease("SUPERFAMILY", null)
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("SUPERFAMILY", null)
     def model2sf = [:]
     dirpath.resolve(model_tab).eachLine { line ->
         def fields = line.trim().split(/\t/)
-        String modelId = fields[0]
-        String superfamilyAccession = fields[1]
+        def modelId = fields[0]
+        def superfamilyAccession = fields[1]
         assert !model2sf.containsKey(modelId)
         model2sf[modelId] = "SSF${superfamilyAccession}"
     }
 
     def model2length = [:]
-    String modelAc = null
-    Integer length = null
+    def modelAc = null
+    def length = null
     dirpath.resolve(hmm).eachLine { line ->
         line = line.trim()
         if (line.startsWith('//')) {
             assert modelAc != null && length != null
             model2length[modelAc] = length
-            modelAc = length = null
+            modelAc = null
+            length = null
         } else if (line.startsWith('N') && !modelAc) {
             def match = (line =~ ~/^NAME\s+(.+)$/)
             if (match) modelAc = match[0][1]
@@ -81,21 +75,21 @@ process PARSE_SUPERFAMILY {
         if (line) {
             def fields = line.split(/\s+/)
             assert fields.size() == 9
-            String seqId = fields[0]
-            String modelId = fields[1]
+            def seqId = fields[0]
+            def modelId = fields[1]
             if (modelId != "-") {
-                String superfamilyAccession = model2sf[modelId]
+                def superfamilyAccession = model2sf[modelId]
                 assert superfamilyAccession != null
 
-                String regionsAsString = fields[2]
-                Double evalue = Double.parseDouble(fields[3])
+                def regionsAsString = fields[2]
+                def evalue = Double.parseDouble(fields[3])
 
                 def regions = []
                 regionsAsString.split(",").each { region ->
                     def boundaries = region.split("-")
                     assert boundaries.size() == 2
-                    int start = boundaries[0].toInteger()
-                    int end = boundaries[1].toInteger()
+                    def start = boundaries[0].toInteger()
+                    def end = boundaries[1].toInteger()
                     regions.add([start, end])
                 }
 
@@ -106,14 +100,14 @@ process PARSE_SUPERFAMILY {
                     a[0] <=> b[0] ?: a[1] <=> b[1]
                 }
 
-                int start = regions[0][0]
-                int end = regions.collect { it[1] }.max()
-                Integer hmmLength = model2length[modelId]
-                List<LocationFragment> fragments = []
+                def start = regions[0][0]
+                def end = regions.collect { it[1] }.max()
+                def hmmLength = model2length[modelId]
+                def fragments = []
                 if (regions.size() > 1) {
                     regions.eachWithIndex { obj, idx ->
                         def (fragStart, fragEnd) = obj
-                        String dcStatus
+                        def dcStatus
                         if (idx == 0) {
                             dcStatus = "C_TERMINAL_DISC"
                         } else if (idx == regions.size() - 1) {
@@ -121,18 +115,18 @@ process PARSE_SUPERFAMILY {
                         } else {
                             dcStatus = "NC_TERMINAL_DISC"
                         }
-                        fragments.add(new LocationFragment(fragStart, fragEnd, dcStatus))
+                        fragments.add(new uk.ac.ebi.interpro.LocationFragment(fragStart, fragEnd, dcStatus))
                     }
 
                 } else {
                     def (fragStart, fragEnd) = regions[0]
-                    fragments.add(new LocationFragment(fragStart, fragEnd, "CONTINUOUS"))
+                    fragments.add(new uk.ac.ebi.interpro.LocationFragment(fragStart, fragEnd, "CONTINUOUS"))
                 }
 
-                Location location = new Location(start, end, hmmLength, evalue, fragments)
-                Match match = matches[seqId][modelId]
+                def location = new uk.ac.ebi.interpro.Location(start, end, hmmLength, evalue, fragments)
+                def match = matches[seqId][modelId]
                 if (match == null) {
-                    match = new Match(modelId, new Signature(superfamilyAccession, library))
+                    match = new uk.ac.ebi.interpro.Match(modelId, new uk.ac.ebi.interpro.Signature(superfamilyAccession, library))
                     match.addLocation(location)
                     matches[seqId][modelId] = match
                 } else {
@@ -143,5 +137,5 @@ process PARSE_SUPERFAMILY {
     }
 
     def filepath = task.workDir.resolve("superfamily.json")
-    filepath.text = JsonOutput.toJson(matches)
+    filepath.text  = groovy.json.JsonOutput.toJson(matches)
 }

--- a/modules/superfamily/main.nf
+++ b/modules/superfamily/main.nf
@@ -101,7 +101,7 @@ process PARSE_SUPERFAMILY {
                 }
 
                 def start = regions[0][0]
-                def end = regions.collect { it[1] }.max()
+                def end = regions.collect { r -> r[1] }.max()
                 def hmmLength = model2length[modelId]
                 def fragments = []
                 if (regions.size() > 1) {

--- a/modules/tmbed/main.nf
+++ b/modules/tmbed/main.nf
@@ -1,5 +1,6 @@
 process PREPARE_TMBED {
-    label    'mem_low', 'time_short'
+    label    'mem_low'
+    label    'time_short'
     executor 'local'
 
     input:
@@ -34,7 +35,9 @@ process PREPARE_TMBED {
 }
 
 process RUN_TMBED_CPU {
-    label     'mem_high', 'time_medium', 'dynamic'
+    label     'mem_high'
+    label     'time_medium'
+    label     'dynamic'
     container 'interpro/tmbed:1.0.2'
 
     input:
@@ -56,7 +59,9 @@ process RUN_TMBED_CPU {
 }
 
 process RUN_TMBED_GPU {
-    label     'mem_medium', 'time_short', 'use_gpu'
+    label     'mem_medium'
+    label     'time_short'
+    label     'use_gpu'
     container 'interpro/tmbed:1.0.2'
 
     input:
@@ -78,7 +83,8 @@ process RUN_TMBED_GPU {
 }
 
 process PARSE_TMBED {
-    label    'mem_low', 'time_short'
+    label    'mem_low'
+    label    'time_short'
     executor 'local'
 
     input:

--- a/modules/tmbed/main.nf
+++ b/modules/tmbed/main.nf
@@ -143,12 +143,12 @@ process PARSE_TMBED {
         if (chunks.size() > 1) {
             chunks.subList(1, chunks.size()).each { chunk ->
                 def chunkPred = chunk.pred
-                int chunkPredLen = chunkPred.length()
+                def chunkPredLen = chunkPred.length()
 
                 // Effective overlap might be smaller than chunk_overlap for the last chunk
-                int effOverlap = Math.min(chunk_overlap, chunkPredLen)
-                int mergedLen = mergedPred.length()
-                int overlapStart = mergedLen - effOverlap
+                def effOverlap = Math.min(chunk_overlap, chunkPredLen)
+                def mergedLen = mergedPred.length()
+                def overlapStart = mergedLen - effOverlap
 
                 // Build a "reconciled" overlap region by comparing per-residue predictions
                 def mergedOverlap = new StringBuilder(effOverlap)
@@ -160,8 +160,8 @@ process PARSE_TMBED {
                     } else {
                         /* Conflict between predictions
                            Resolve by local consensus using a +/- 2 residue window */
-                        int winStart = Math.max(0, j - 2)
-                        int winEnd = Math.min(effOverlap, j + 3)
+                        def winStart = Math.max(0, j - 2)
+                        def winEnd = Math.min(effOverlap, j + 3)
                         def winPrev = mergedPred.substring(overlapStart + winStart, overlapStart + winEnd)
                         def winNext = chunkPred.substring(winStart, winEnd)
                         def mostPrev = mostCommonChar(winPrev)
@@ -231,17 +231,17 @@ process PARSE_TMBED {
 
 
 /** Apply categorical smoothing (mode over a sliding window) */
-def smoothString(String s, int window) {
-    int half = Math.floor(window / 2) as int
+def smoothString(s, window) {
+    def half = Math.floor(window / 2) as int
     return (0..<s.size()).collect { i ->
-        int start = Math.max(0, i - half)
-        int end = Math.min(s.size(), i + half + 1)
+        def start = Math.max(0, i - half)
+        def end = Math.min(s.size(), i + half + 1)
         mostCommonChar(s.substring(start, end))
     }.join()
 }
 
 /** Return the most frequent character in a string */
-def mostCommonChar(String s) {
+def mostCommonChar(s) {
     def counts = [:].withDefault { 0 }
     s.each { c -> counts[c] += 1 }
     return counts.max { elem -> elem.value }.key

--- a/modules/tmbed/main.nf
+++ b/modules/tmbed/main.nf
@@ -237,7 +237,7 @@ def smoothString(s, window) {
         def start = Math.max(0, i - half)
         def end = Math.min(s.size(), i + half + 1)
         mostCommonChar(s.substring(start, end))
-    }.join()
+    }.inject(new StringBuilder()) { sb, c -> sb.append(c) }.toString()
 }
 
 /** Return the most frequent character in a string */

--- a/modules/tmbed/main.nf
+++ b/modules/tmbed/main.nf
@@ -25,7 +25,7 @@ process PREPARE_TMBED {
         }
         seq.chunks.eachWithIndex { chunk, idx ->
             writer.writeLine(">${seq.id}_${idx + 1}")
-            chunk.eachMatch(/.{1,60}/) { writer.writeLine(it) }
+            chunk.eachMatch(/.{1,60}/) { m -> writer.writeLine(m) }
             seqCount += 1
         }
     }
@@ -121,7 +121,6 @@ process PARSE_TMBED {
         lineCounter += 1
     }
 
-    def mergedList = []
     def hits = [:].withDefault { [:] }
     def libRelease = new uk.ac.ebi.interpro.SignatureLibraryRelease("TMbed", "1.0.2")
     def MODEL_TYPES = [  // Sig(acc, name, desc, type, lib, entry)
@@ -244,6 +243,6 @@ def smoothString(String s, int window) {
 /** Return the most frequent character in a string */
 def mostCommonChar(String s) {
     def counts = [:].withDefault { 0 }
-    s.each { counts[it] += 1 }
-    return counts.max { it.value }.key
+    s.each { c -> counts[c] += 1 }
+    return counts.max { elem -> elem.value }.key
 }

--- a/modules/tmbed/main.nf
+++ b/modules/tmbed/main.nf
@@ -1,11 +1,3 @@
-// codenarc-disable AllowedDirectivesRule
-import groovy.json.JsonOutput
-import uk.ac.ebi.interpro.FastaFile
-import uk.ac.ebi.interpro.Location
-import uk.ac.ebi.interpro.Match
-import uk.ac.ebi.interpro.Signature
-import uk.ac.ebi.interpro.SignatureLibraryRelease
-
 process PREPARE_TMBED {
     label    'mem_low', 'time_short'
     executor 'local'
@@ -20,31 +12,25 @@ process PREPARE_TMBED {
     tuple val(meta), path("tmbed_*.fasta", arity: '1..*')
 
     exec:
-    def sequences = FastaFile.chunkSequences(fasta, chunk_size, chunk_overlap)
+    def sequences = uk.ac.ebi.interpro.FastaFile.chunkSequences(fasta, chunk_size, chunk_overlap)
     def fileIndex = 1
     def seqCount = 0
-    def writer = null
-    def openNewFile = {
-        if (writer) writer.close()
-        writer = task.workDir.resolve("tmbed_${fileIndex}.fasta").newWriter("UTF-8")
-        fileIndex++
-        seqCount = 0
-        return writer
-    }
-
-    writer = openNewFile()
+    def writer = task.workDir.resolve("tmbed_${fileIndex}.fasta").newWriter("UTF-8")
     sequences.each { seq ->
         if (batch_size > 0 && seqCount >= batch_size) {
-            writer = openNewFile()
+            writer.close()
+            fileIndex += 1
+            seqCount = 0
+            writer = task.workDir.resolve("tmbed_${fileIndex}.fasta").newWriter("UTF-8")
         }
         seq.chunks.eachWithIndex { chunk, idx ->
             writer.writeLine(">${seq.id}_${idx + 1}")
             chunk.eachMatch(/.{1,60}/) { writer.writeLine(it) }
-            seqCount++
+            seqCount += 1
         }
     }
 
-    if (writer) writer.close()
+    writer.close()
 }
 
 process RUN_TMBED_CPU {
@@ -137,13 +123,13 @@ process PARSE_TMBED {
 
     def mergedList = []
     def hits = [:].withDefault { [:] }
-    SignatureLibraryRelease libRelease = new SignatureLibraryRelease("TMbed", "1.0.2")
+    def libRelease = new uk.ac.ebi.interpro.SignatureLibraryRelease("TMbed", "1.0.2")
     def MODEL_TYPES = [  // Sig(acc, name, desc, type, lib, entry)
-        "b": new Signature("TMbeta_out-to-in", "Transmembrane beta strand (out-to-in)", null, "Region", libRelease, null),
-        "B": new Signature("TMbeta_in-to-out" ,"Transmembrane beta strand (in-to-out)", null, "Region", libRelease, null),
-        "h": new Signature("TMhelix_out-to-in", "Transmembrane alpha helix (out-to-in)", null, "Region", libRelease, null),
-        "H": new Signature("TMhelix_in-to-out", "Transmembrane alpha helix (in-to-out)", null, "Region", libRelease, null),
-        "S": new Signature("Signal_peptide", "Signal peptide", null, "Region", libRelease, null)
+        "b": new uk.ac.ebi.interpro.Signature("TMbeta_out-to-in", "Transmembrane beta strand (out-to-in)", null, "Region", libRelease, null),
+        "B": new uk.ac.ebi.interpro.Signature("TMbeta_in-to-out" ,"Transmembrane beta strand (in-to-out)", null, "Region", libRelease, null),
+        "h": new uk.ac.ebi.interpro.Signature("TMhelix_out-to-in", "Transmembrane alpha helix (out-to-in)", null, "Region", libRelease, null),
+        "H": new uk.ac.ebi.interpro.Signature("TMhelix_in-to-out", "Transmembrane alpha helix (in-to-out)", null, "Region", libRelease, null),
+        "S": new uk.ac.ebi.interpro.Signature("Signal_peptide", "Signal peptide", null, "Region", libRelease, null)
     ]
     chunksbySeqId.each { hitId, chunks ->
         // Sort chunks to ensure correct order before starting to merge 
@@ -155,43 +141,46 @@ process PARSE_TMBED {
         def mergedPred = new StringBuilder(chunks[0].pred)
 
         // Merge subsequent chunks
-        for (int i = 1; i < chunks.size(); i++) {
-            def chunkPred = chunks[i].pred
+        if (chunks.size() > 1) {
+            chunks.subList(1, chunks.size()).each { chunk ->
+                def chunkPred = chunk.pred
+                int chunkPredLen = chunkPred.length()
 
-            // Effective overlap might be smaller than chunk_overlap for the last chunk
-            int effOverlap = Math.min(chunk_overlap, chunkPred.length())
+                // Effective overlap might be smaller than chunk_overlap for the last chunk
+                int effOverlap = Math.min(chunk_overlap, chunkPredLen)
+                int mergedLen = mergedPred.length()
+                int overlapStart = mergedLen - effOverlap
 
-            // Extract overlapping regions
-            def overlapPrev = mergedPred.substring(mergedPred.length() - effOverlap)
-            def overlapNext = chunkPred.substring(0, effOverlap)
-
-            // Build a "reconciled" overlap region by comparing per-residue predictions
-            def mergedOverlap = new StringBuilder()
-            for (int j = 0; j < effOverlap; j++) {
-                def a = overlapPrev.charAt(j)
-                def b = overlapNext.charAt(j)
-                if (a == b) {
-                    mergedOverlap.append(a)
-                } else {
-                    /* Conflict between predictions
-                       Resolve by local consensus using a +/- 2 residue window */
-                    def winPrev = overlapPrev.substring(Math.max(0, j - 2), Math.min(effOverlap, j + 3))
-                    def winNext = overlapNext.substring(Math.max(0, j - 2), Math.min(effOverlap, j + 3))
-                    def mostPrev = mostCommonChar(winPrev)
-                    def mostNext = mostCommonChar(winNext)
-                    /* If the current prediction agrees with the local consensus 
-                       of the previous chunk, we prefer that prediction as 
-                       it reflects the accumulated consensus and preserves continuity 
-                       across chunk boundaries */
-                    mergedOverlap.append(mostPrev == a ? mostPrev : mostNext)
+                // Build a "reconciled" overlap region by comparing per-residue predictions
+                def mergedOverlap = new StringBuilder(effOverlap)
+                effOverlap.times { j ->
+                    def a = mergedPred.charAt(overlapStart + j)
+                    def b = chunkPred.charAt(j)
+                    if (a == b) {
+                        mergedOverlap.append(a)
+                    } else {
+                        /* Conflict between predictions
+                           Resolve by local consensus using a +/- 2 residue window */
+                        int winStart = Math.max(0, j - 2)
+                        int winEnd = Math.min(effOverlap, j + 3)
+                        def winPrev = mergedPred.substring(overlapStart + winStart, overlapStart + winEnd)
+                        def winNext = chunkPred.substring(winStart, winEnd)
+                        def mostPrev = mostCommonChar(winPrev)
+                        def mostNext = mostCommonChar(winNext)
+                        /* If the current prediction agrees with the local consensus
+                           of the previous chunk, we prefer that prediction as
+                           it reflects the accumulated consensus and preserves continuity
+                           across chunk boundaries */
+                        mergedOverlap.append(mostPrev == a ? mostPrev : mostNext)
+                    }
                 }
+
+                // Replace the overlapping region in mergedPred with the reconciled overlap
+                mergedPred.setLength(overlapStart)
+                mergedPred.append(mergedOverlap).append(chunkPred, effOverlap, chunkPredLen)
             }
-
-            // Replace the overlapping region in mergedPred with the reconciled overlap
-            mergedPred.setLength(mergedPred.length() - effOverlap)
-            mergedPred.append(mergedOverlap).append(chunkPred.substring(effOverlap))
         }
-
+        
         // Smoothing step to avoid short suprious regions introduced by merging
         def mergedPredStr = mergedPred.toString()
         if (chunks.size() > 1 && smooth_window > 1) {
@@ -199,25 +188,25 @@ process PARSE_TMBED {
         }
 
         // Parse merged predictions into Match objects
-        Match currentMatch = null
+        def currentMatch = null
         def start = null
         def end = null
         mergedPredStr.eachWithIndex { symbol, position ->
             end = position
             if (symbol != ".") { // Found a hit
                 if (!currentMatch) {  // Start a new match
-                    Signature signature = MODEL_TYPES[symbol]
+                    def signature = MODEL_TYPES[symbol]
                     currentMatch = hits[hitId].computeIfAbsent(signature.accession) {
-                        Match newMatch = new Match(signature.accession, signature)
+                        def newMatch = new uk.ac.ebi.interpro.Match(signature.accession, signature)
                         newMatch
                     }
                     start = position + 1
 
                 } else if (currentMatch.modelAccession != MODEL_TYPES[symbol].accession) { // Found a new hit
-                    currentMatch.addLocation(new Location(start, position))
-                    Signature signature = MODEL_TYPES[symbol]
+                    currentMatch.addLocation(new uk.ac.ebi.interpro.Location(start, position))
+                    def signature = MODEL_TYPES[symbol]
                     currentMatch = hits[hitId].computeIfAbsent(signature.accession) {
-                        Match newMatch = new Match(signature.accession, signature)
+                        def newMatch = new uk.ac.ebi.interpro.Match(signature.accession, signature)
                         newMatch
                     }
                     start = position + 1
@@ -225,7 +214,7 @@ process PARSE_TMBED {
                 // else, parsing another symbol from the same currentMatch/hit
             } else {
                 if (currentMatch) {
-                    currentMatch.addLocation(new Location(start, position))
+                    currentMatch.addLocation(new uk.ac.ebi.interpro.Location(start, position))
                     currentMatch = null
                 }
             }
@@ -233,31 +222,28 @@ process PARSE_TMBED {
 
         // Add the final match for this sequence
         if (currentMatch) {
-            currentMatch.addLocation(new Location(start, end))
+            currentMatch.addLocation(new uk.ac.ebi.interpro.Location(start, end))
         }
     }
 
     def filepath = task.workDir.resolve("tmbed.json")
-    filepath.text = JsonOutput.toJson(hits)
+    filepath.text  = groovy.json.JsonOutput.toJson(hits)
 }
 
 
 /** Apply categorical smoothing (mode over a sliding window) */
 def smoothString(String s, int window) {
     int half = Math.floor(window / 2) as int
-    def out = new StringBuilder()
-    for (int i = 0; i < s.size(); i++) {
+    return (0..<s.size()).collect { i ->
         int start = Math.max(0, i - half)
         int end = Math.min(s.size(), i + half + 1)
-        def windowSeq = s.substring(start, end)
-        out.append(mostCommonChar(windowSeq))
-    }
-    return out.toString()
+        mostCommonChar(s.substring(start, end))
+    }.join()
 }
 
 /** Return the most frequent character in a string */
 def mostCommonChar(String s) {
     def counts = [:].withDefault { 0 }
-    s.each { counts[it]++ }
+    s.each { counts[it] += 1 }
     return counts.max { it.value }.key
 }

--- a/modules/write_output/main.nf
+++ b/modules/write_output/main.nf
@@ -1,5 +1,6 @@
 process WRITE_GFF3 {
-    label    'mem_medium', 'time_long'
+    label    'mem_medium'
+    label    'time_long'
     executor 'local'
 
     input:
@@ -24,7 +25,8 @@ process WRITE_GFF3 {
 }
 
 process WRITE_JSON {
-    label    'mem_medium', 'time_long'
+    label    'mem_medium'
+    label    'time_long'
     executor 'local'
 
     input:
@@ -51,7 +53,8 @@ process WRITE_JSON {
 }
 
 process WRITE_TSV {
-    label    'mem_medium', 'time_long'
+    label    'mem_medium'
+    label    'time_long'
     executor 'local'
 
     input:
@@ -72,7 +75,8 @@ process WRITE_TSV {
 }
 
 process WRITE_XML {
-    label    'mem_medium', 'time_long'
+    label    'mem_medium'
+    label    'time_long'
     executor 'local'
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,6 +23,7 @@ params {
     noMatchesApi              = false
     globus                    = false
     skipInterproVersionCheck  = false
+    help                      = false
 }
 
 includeConfig "conf/applications.config"

--- a/subworkflows/cath/main.nf
+++ b/subworkflows/cath/main.nf
@@ -59,5 +59,5 @@ workflow CATH {
 
     emit:
     results
-        .map { meta, meta2, json -> tuple (meta, json) }  // [ meta, json ]
+        .map { meta, _meta2, json -> tuple (meta, json) }  // [ meta, json ]
 }

--- a/subworkflows/cath/main.nf
+++ b/subworkflows/cath/main.nf
@@ -11,7 +11,7 @@ workflow CATH {
     batch_size            // int, number of sequences per sub batch for searching
 
     main:
-    results = Channel.empty()
+    results = channel.empty()
 
     ch_split = fasta
         .map { meta, fasta ->

--- a/subworkflows/cath/main.nf
+++ b/subworkflows/cath/main.nf
@@ -3,7 +3,7 @@ include { SEARCH_FUNFAM; PARSE_FUNFAM     } from  "../../modules/cath"
 
 workflow CATH {
     take:
-    fasta                 // [meta, fasta]
+    ch_fasta              // [meta, fasta]
     report_cathgene3d     // boolean to report Gene3D results
     cathgene3d_files      // [hmm, model2sfs, disc_regs]
     report_cathfunfam     // boolean to report FunFam results
@@ -13,7 +13,7 @@ workflow CATH {
     main:
     results = channel.empty()
 
-    ch_split = fasta
+    ch_split = ch_fasta
         .map { meta, fasta ->
             fasta
                 .splitFasta( by: batch_size, file: true )

--- a/subworkflows/combine/main.nf
+++ b/subworkflows/combine/main.nf
@@ -13,14 +13,14 @@ workflow COMBINE {
 
     main:
     ch_interpro = appl_dirs
-        .filter { name, dirpath -> name == "interpro" }
-        .map    { name, dirpath -> dirpath }
+        .filter { name, _dirpath -> name == "interpro" }
+        .map    { _name, dirpath -> dirpath }
         .ifEmpty(file("${projectDir}/assets/DUMMY")) 
         .first()
 
     ch_panther = appl_dirs
-        .filter { name, dirpath -> name == "panther" }
-        .map    { name, dirpath -> dirpath.resolve(appl_config.panther.paint) }
+        .filter { name, _dirpath -> name == "panther" }
+        .map    { _name, dirpath -> dirpath.resolve(appl_config.panther.paint) }
         .ifEmpty(file("${projectDir}/assets/DUMMY2")) 
         .first()
 
@@ -41,11 +41,9 @@ workflow COMBINE {
         ch_combined = REPRESENTATIVE_LOCATIONS(ch_xrefs)
     }
 
+    emit:
     // Collect all JSON files into a single channel so we don't have concurrent writing to the output files
     results = ch_combined
-        .map { meta, json -> json }
+        .map { _meta, json -> json }
         .collect(flat: true)
-
-    emit:
-    results
 }

--- a/subworkflows/combine/main.nf
+++ b/subworkflows/combine/main.nf
@@ -4,7 +4,7 @@ include { REPRESENTATIVE_LOCATIONS } from "../../modules/representative_location
 
 workflow COMBINE {
     take:
-    json                // [ meta, [json] ]
+    ch_json             // [ meta, [json] ]
     appl_config
     appl_dirs
     add_goterms
@@ -24,7 +24,7 @@ workflow COMBINE {
         .ifEmpty(file("${projectDir}/assets/DUMMY2")) 
         .first()
 
-    COMBINE_MATCHES(json)
+    COMBINE_MATCHES(ch_json)
 
     ch_xrefs = ADD_XREFS(
         COMBINE_MATCHES.out,

--- a/subworkflows/init/databases/main.nf
+++ b/subworkflows/init/databases/main.nf
@@ -11,7 +11,7 @@ workflow INIT_DATABASES {
     data_dir                // path
     interpro_version        // str, version of InterPro to run
     iprscan_version         // str, version of InterProScan
-    use_matches_api         // bool, whether to use the Matches API
+    _use_matches_api        // bool, whether to use the Matches API
     use_globus              // bool, whether to use Globus instead of the EMBL-EBI FTP
     enforce_compatibility   // bool, whether we check that InterProScan and InterPro are compatible
 
@@ -49,7 +49,7 @@ workflow INIT_DATABASES {
         
         // Handle applications with a common directory (cath -> CATH-Gene3 / CATH-FunFam, prosite -> PROSITE Patterns / PROSITE Profiles)
         appl_dirs = appl_configs
-            .findAll { k, v -> v.has_data == true }
+            .findAll { _k, v -> v.has_data == true }
             .collectEntries { key, value ->
                 def dir = value.get("dir", "")
                 def parts = dir.split('/')

--- a/subworkflows/init/databases/main.nf
+++ b/subworkflows/init/databases/main.nf
@@ -1,7 +1,4 @@
 // codenarc-disable ModuleIncludedTwiceRule
-import groovy.json.JsonSlurper
-import uk.ac.ebi.interpro.InterProScan
-
 include { DOWNLOAD as DOWNLOAD_INTERPRO } from "../../../modules/download"
 include { DOWNLOAD as DOWNLOAD_DATABASE } from "../../../modules/download"
 include { FIND_DATABASES                } from "../../../modules/download"
@@ -27,11 +24,11 @@ workflow INIT_DATABASES {
         //     enforce_compatibility = true
         // }
 
-        def versions = InterProScan.fetchCompatibleVersions(iprscan_maj_min_version, use_globus)
+        def versions = uk.ac.ebi.interpro.InterProScan.fetchCompatibleVersions(iprscan_maj_min_version, use_globus)
         if (versions == null) {
             if (!use_globus) {
                 // Try again, but using Globus
-                versions = InterProScan.fetchCompatibleVersions(iprscan_maj_min_version, true)
+                versions = uk.ac.ebi.interpro.InterProScan.fetchCompatibleVersions(iprscan_maj_min_version, true)
             }
 
             if (versions == null) {
@@ -46,7 +43,7 @@ workflow INIT_DATABASES {
         }
     }
 
-    ch_ready = Channel.empty()
+    ch_ready = channel.empty()
     if (data_dir != null) {
         // At least one applications requires data files
         
@@ -66,7 +63,7 @@ workflow INIT_DATABASES {
         def databases_json = interpro_dir.resolve("databases.json")
         if (databases_json.isFile()) {
             // InterPro data already downloaded (at least databases.json)
-            ch_interpro = Channel.value(["interpro", interpro_dir])
+            ch_interpro = channel.value(["interpro", interpro_dir])
 
             FIND_DATABASES(
                 ["", ""],  // state dependency, can be anything
@@ -106,7 +103,7 @@ workflow INIT_DATABASES {
 
         ch_ready = ch_ready.mix(DOWNLOAD_DATABASE.out)
     } else {
-        ch_ready = Channel.of(["interpro", null])
+        ch_ready = channel.of(["interpro", null])
     }
 
     emit:

--- a/subworkflows/init/pipeline/main.nf
+++ b/subworkflows/init/pipeline/main.nf
@@ -15,7 +15,7 @@ workflow INIT_PIPELINE {
     skip_applications
     goterms
     pathways
-    workflow_manifest
+    _workflow_manifest
 
     main:
     // Check the input

--- a/subworkflows/init/pipeline/main.nf
+++ b/subworkflows/init/pipeline/main.nf
@@ -1,5 +1,3 @@
-import uk.ac.ebi.interpro.InterProScan
-
 workflow INIT_PIPELINE {
     // Validate pipeline input parameters
     take:
@@ -28,7 +26,7 @@ workflow INIT_PIPELINE {
     }
 
     // Applications validation
-    (apps, error, warn) = InterProScan.validateApplications(applications, skip_applications, applications_config, run_ml)
+    (apps, error, warn) = uk.ac.ebi.interpro.InterProScan.validateApplications(applications, skip_applications, applications_config, run_ml)
     if (!apps) {
         log.error error
         exit 1
@@ -37,7 +35,7 @@ workflow INIT_PIPELINE {
     }
 
     // Enable gpu acceleration if requested
-    (apps_config, warn) = InterProScan.enableGpuAcceleration(use_gpu, apps, applications_config)
+    (apps_config, warn) = uk.ac.ebi.interpro.InterProScan.enableGpuAcceleration(use_gpu, apps, applications_config)
     if (warn) {
         log.warn warn
     }
@@ -48,13 +46,13 @@ workflow INIT_PIPELINE {
     }
 
     // Check valid output file formats were provided
-    (formats, error) = InterProScan.validateFormats(formats)
+    (formats, error) = uk.ac.ebi.interpro.InterProScan.validateFormats(formats)
     if (error) {
         log.error error
         exit 1
     }
 
-    apps_with_data = InterProScan.getAppsWithData(apps, apps_config)
+    apps_with_data = uk.ac.ebi.interpro.InterProScan.getAppsWithData(apps, apps_config)
     if (apps_with_data.size() > 0) {
         if (datadir == null) {
             log.error "'--datadir <DATA-DIR>' is required for the selected applications."
@@ -72,7 +70,7 @@ workflow INIT_PIPELINE {
         datadir = null
     }
   
-    version = InterProScan.validateInterProVersion(interpro_version)
+    version = uk.ac.ebi.interpro.InterProScan.validateInterProVersion(interpro_version)
     if (version == null) {
         log.error "--interpro <VERSION>: invalid format; expecting number or 'latest'"
         exit 1

--- a/subworkflows/interpro_n/main.nf
+++ b/subworkflows/interpro_n/main.nf
@@ -10,9 +10,14 @@ workflow INTERPRO_N {
     seq_batch_size      // int, number of sequences per sub batch for searching
 
     main:
+    def max_length    = 2047  // Maximum sequence length
+    def chunk_overlap = 1000  // Number of overlapping residues between consecutive chunks
+    def match_overlap = 0.25  // Fractional overlap threshold for merging matches
     PREPARE_INTERPRO_N(
         ch_seqs, 
-        use_gpu ? seq_batch_size * 10 : seq_batch_size.intdiv(5)
+        use_gpu ? seq_batch_size * 10 : seq_batch_size.intdiv(5),
+        max_length,
+        chunk_overlap
     )
 
     ch_tsv = PREPARE_INTERPRO_N.out
@@ -37,7 +42,12 @@ workflow INTERPRO_N {
         ch_json = RUN_INTERPRO_N_CPU.out
     }
 
-    PARSE_INTERPRO_N(ch_json, applications)
+    PARSE_INTERPRO_N(
+        ch_json, 
+        applications,
+        max_length,
+        chunk_overlap,
+        match_overlap)
 
     emit:
     PARSE_INTERPRO_N.out  // [ meta, json ]

--- a/subworkflows/lookup/main.nf
+++ b/subworkflows/lookup/main.nf
@@ -10,11 +10,11 @@ workflow LOOKUP {
     interproscan_version  // str
 
     main:
-    (appls_in_api, appls_not_in_api) = check_matches_api(applications, matches_api_url, interproscan_version)
+    def (in_api, not_in_api) = check_matches_api(applications, matches_api_url, interproscan_version)
 
     GET_MATCHES(
         fasta,
-        appls_in_api,
+        in_api,
         matches_api_url,
         chunk_size,
         max_retries
@@ -23,6 +23,6 @@ workflow LOOKUP {
     emit:
     json             = GET_MATCHES.out.json
     fasta            = GET_MATCHES.out.fasta
-    appls_in_api
-    appls_not_in_api
+    appls_in_api     = in_api
+    appls_not_in_api = not_in_api
 }

--- a/subworkflows/mobidblite/main.nf
+++ b/subworkflows/mobidblite/main.nf
@@ -21,5 +21,5 @@ workflow MOBIDBLITE {
 
     emit:
     PARSE_MOBIDBLITE.out
-        .map { meta, meta2, json -> tuple (meta, json) }  // [ meta, json ]
+        .map { meta, _meta2, json -> tuple (meta, json) }  // [ meta, json ]
 }

--- a/subworkflows/output/main.nf
+++ b/subworkflows/output/main.nf
@@ -19,7 +19,7 @@ workflow OUTPUT {
     outfiles = channel.empty()
 
     // convert to uppercase in case iprscan is imported directly into another workflow
-    def formats_upper = formats.collect { it.toUpperCase() }
+    def formats_upper = formats.collect { fmt -> fmt.toUpperCase() }
 
     if (formats_upper.contains("GFF3")) {
         WRITE_GFF3(json, file("${outprefix}.gff3"), seqdb, nucleic, interproscan_version, interpro_version)

--- a/subworkflows/output/main.nf
+++ b/subworkflows/output/main.nf
@@ -16,7 +16,7 @@ workflow OUTPUT {
     interproscan_version
 
     main:
-    outfiles = Channel.empty()
+    outfiles = channel.empty()
 
     // convert to uppercase in case iprscan is imported directly into another workflow
     def formats_upper = formats.collect { it.toUpperCase() }

--- a/subworkflows/panther/main.nf
+++ b/subworkflows/panther/main.nf
@@ -16,20 +16,20 @@ workflow PANTHER {
         }
         .flatMap()
 
-    hmms = panther.map { hmm, msf -> hmm }
+    ch_hmm = panther.map { hmm, _msf -> hmm }
     SEARCH_PANTHER(
         ch_split,
-        hmms
+        ch_hmm
     )
 
     PREPARE_TREEGRAFTER(
         SEARCH_PANTHER.out,
     )
 
-    msfs = panther.map { hmm, msf -> msf }
+    ch_msf = panther.map { _hmm, msf -> msf }
     RUN_TREEGRAFTER(
         PREPARE_TREEGRAFTER.out,
-        msfs
+        ch_msf
     )
 
     PARSE_PANTHER(
@@ -43,5 +43,5 @@ workflow PANTHER {
         
     emit:
     PARSE_PANTHER.out
-        .map { meta, meta2, json -> tuple (meta, json) }  // [ meta, json ]
+        .map { meta, _meta2, json -> tuple (meta, json) }  // [ meta, json ]
 }

--- a/subworkflows/panther/main.nf
+++ b/subworkflows/panther/main.nf
@@ -2,12 +2,12 @@ include { SEARCH_PANTHER; PREPARE_TREEGRAFTER; RUN_TREEGRAFTER; PARSE_PANTHER } 
 
 workflow PANTHER {
     take:
-    fasta          // [meta, fasta]
+    ch_fasta       // [meta, fasta]
     panther        // [hmm, msf]
     batch_size     // int, number of sequences per sub batch for searching
 
     main:
-    ch_split = fasta
+    ch_split = ch_fasta
         .map { meta, fasta ->
             fasta
                 .splitFasta( by: batch_size, file: true )
@@ -16,20 +16,20 @@ workflow PANTHER {
         }
         .flatMap()
 
-    hmm = panther.map { hmm, msf -> hmm }
+    hmms = panther.map { hmm, msf -> hmm }
     SEARCH_PANTHER(
         ch_split,
-        hmm
+        hmms
     )
 
     PREPARE_TREEGRAFTER(
         SEARCH_PANTHER.out,
     )
 
-    msf = panther.map { hmm, msf -> msf }
+    msfs = panther.map { hmm, msf -> msf }
     RUN_TREEGRAFTER(
         PREPARE_TREEGRAFTER.out,
-        msf
+        msfs
     )
 
     PARSE_PANTHER(

--- a/subworkflows/pfam/main.nf
+++ b/subworkflows/pfam/main.nf
@@ -7,14 +7,14 @@ workflow PFAM {
     pfam     // [hmm, dat]
 
     main:
-    ch_hmm = pfam.map { hmm, dat -> hmm }
+    ch_hmm = pfam.map { hmm, _dat -> hmm }
     SEARCH_PFAM(
         ch_fasta,
         ch_hmm,
         "-Z 61295632 --cut_ga"
     )
 
-    ch_dat = pfam.map { hmm, dat -> dat }
+    ch_dat = pfam.map { _hmm, dat -> dat }
     PARSE_PFAM(
         SEARCH_PFAM.out,
         ch_dat

--- a/subworkflows/pfam/main.nf
+++ b/subworkflows/pfam/main.nf
@@ -3,21 +3,21 @@ include { PARSE_PFAM               } from "../../modules/pfam"
 
 workflow PFAM {
     take:
-    fasta  // [meta, fasta] 
-    pfam   // [hmm, dat]
+    ch_fasta  // [meta, fasta] 
+    pfam     // [hmm, dat]
 
     main:
-    hmm = pfam.map { hmm, dat -> hmm }
+    ch_hmm = pfam.map { hmm, dat -> hmm }
     SEARCH_PFAM(
-        fasta,
-        hmm,
+        ch_fasta,
+        ch_hmm,
         "-Z 61295632 --cut_ga"
     )
 
-    dat = pfam.map { hmm, dat -> dat }
+    ch_dat = pfam.map { hmm, dat -> dat }
     PARSE_PFAM(
         SEARCH_PFAM.out,
-        dat
+        ch_dat
     )
 
     emit:

--- a/subworkflows/pirsf/main.nf
+++ b/subworkflows/pirsf/main.nf
@@ -9,6 +9,11 @@ workflow PIRSF {
     ch_hmm = pirsf.map { hmm, _dat -> hmm }
     ch_dat = pirsf.map { _hmm, dat -> dat }
 
+    ch_parsed = ch_dat.map { dat ->
+        def parsed = parseDatFile(dat)
+        tuple(parsed[0], parsed[1])
+    }
+
     SEARCH_PIRSF(
         fasta,
         ch_hmm
@@ -16,9 +21,36 @@ workflow PIRSF {
 
     PARSE_PIRSF(
         SEARCH_PIRSF.out,
-        ch_dat
+        ch_parsed
     )
 
     emit:
     PARSE_PIRSF.out  // [ meta, json ]
+}
+
+def parseDatFile(datFile) {
+    def models = [:]    // PIRSF -> list of 5 doubles (meanL, stdL, minS, meanS, stdS)
+    def subfamilies = [:]   // child PIRSF -> parent PIRSF
+    new File(datFile.toString()).withReader { reader ->
+        def accession = null
+        reader.eachLine { line ->
+            if (line.startsWith('>')) {
+                def parts = line.split(/\s+/)
+                accession = parts[0].replace('>', '')
+
+                def match = (line =~ /^>PIRSF\d+\schild:\s(.+)$/)
+                if (match) {
+                    match[0][1].trim().split(/\s+/).each { child ->
+                        subfamilies[child] = accession
+                    }
+                }
+
+            } else if (line ==~ /\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*/) {
+                def values = line.split(/\s+/)*.toDouble()
+                models[accession] = values
+            }
+        }
+    }
+
+    return [models, subfamilies]
 }

--- a/subworkflows/pirsf/main.nf
+++ b/subworkflows/pirsf/main.nf
@@ -6,8 +6,8 @@ workflow PIRSF {
     pirsf    // [hmm, dat]
 
     main:
-    ch_hmm = pirsf.map { hmm, dat -> hmm }
-    ch_dat = pirsf.map { hmm, dat -> dat }
+    ch_hmm = pirsf.map { hmm, _dat -> hmm }
+    ch_dat = pirsf.map { _hmm, dat -> dat }
 
     SEARCH_PIRSF(
         fasta,

--- a/subworkflows/pirsf/main.nf
+++ b/subworkflows/pirsf/main.nf
@@ -6,17 +6,17 @@ workflow PIRSF {
     pirsf    // [hmm, dat]
 
     main:
-    hmm = pirsf.map { hmm, dat -> hmm }
-    dat = pirsf.map { hmm, dat -> dat }
+    ch_hmm = pirsf.map { hmm, dat -> hmm }
+    ch_dat = pirsf.map { hmm, dat -> dat }
 
     SEARCH_PIRSF(
         fasta,
-        hmm
+        ch_hmm
     )
 
     PARSE_PIRSF(
         SEARCH_PIRSF.out,
-        dat
+        ch_dat
     )
 
     emit:

--- a/subworkflows/pirsf/main.nf
+++ b/subworkflows/pirsf/main.nf
@@ -9,11 +9,6 @@ workflow PIRSF {
     ch_hmm = pirsf.map { hmm, _dat -> hmm }
     ch_dat = pirsf.map { _hmm, dat -> dat }
 
-    ch_parsed = ch_dat.map { dat ->
-        def parsed = parseDatFile(dat)
-        tuple(parsed[0], parsed[1])
-    }
-
     SEARCH_PIRSF(
         fasta,
         ch_hmm
@@ -21,36 +16,9 @@ workflow PIRSF {
 
     PARSE_PIRSF(
         SEARCH_PIRSF.out,
-        ch_parsed
+        ch_dat
     )
 
     emit:
     PARSE_PIRSF.out  // [ meta, json ]
-}
-
-def parseDatFile(datFile) {
-    def models = [:]    // PIRSF -> list of 5 doubles (meanL, stdL, minS, meanS, stdS)
-    def subfamilies = [:]   // child PIRSF -> parent PIRSF
-    new File(datFile.toString()).withReader { reader ->
-        def accession = null
-        reader.eachLine { line ->
-            if (line.startsWith('>')) {
-                def parts = line.split(/\s+/)
-                accession = parts[0].replace('>', '')
-
-                def match = (line =~ /^>PIRSF\d+\schild:\s(.+)$/)
-                if (match) {
-                    match[0][1].trim().split(/\s+/).each { child ->
-                        subfamilies[child] = accession
-                    }
-                }
-
-            } else if (line ==~ /\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*\s+\d+\.?\d*/) {
-                def values = line.split(/\s+/)*.toDouble()
-                models[accession] = values
-            }
-        }
-    }
-
-    return [models, subfamilies]
 }

--- a/subworkflows/pirsr/main.nf
+++ b/subworkflows/pirsr/main.nf
@@ -3,22 +3,22 @@ include { PARSE_PIRSR               } from  "../../modules/pirsr"
 
 workflow PIRSR {
     take:
-    fasta    // [meta, fasta]
-    pirsr    // [hmm, json]
+    ch_fasta    // [meta, fasta]
+    ch_pirsr    // [hmm, json]
 
     main:
-    hmm  = pirsr.map { hmm, json -> hmm }
-    json = pirsr.map { hmm, json -> json }
+    ch_hmm  = ch_pirsr.map { hmm, json -> hmm }
+    ch_json = ch_pirsr.map { hmm, json -> json }
 
     SEARCH_PIRSR(
-        fasta,
-        hmm,
+        ch_fasta,
+        ch_hmm,
         "-E 0.01 --acc"
     )
 
     PARSE_PIRSR(
         SEARCH_PIRSR.out,
-        json
+        ch_json
     )
 
     emit:

--- a/subworkflows/pirsr/main.nf
+++ b/subworkflows/pirsr/main.nf
@@ -7,8 +7,8 @@ workflow PIRSR {
     ch_pirsr    // [hmm, json]
 
     main:
-    ch_hmm  = ch_pirsr.map { hmm, json -> hmm }
-    ch_json = ch_pirsr.map { hmm, json -> json }
+    ch_hmm  = ch_pirsr.map { hmm, _json -> hmm }
+    ch_json = ch_pirsr.map { _hmm, json -> json }
 
     SEARCH_PIRSR(
         ch_fasta,

--- a/subworkflows/prints/main.nf
+++ b/subworkflows/prints/main.nf
@@ -10,17 +10,17 @@ workflow PRINTS {
     ch_split = fasta
         .splitFasta( by: batch_size, file: true )
 
-    pval = prints.map { pval, hierarchy -> pval }
-    hierarchy = prints.map { pval, hierarchy -> hierarchy }
+    ch_pval = prints.map { pval, hierarchy -> pval }
+    ch_hierarchy = prints.map { pval, hierarchy -> hierarchy }
 
     RUN_PRINTS(
         ch_split,
-        pval
+        ch_pval
     )
 
     PARSE_PRINTS(
         RUN_PRINTS.out,
-        hierarchy
+        ch_hierarchy
     )
 
     emit:

--- a/subworkflows/prints/main.nf
+++ b/subworkflows/prints/main.nf
@@ -10,8 +10,8 @@ workflow PRINTS {
     ch_split = fasta
         .splitFasta( by: batch_size, file: true )
 
-    ch_pval = prints.map { pval, hierarchy -> pval }
-    ch_hierarchy = prints.map { pval, hierarchy -> hierarchy }
+    ch_pval = prints.map { pval, _hierarchy -> pval }
+    ch_hierarchy = prints.map { _pval, hierarchy -> hierarchy }
 
     RUN_PRINTS(
         ch_split,

--- a/subworkflows/prosite/profiles/main.nf
+++ b/subworkflows/prosite/profiles/main.nf
@@ -6,8 +6,8 @@ workflow PROSITE_PROFILES {
     profiles    // [dir, skipped]
 
     main:
-    ch_dir = profiles. map { dir, skipped -> dir }
-    ch_skipped = profiles. map { dir, skipped -> skipped }
+    ch_dir = profiles. map { dir, _skipped -> dir }
+    ch_skipped = profiles. map { _dir, skipped -> skipped }
 
     RUN_PFSEARCH(
         fasta,

--- a/subworkflows/scan/main.nf
+++ b/subworkflows/scan/main.nf
@@ -36,9 +36,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("antifam")) {
         ch_antifam = appl_dirs
-            .filter { name, dirpath -> name == "antifam" }
+            .filter { name, _dirpath -> name == "antifam" }
             .first()
-            .map    { name, dirpath -> dirpath.resolve(appl_config.antifam.hmm) }
+            .map    { _name, dirpath -> dirpath.resolve(appl_config.antifam.hmm) }
 
         ANTIFAM(ch_fasta, ch_antifam)
         results = results.mix(ANTIFAM.out)
@@ -46,9 +46,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("cathgene3d") || applications.contains("cathfunfam")) {
         ch_cathgene3d = appl_dirs
-            .filter { name, dirpath -> name == "cathgene3d" }
+            .filter { name, _dirpath -> name == "cathgene3d" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath.resolve(appl_config.cathgene3d.hmm),
                     dirpath.resolve(appl_config.cathgene3d.model2sfs),
@@ -57,9 +57,9 @@ workflow SCAN_SEQUENCES {
             }
 
         ch_cathfunfam = appl_dirs
-            .filter { name, dirpath -> name == "cathfunfam" }
+            .filter { name, _dirpath -> name == "cathfunfam" }
             .first()
-            .map    { name, dirpath -> dirpath }
+            .map    { _name, dirpath -> dirpath }
         
         CATH(
             ch_fasta,
@@ -75,9 +75,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("cdd")) {
         ch_cdd = appl_dirs
-            .filter { name, dirpath -> name == "cdd" }
+            .filter { name, _dirpath -> name == "cdd" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath,
                     appl_config.cdd.rpsblast_db,
@@ -106,9 +106,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("hamap")) {
         ch_hamap = appl_dirs
-            .filter { name, dirpath -> name == "hamap" }
+            .filter { name, _dirpath -> name == "hamap" }
             .first()
-            .map    { name, dirpath -> dirpath.resolve(appl_config.hamap.profiles) }
+            .map    { _name, dirpath -> dirpath.resolve(appl_config.hamap.profiles) }
 
         HAMAP(ch_fasta, ch_hamap)
         results = results.mix(HAMAP.out)
@@ -134,9 +134,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("ncbifam")) {
         ch_ncbifam = appl_dirs
-            .filter { name, dirpath -> name == "ncbifam" }
+            .filter { name, _dirpath -> name == "ncbifam" }
             .first()
-            .map    { name, dirpath -> dirpath.resolve(appl_config.ncbifam.hmm) }
+            .map    { _name, dirpath -> dirpath.resolve(appl_config.ncbifam.hmm) }
 
         NCBIFAM(ch_fasta, ch_ncbifam)
         results = results.mix(NCBIFAM.out)
@@ -144,9 +144,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("panther")) {
         ch_panther = appl_dirs
-            .filter { name, dirpath -> name == "panther" }
+            .filter { name, _dirpath -> name == "panther" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath.resolve(appl_config.panther.hmm),
                     dirpath.resolve(appl_config.panther.msf)
@@ -159,9 +159,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("pfam")) {
         ch_pfam = appl_dirs
-            .filter { name, dirpath -> name == "pfam" }
+            .filter { name, _dirpath -> name == "pfam" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath.resolve(appl_config.pfam.hmm),
                     dirpath.resolve(appl_config.pfam.dat)
@@ -182,9 +182,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("pirsf")) {
         ch_pirsf = appl_dirs
-            .filter { name, dirpath -> name == "pirsf" }
+            .filter { name, _dirpath -> name == "pirsf" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath.resolve(appl_config.pirsf.hmm),
                     dirpath.resolve(appl_config.pirsf.dat)
@@ -197,9 +197,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("pirsr")) {
         ch_pirsr = appl_dirs
-            .filter { name, dirpath -> name == "pirsr" }
+            .filter { name, _dirpath -> name == "pirsr" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath.resolve(appl_config.pirsr.hmm),
                     dirpath.resolve(appl_config.pirsr.rules)
@@ -212,9 +212,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("prints")) {
         ch_prints = appl_dirs
-            .filter { name, dirpath -> name == "prints" }
+            .filter { name, _dirpath -> name == "prints" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath.resolve(appl_config.prints.pval),
                     dirpath.resolve(appl_config.prints.hierarchy)
@@ -227,9 +227,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("prositepatterns")) {
         ch_prositepatterns = appl_dirs
-            .filter { name, dirpath -> name == "prositepatterns" }
+            .filter { name, _dirpath -> name == "prositepatterns" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath.resolve(appl_config.prositepatterns.dat),
                     dirpath.resolve(appl_config.prositepatterns.evaluator)
@@ -242,9 +242,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("prositeprofiles")) {
         ch_prositeprofiles = appl_dirs
-            .filter { name, dirpath -> name == "prositeprofiles" }
+            .filter { name, _dirpath -> name == "prositeprofiles" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath.resolve(appl_config.prositeprofiles.profiles),
                     dirpath.resolve(appl_config.prositeprofiles.skip_flagged_profiles)
@@ -257,9 +257,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("sfld")) {
         ch_sfld = appl_dirs
-            .filter { name, dirpath -> name == "sfld" }
+            .filter { name, _dirpath -> name == "sfld" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath.resolve(appl_config.sfld.hmm),
                     dirpath.resolve(appl_config.sfld.sites_annotation),
@@ -290,9 +290,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("smart")) {
         ch_smart = appl_dirs
-            .filter { name, dirpath -> name == "smart" }
+            .filter { name, _dirpath -> name == "smart" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath.resolve(appl_config.smart.hmm3),
                     dirpath.resolve(appl_config.smart.hmm2)
@@ -305,9 +305,9 @@ workflow SCAN_SEQUENCES {
 
     if (applications.contains("superfamily")) {
         ch_superfamily = appl_dirs
-            .filter { name, dirpath -> name == "superfamily" }
+            .filter { name, _dirpath -> name == "superfamily" }
             .first()
-            .map    { name, dirpath ->
+            .map    { _name, dirpath ->
                 tuple(
                     dirpath,
                     appl_config.superfamily.hmm,
@@ -337,7 +337,7 @@ workflow SCAN_SEQUENCES {
     }
 
     // Add a dummy null value for each fasta so there are no mismatches when calling join()
-    results = results.mix(ch_fasta.map { meta, fasta -> tuple(meta, null) })
+    results = results.mix(ch_fasta.map { meta, _fasta -> tuple(meta, null) })
 
     results = ch_fasta
         .join(
@@ -356,7 +356,7 @@ workflow SCAN_SEQUENCES {
         failOnDuplicate: true,
         failOnMismatch: true
     )
-    .map { meta, fasta, jsons, json ->
+    .map { meta, _fasta, jsons, json ->
         tuple(meta, jsons + [json])
     }
 

--- a/subworkflows/scan/main.nf
+++ b/subworkflows/scan/main.nf
@@ -24,7 +24,7 @@ include { REPORT_NO_MATCHES } from "../../modules/no_matches"
 
 workflow SCAN_SEQUENCES {
     take:
-    fasta            // [meta, fasta]
+    ch_fasta         // [meta, fasta]
     appl_config
     appl_dirs  
     applications     // application to run in this workflow
@@ -40,7 +40,7 @@ workflow SCAN_SEQUENCES {
             .first()
             .map    { name, dirpath -> dirpath.resolve(appl_config.antifam.hmm) }
 
-        ANTIFAM(fasta, ch_antifam)
+        ANTIFAM(ch_fasta, ch_antifam)
         results = results.mix(ANTIFAM.out)
     }
 
@@ -62,7 +62,7 @@ workflow SCAN_SEQUENCES {
             .map    { name, dirpath -> dirpath }
         
         CATH(
-            fasta,
+            ch_fasta,
             applications.contains("cathgene3d"),
             ch_cathgene3d,
             applications.contains("cathfunfam"),
@@ -85,18 +85,18 @@ workflow SCAN_SEQUENCES {
                 )
             }
 
-        CDD(fasta, ch_cdd)
+        CDD(ch_fasta, ch_cdd)
         results = results.mix(CDD.out)
     }
 
     if (applications.contains("coils")) {
-        COILS(fasta)
+        COILS(ch_fasta)
         results = results.mix(COILS.out)
     }
 
     if (applications.contains("deeptmhmm")) {
         DEEPTMHMM(
-            fasta,
+            ch_fasta,
             appl_config.deeptmhmm.dir,
             appl_config.deeptmhmm.use_gpu,
             batch_size
@@ -110,13 +110,13 @@ workflow SCAN_SEQUENCES {
             .first()
             .map    { name, dirpath -> dirpath.resolve(appl_config.hamap.profiles) }
 
-        HAMAP(fasta, ch_hamap)
+        HAMAP(ch_fasta, ch_hamap)
         results = results.mix(HAMAP.out)
     }
 
     if (applications.contains("interpro_n")) {
         INTERPRO_N(
-            fasta,
+            ch_fasta,
             all_applications,
             appl_config.interpro_n.dir,
             appl_config.interpro_n.use_gpu,
@@ -128,7 +128,7 @@ workflow SCAN_SEQUENCES {
     }
 
     if (applications.contains("mobidblite")) {
-        MOBIDBLITE(fasta, batch_size)
+        MOBIDBLITE(ch_fasta, batch_size)
         results = results.mix(MOBIDBLITE.out)
     }
 
@@ -138,7 +138,7 @@ workflow SCAN_SEQUENCES {
             .first()
             .map    { name, dirpath -> dirpath.resolve(appl_config.ncbifam.hmm) }
 
-        NCBIFAM(fasta, ch_ncbifam)
+        NCBIFAM(ch_fasta, ch_ncbifam)
         results = results.mix(NCBIFAM.out)
     }
 
@@ -153,7 +153,7 @@ workflow SCAN_SEQUENCES {
                 )
             }
 
-        PANTHER(fasta, ch_panther, batch_size)
+        PANTHER(ch_fasta, ch_panther, batch_size)
         results = results.mix(PANTHER.out)
     }
 
@@ -168,13 +168,13 @@ workflow SCAN_SEQUENCES {
                 )
             }
         
-        PFAM(fasta, ch_pfam)
+        PFAM(ch_fasta, ch_pfam)
         results = results.mix(PFAM.out)
     }
 
     if (applications.contains("phobius")) {
         PHOBIUS(
-            fasta,
+            ch_fasta,
             appl_config.phobius.dir
         )
         results = results.mix(PHOBIUS.out)
@@ -191,7 +191,7 @@ workflow SCAN_SEQUENCES {
                 )
             }
 
-        PIRSF(fasta, ch_pirsf)
+        PIRSF(ch_fasta, ch_pirsf)
         results = results.mix(PIRSF.out)
     }
 
@@ -206,7 +206,7 @@ workflow SCAN_SEQUENCES {
                 )
             }
 
-        PIRSR(fasta, ch_pirsr)
+        PIRSR(ch_fasta, ch_pirsr)
         results = results.mix(PIRSR.out)
     }
 
@@ -221,7 +221,7 @@ workflow SCAN_SEQUENCES {
                 )
             }
 
-        PRINTS(fasta, ch_prints, batch_size)
+        PRINTS(ch_fasta, ch_prints, batch_size)
         results = results.mix(PRINTS.out)
     }
 
@@ -236,7 +236,7 @@ workflow SCAN_SEQUENCES {
                 )
             }
 
-        PROSITE_PATTERNS(fasta, ch_prositepatterns)
+        PROSITE_PATTERNS(ch_fasta, ch_prositepatterns)
         results = results.mix(PROSITE_PATTERNS.out)
     }
 
@@ -251,7 +251,7 @@ workflow SCAN_SEQUENCES {
                 )
             }
 
-        PROSITE_PROFILES(fasta, ch_prositeprofiles)
+        PROSITE_PROFILES(ch_fasta, ch_prositeprofiles)
         results = results.mix(PROSITE_PROFILES.out)
     }
 
@@ -267,13 +267,13 @@ workflow SCAN_SEQUENCES {
                 )
             }
     
-        SFLD(fasta, ch_sfld)
+        SFLD(ch_fasta, ch_sfld)
         results = results.mix(SFLD.out)
     }
 
     if (applications.contains("signalp_euk") || applications.contains("signalp_prok")) {
         SIGNALP(
-            fasta,
+            ch_fasta,
             applications,
             appl_config.signalp_euk.organism,
             appl_config.signalp_euk.mode,
@@ -299,7 +299,7 @@ workflow SCAN_SEQUENCES {
                 )
             }
 
-        SMART(fasta, ch_smart)
+        SMART(ch_fasta, ch_smart)
         results = results.mix(SMART.out)
     }
 
@@ -318,13 +318,13 @@ workflow SCAN_SEQUENCES {
                 )
             }
 
-        SUPERFAMILY(fasta, ch_superfamily, batch_size)
+        SUPERFAMILY(ch_fasta, ch_superfamily, batch_size)
         results = results.mix(SUPERFAMILY.out)
     }
 
     if (applications.contains("tmbed")) {
         TMBED(
-            fasta,
+            ch_fasta,
             appl_config.tmbed.use_gpu,
             appl_config.tmbed.chunk_size,
             appl_config.tmbed.chunk_overlap,
@@ -337,9 +337,9 @@ workflow SCAN_SEQUENCES {
     }
 
     // Add a dummy null value for each fasta so there are no mismatches when calling join()
-    results = results.mix(fasta.map { meta, fasta -> tuple(meta, null) })
+    results = results.mix(ch_fasta.map { meta, fasta -> tuple(meta, null) })
 
-    results = fasta
+    results = ch_fasta
         .join(
             results.groupTuple(),
             failOnDuplicate: true,

--- a/subworkflows/sfld/main.nf
+++ b/subworkflows/sfld/main.nf
@@ -6,8 +6,8 @@ workflow SFLD {
     files       // [hmm, sites, hierarchy]
 
     main:
-    ch_search = files.map { hmm, sites, hierarchy -> tuple(hmm, sites) }
-    ch_parse = files.map { hmm, sites, hierarchy -> hierarchy }
+    ch_search = files.map { hmm, sites, _hierarchy -> tuple(hmm, sites) }
+    ch_parse = files.map { _hmm, _sites, hierarchy -> hierarchy }
 
     SEARCH_SFLD(fasta, ch_search)
 

--- a/subworkflows/signalp/main.nf
+++ b/subworkflows/signalp/main.nf
@@ -21,7 +21,7 @@ workflow SIGNALP {
     batch_size     // int, number of sequences per sub-batch for searching
 
     main:
-    results = Channel.empty()
+    results = channel.empty()
 
     if (applications.contains("signalp_euk")) {
         if (euk_gpu) {

--- a/subworkflows/smart/main.nf
+++ b/subworkflows/smart/main.nf
@@ -6,8 +6,8 @@ workflow SMART {
     ch_hmm      // [hmm3, hmm2]
 
     main:
-    ch_hmm3 = ch_hmm.map { hmm3, hmm2 -> hmm3 }
-    ch_hmm2 = ch_hmm.map { hmm3, hmm2 -> hmm2 }
+    ch_hmm3 = ch_hmm.map { hmm3, _hmm2 -> hmm3 }
+    ch_hmm2 = ch_hmm.map { _hmm3, hmm2 -> hmm2 }
 
     PREFILTER_SMART(
         ch_fasta,

--- a/subworkflows/smart/main.nf
+++ b/subworkflows/smart/main.nf
@@ -2,16 +2,16 @@ include { PREFILTER_SMART; PREPARE_SMART; SEARCH_SMART; PARSE_SMART } from  "../
 
 workflow SMART {
     take:
-    fasta       // [meta, fasta]
-    hmm         // [hmm3, hmm2]
+    ch_fasta     // [meta, fasta]
+    ch_hmm      // [hmm3, hmm2]
 
     main:
-    hmm3 = hmm.map { hmm3, hmm2 -> hmm3 }
-    hmm2 = hmm.map { hmm3, hmm2 -> hmm2 }
+    ch_hmm3 = ch_hmm.map { hmm3, hmm2 -> hmm3 }
+    ch_hmm2 = ch_hmm.map { hmm3, hmm2 -> hmm2 }
 
     PREFILTER_SMART(
-        fasta,
-        hmm3
+        ch_fasta,
+        ch_hmm3
     )
 
     PREPARE_SMART(
@@ -20,7 +20,7 @@ workflow SMART {
 
     SEARCH_SMART(
         PREPARE_SMART.out,
-        hmm2
+        ch_hmm2
     )
 
     PARSE_SMART(

--- a/subworkflows/superfamily/main.nf
+++ b/subworkflows/superfamily/main.nf
@@ -18,7 +18,7 @@ workflow SUPERFAMILY {
 
     SEARCH_SUPERFAMILY(ch_split, ssf)
 
-    ch_parse = ssf.map { dir, hmm, selfhits, cla, model, pdbj95d -> tuple (dir, hmm, model) }
+    ch_parse = ssf.map { dir, hmm, _selfhits, _cla, model, _pdbj95d -> tuple (dir, hmm, model) }
 
     PARSE_SUPERFAMILY(
         SEARCH_SUPERFAMILY.out,
@@ -27,5 +27,5 @@ workflow SUPERFAMILY {
 
     emit:
     PARSE_SUPERFAMILY.out
-        .map { meta, meta2, json -> tuple (meta, json) }  // [ meta, json ]
+        .map { meta, _meta2, json -> tuple (meta, json) }  // [ meta, json ]
 }

--- a/subworkflows/superfamily/main.nf
+++ b/subworkflows/superfamily/main.nf
@@ -2,12 +2,12 @@ include { SEARCH_SUPERFAMILY; PARSE_SUPERFAMILY } from  "../../modules/superfami
 
 workflow SUPERFAMILY {
     take:
-    fasta      // [meta, fasta]
+    ch_fasta    // [meta, fasta]
     ssf        // [dir, hmm, selfhits, cla, model, pdbj95d]
     batch_size // [int]
 
     main:
-    ch_split = fasta
+    ch_split = ch_fasta
         .map { meta, fasta ->
             fasta
                 .splitFasta( by: batch_size, file: true )

--- a/tests/diff.py
+++ b/tests/diff.py
@@ -230,8 +230,8 @@ def parse_external_json(
                 seq_id = xref["id"]
 
                 for orf in seq["openReadingFrames"]:
-                    for xref in orf["protein"]["xref"]:
-                        orf_id = xref["id"]
+                    for orf_xref in orf["protein"]["xref"]:
+                        orf_id = orf_xref["id"]
 
                         for m in parse_json_matches(
                             orf["protein"]["matches"],

--- a/tests/diff.py
+++ b/tests/diff.py
@@ -5,7 +5,6 @@ import gzip
 import hashlib
 import json
 import shutil
-import sys
 import xml.etree.ElementTree as ET
 import zipfile
 from collections import defaultdict

--- a/tests/modules/interpro_n/main.parse_interpro_n.nf.test
+++ b/tests/modules/interpro_n/main.parse_interpro_n.nf.test
@@ -14,6 +14,9 @@ nextflow_process {
                     [file("${projectDir}/tests/data/interpro_n/output.json", checkIfExists: true)]
                 ))
                 input[1] = ["cathgene3d", "pirsf", "prints", "sfld", "smart", "superfamily"]
+                input[2] = 2047
+                input[3] = 1000
+                input[4] = 0.25
                 """
             }
         }

--- a/tests/modules/interpro_n/main.prepare_interpro_n.nf.test
+++ b/tests/modules/interpro_n/main.prepare_interpro_n.nf.test
@@ -11,6 +11,8 @@ nextflow_process {
                 """
                 input[0] = channel.of(tuple(1, file("${projectDir}/tests/data/sequences/input.1.fasta", checkIfExists: true)))
                 input[1] = 100
+                input[2] = 2047
+                input[3] = 1000
                 """
             }
         }

--- a/workflows/interproscan.nf
+++ b/workflows/interproscan.nf
@@ -7,11 +7,9 @@ include { SCAN_SEQUENCES as SCAN_REMAINING;
 include { COMBINE              } from "../subworkflows/combine"
 include { OUTPUT               } from "../subworkflows/output"
 
-import uk.ac.ebi.interpro.InterProScan
-
 workflow INTERPROSCAN {
     take:
-    fasta_file              // Channel.fromPath(input fasta file)
+    fasta_file              // channel.fromPath(input fasta file)
     applications            // list[str], names of applications to run
     appl_config             // map, contents of the conf/applications.conf file
     data_dir                // path to the data directory
@@ -138,7 +136,7 @@ workflow PREPARE_INTERPROSCAN {
     use_gpu      // boolean, use GPU acceleration where applicable
 
     main:
-    (apps_config, warn) = InterProScan.parseAppsConfig(use_gpu, applications, apps_config)
+    (apps_config, warn) = uk.ac.ebi.interpro.InterProScan.parseAppsConfig(use_gpu, applications, apps_config)
     if (warn) {
         log.warn warn
     }

--- a/workflows/interproscan.nf
+++ b/workflows/interproscan.nf
@@ -119,7 +119,7 @@ workflow INTERPROSCAN {
         seqdb,
         formats,
         outprefix,
-        nucleic.toBoolean,
+        nucleic.toBoolean(),
         interpro_version,
         interproscan_version
     )

--- a/workflows/interproscan.nf
+++ b/workflows/interproscan.nf
@@ -39,23 +39,23 @@ workflow INTERPROSCAN {
         data_dir,
         interpro_version,
         interproscan_version,
-        !no_matches_api,
-        globus,
-        enforce_compatibility
+        !no_matches_api.toBoolean(),
+        globus.toBoolean(),
+        enforce_compatibility.toBoolean()
     )
     appl_dirs        = INIT_DATABASES.out.directories
     interpro_version = INIT_DATABASES.out.interpro_version
 
     INIT_SEQUENCES(
         fasta_file,
-        nucleic,
+        nucleic.toBoolean(),
         batch_size
     )
     fasta = INIT_SEQUENCES.out.fasta
     seqdb = INIT_SEQUENCES.out.database
 
     scan_results = channel.empty()
-    if (no_matches_api) {
+    if (no_matches_api.toBoolean()) {
         SCAN_SEQUENCES(
             fasta,
             appl_config,
@@ -109,9 +109,9 @@ workflow INTERPROSCAN {
         scan_results,
         appl_config,
         appl_dirs,
-        goterms,
-        pathways,
-        skip_repr_locations
+        goterms.toBoolean(),
+        pathways.toBoolean(),
+        skip_repr_locations.toBoolean()
     )
 
     OUTPUT(
@@ -119,7 +119,7 @@ workflow INTERPROSCAN {
         seqdb,
         formats,
         outprefix,
-        nucleic,
+        nucleic.toBoolean,
         interpro_version,
         interproscan_version
     )

--- a/workflows/interproscan.nf
+++ b/workflows/interproscan.nf
@@ -17,7 +17,7 @@ workflow INTERPROSCAN {
     formats                 // list[str], output formats
     interpro_version        // str, version of InterPro
     interproscan_version    // str, version of InterProScan
-    interproscan_name       // str, name of the InterProScan workflow: "InterProScan6"
+    _interproscan_name      // str, name of the InterProScan workflow: "InterProScan6"
     no_matches_api          // boolean, use the Matches API
     matches_api_url         // str, url to the Matches API
     matches_api_chunk_size  // int, chunk size for Matches API requests
@@ -114,7 +114,7 @@ workflow INTERPROSCAN {
         skip_repr_locations
     )
 
-    output_files = OUTPUT(
+    OUTPUT(
         COMBINE.out,
         seqdb,
         formats,
@@ -125,7 +125,7 @@ workflow INTERPROSCAN {
     )
 
     emit:
-    output_files
+    OUTPUT.out
 }
 
 workflow PREPARE_INTERPROSCAN {


### PR DESCRIPTION
Relative to [Jira ticket](https://embl.atlassian.net/browse/IBU-12394).

Preparing interproscan6 to the [strict syntax](https://docs.seqera.io/nextflow/strict-syntax), enabled by default from nextflow version 26.04.
 
**IMPORTANT** ⚠️  Before to test make sure to update cache:
```
nextflow drop ebi-pf-team/interproscan6
nextflow pull ebi-pf-team/interproscan6 -r strict-syntax-v2
```

Tests:
✅  benchmark (-profile singularity): Improve comparing to i6 6.0.0 version (~same average time of edge branch)
<details>
<summary>Benchmark summary (6.0.0 VS strict-syntax-v2)</summary>
  - Average time for observed_UP000001940_6239: 2h 17m 45s (strict-syntax-v2)
  - Average time for expected_UP000001940_6239: 2h 31m 44s
  - Average time for observed_UP000000625_83333: 0h 24m 31s (strict-syntax-v2)
  - Average time for expected_UP000000625_83333: 0h 28m 6s
  - Average time for observed_UP000002311_559292: 0h 49m 11s (strict-syntax-v2)
  - Average time for expected_UP000002311_559292: 0h 52m 38s
  - Average time for observed_UP000001584_83332: 0h 22m 12s (strict-syntax-v2)
  - Average time for expected_UP000001584_83332: 0h 25m 54s
  - Average time for observed_UP000000589_10090: 4h 3m 35s (strict-syntax-v2)
  - Average time for expected_UP000000589_10090: 4h 25m 28s
  - Average time for observed_UP000000803_7227: 2h 24m 58s (strict-syntax-v2)
  - Average time for expected_UP000000803_7227: 2h 34m 14s
  - Average time for observed_UP000006548_3702: 3h 19m 52s (strict-syntax-v2)
  - Average time for expected_UP000006548_3702: 4h 6m 33s
  - Average time for observed_UP000007305_4577: 4h 6m 2s (strict-syntax-v2)
  - Average time for expected_UP000007305_4577: 4h 58m 20s
  - Average time for observed_UP000005640_9606: 3h 47m 40s (strict-syntax-v2)
  - Average time for expected_UP000005640_9606: 3h 52m 52s
  - Total successful: 90 from 90 tasks
  </details>
✅  AWS (-profile awsbatch,docker,wave,test)

✅  GCP (-profile googlebatch,docker,wave,test)

✅  MAC using nextflow 26.04.0 (-profile docker,test)

✅  goterms, pathways

✅  nucleic

✅ run-ml (--skip-applications interpron,deeptmhmm) 

✅  regression tests using human proteome (only mobidb differences, ~30 matches):
- (expected) nextflow version 25.04.6, branch 6.0.0
- (observed) nextflow version 25.04.6, branch strict-syntax-v2, NXF_SYNTAX_PARSER=v2 
- (observed) nextflow version 26.04.0, branch strict-syntax-v2


Warnings ONLY running version 25.04.6, branch strict-syntax-v2, NXF_SYNTAX_PARSER=v2:
```
WARN: Unrecognized config option 'process.withLabel:mem_min.memory'
WARN: Unrecognized config option 'process.withLabel:mem_low.memory'
WARN: Unrecognized config option 'process.withLabel:mem_medium.memory'
WARN: Unrecognized config option 'process.withLabel:mem_high.memory'
WARN: Unrecognized config option 'process.withLabel:mem_veryhigh.memory'
WARN: Unrecognized config option 'process.withLabel:time_veryshort.time'
WARN: Unrecognized config option 'process.withLabel:time_short.time'
WARN: Unrecognized config option 'process.withLabel:time_medium.time'
WARN: Unrecognized config option 'process.withLabel:time_long.time'
WARN: Unrecognized config option 'process.withLabel:dynamic.cpus'
WARN: Unrecognized config option 'process.withName:DOWNLOAD_INTERPRO|DOWNLOAD_DATABASE.errorStrategy'
WARN: Unrecognized config option 'process.withLabel:use_gpu.containerOptions'
WARN: Unrecognized config option 'process.withLabel:use_gpu.clusterOptions'
```