### PR TITLE
Add citation and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InterProScan 6
 
-[![Nextflow](https://img.shields.io/badge/%E2%89%A525.04.6-0dc09d?style=flat&logo=nextflow&label=nextflow&labelColor=f5fafe)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/%E2%89%A525.10.4-0dc09d?style=flat&logo=nextflow&label=nextflow&labelColor=f5fafe)](https://www.nextflow.io/)
 [![run with docker](https://img.shields.io/badge/docker-1D63ED?logo=docker&logoColor=1D63ED&label=run%20with&labelColor=f5fafe)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/singularity-1E4383?label=run%20with&labelColor=f5fafe)](https://sylabs.io/docs/)
 
@@ -12,7 +12,7 @@
 
 Before you begin, install:
 
-* [Nextflow](https://www.nextflow.io/) 25.04 or later
+* [Nextflow](https://www.nextflow.io/) 25.10 or later
 * A container runtime. The currently supported are:
     * [Docker](https://www.docker.com/)
     * [SingularityCE](https://sylabs.io/singularity/)
@@ -32,7 +32,7 @@ If you have Docker and Nextflow installed, you can quickly test InterProScan and
 
 ```sh
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker,test \
   --datadir data \
   --interpro latest
@@ -40,7 +40,7 @@ nextflow run ebi-pf-team/interproscan6 \
 
 Explanation of parameters:
 
-* `-r 6.0.0`: Specifies the version of InterProScan to run. We strongly recommend always specifying a version to ensure consistent and reproducible results.
+* `-r 6.0.1`: Specifies the version of InterProScan to run. We strongly recommend always specifying a version to ensure consistent and reproducible results.
 * `-profile docker,test`:
   * `docker`: Executes tasks in Docker containers.
   * `test`: Uses a small test FASTA file included in the workflow.
@@ -66,7 +66,7 @@ To annotate your own sequences FASTA file, omit the `test` profile and specify `
 
 ```sh
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker \
   --datadir data \
   --input /path/to/sequences.faa
@@ -76,7 +76,7 @@ For nucleotide sequences, add `--nucleic`:
 
 ```sh
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker \
   --datadir data \
   --input /path/to/sequences.fna \
@@ -93,6 +93,8 @@ For further assistance, please [create an issue](https://github.com/ebi-pf-team/
 
 ## Citation
 
-If you use InterProScan in your work, please cite the following publication:
+If you use InterProScan in your work, please cite the following publications:
+
+> Blum M, Hobbs E, Florentino L, Bateman A. **InterProScan 6: a modern large-scale protein function annotation pipeline**. *Bioinform Adv*. 2026 May 21;6(1):vbag141. [doi: 10.1093/bioadv/vbag141](https://doi.org/10.1093/bioadv/vbag141).
 
 > Blum M, Andreeva A, Florentino LC, Chuguransky SR, Grego T, Hobbs E, Pinto BL, Orr A, Paysan-Lafosse T, Ponamareva I, Salazar GA, Bordin N, Bork P, Bridge A, Colwell L, Gough J, Haft DH, Letunic I, Llinares-López F, Marchler-Bauer A, Meng-Papaxanthos L, Mi H, Natale DA, Orengo CA, Pandurangan AP, Piovesan D, Rivoire C, Sigrist CJA, Thanki N, Thibaud-Nissen F, Thomas PD, Tosatto SCE, Wu CH, Bateman A. **InterPro: the protein sequence classification resource in 2025**. *Nucleic Acids Res*. 2025 Jan;53(D1):D444-D456. [doi: 10.1093/nar/gkae1082](https://doi.org/10.1093/nar/gkae1082).

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ To get a first successful run:
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \ # (1)!
+  -r 6.0.1 \ # (1)!
   -profile docker,test \ # (2)!
   --datadir data \ # (3)!
   --interpro latest # (4)!

--- a/docs/licensed_applications.md
+++ b/docs/licensed_applications.md
@@ -101,7 +101,7 @@ Run InterProScan with the default analyses plus all licensed deep-learning analy
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker \
   -c licensed.conf \
   --input /path/to/sequences.faa \
@@ -114,7 +114,7 @@ Run only the licensed applications explicitly:
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker \
   -c licensed.conf \
   --input /path/to/sequences.faa \

--- a/docs/options.md
+++ b/docs/options.md
@@ -26,7 +26,7 @@ The tables below describe the InterProScan 6 parameters, plus the main Nextflow 
 
 | Option | Description |
 |--------|-------------|
-| `-r`, `-revision <VERSION>` | Tells Nextflow which InterProScan version to run. Recommended for reproducibility. For example, use `-r 6.0.0` to pin a specific InterProScan release. |
+| `-r`, `-revision <VERSION>` | Tells Nextflow which InterProScan version to run. Recommended for reproducibility. For example, use `-r 6.0.1` to pin a specific InterProScan release. |
 | `-profile <PROFILE>` | Selects the runtime environment, such as `docker`, `slurm`, etc. Common combinations include `docker,test` and `singularity,slurm`. |
 | `--input <FASTA>` | Path to the input FASTA file. Required unless a profile such as `test` supplies it automatically. |
 | `--datadir <DATADIR>` | Directory used for InterPro and member-database data files. |

--- a/docs/output.md
+++ b/docs/output.md
@@ -33,7 +33,7 @@ The GFF3 output follows the standard GFF3 format with InterProScan-specific head
 ```
 ##gff-version 3.1.26
 ##interpro-version 108.0
-##interproscan-version 6.0.0
+##interproscan-version 6.0.1
 ```
 
 ### Features
@@ -66,7 +66,7 @@ Common attributes include: `Name`, `Alias`, `Parent` (for ORF/nucleic mode), `Db
 ```gff3
 ##gff-version 3.1.26
 ##interpro-version 108.0
-##interproscan-version 6.0.0
+##interproscan-version 6.0.1
 ##sequence-region tr|A0A086JQP8|A0A086JQP8_TOXGO 1 847
 tr|A0A086JQP8|A0A086JQP8_TOXGO	COILS	coiled_coil	485	526	.	.	.	Name=Coil;type=Region;representative=false
 tr|A0A086JQP8|A0A086JQP8_TOXGO	PROSITE patterns	polypeptide_motif	106	115	.	.	.	Name=HSP90;Alias=PS00298;Dbxref=InterPro:IPR019805;type=Conserved_site;representative=false
@@ -196,7 +196,7 @@ The schema is aligned with the response returned by the [Matches API](matches_ap
 
 ```json
 {
-  "interproscan-version": "6.0.0",
+  "interproscan-version": "6.0.1",
   "interpro-version": "108.0",
   "results": [
     {
@@ -298,7 +298,7 @@ The schema is aligned with the response returned by the [Matches API](matches_ap
 
 ```json
 {
-  "interproscan-version": "6.0.0",
+  "interproscan-version": "6.0.1",
   "interpro-version": "108.0",
   "results": [
     {
@@ -405,7 +405,7 @@ Compared with the InterProScan 5 XML schema, the InterProScan 6 XML format is si
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<results interproscan-version="6.0.0" interpro-version="108.0">
+<results interproscan-version="6.0.1" interpro-version="108.0">
   <protein>
     <sequence md5="04A129E51F351B91B6373645AFDBCC58">MKAKEIREMGADEIRRKIDDSTQEMFNLRFQHATGQLENTARLNKTKKEVARLKTILKEVEQ</sequence>
     <xref id="sp|B8FES7|RL29_DESAL" name="sp|B8FES7|RL29_DESAL Large ribosomal subunit protein uL29 OS=Desulfatibacillum aliphaticivorans OX=218208 GN=rpmC PE=3 SV=1"/>
@@ -441,7 +441,7 @@ Compared with the InterProScan 5 XML schema, the InterProScan 6 XML format is si
 
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
-<results interproscan-version="6.0.0" interpro-version="108.0">
+<results interproscan-version="6.0.1" interpro-version="108.0">
   <nucleotide-sequence>
     <sequence md5="0A4E057B197C1182FD211A4BFF5271CE">ATGAGGGATTCGCCCGATGAAGTCAGCGTCGACGAGCTGGTGAACATGGCCGTGGCCGGTGGCATCGACGAAGGAACGGCGTTGGACGCCTTACAGGGTAAGCTGGACCCGTACAAGGTAATGCGGGCTGCACACGAGGCCCGACTTAAGATCGTCGGTGAACACGTCACGTTCGTGGTGAACAGGAACATCAACTTCACCAACGTGTGCATTAACAGATGTCGATTCTGTGCGTTCCGGAGGGATCCGGACGACCCGGATGCTTACCGTATGACGCCGGAGGAGGTGGGCGAGCGGGCAGCGGAAGCCCGTGACGCTGGAGCTACGGAAGTATGTCTTCAGGGCGGACTGCATCCCGAGGCGACGTTTGAGTACTACCTGGAAATGTTGGACGAGATCAAGTCCCAAGCCCCGGACATCCACGTGCACGGGTACTCACCGATGGAGGTGAAGTACTGCGCCAAGCTGGCGGGAGAGGACATCGAAGACGTACTACGAGAGCTGAAGCGAGCCGGTCTCGATTCGATGCCCGGAACGGCCGCGGAGATATTCTCCCCTGAGGTGAGGAAGCGGCTATGTCCTGATAAGTTGGAAGCCGATGAGTGGGAACATATCATCAGGATCGCGCACGAGTTGGGAATTCCCACCACTTGTACTATGATGTACGGTCACATCGACTCACCGAGGGACTGGATCGACCACATGAAGCGGCTTCGAGGGATCCAAGAGGACACGGGAGGCTTCACGGAGTTCGTGCCGCTCTCCTTCGTACATTCGAACGCACCGATTTACCGACGAGGAGGGGCGCGACCCGGAGTATCGGGTATGACGGACGTACTCGTGCACGCTGTGGCCCGATTGTACTTCGGACCGTTGATTCCGAACATACAGGCTTCCTGGGTGAAGCTCGGAGTGAAGCTGGCTCAGATGACGCTGCACGCCGGGGCGAACGATCTAGGTGGCACCCTCATGGAAGAGAACATCTCCCGGGAGGCCGGAGCGACCGAGGGCGAGCAGCTCGAGCCCGAGGAGATAGTGGAGATCATTCGGGAGGCGGGCTTCACCCCCGTGCAGCGCACCACGCTCTACGAGCCGGTGAAGGTGTACTAA</sequence>
     <xref id="ENA|AAM02110|AAM02110.1" name="ENA|AAM02110|AAM02110.1 Methanopyrus kandleri AV19 Predicted enzyme related to thiamine biosynthesis enzyme ThiH"/>

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -29,7 +29,7 @@ Example commands:
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile singularity,slurm \
   --input /path/to/sequences.faa \
   --datadir /shared/interproscan/data
@@ -37,7 +37,7 @@ nextflow run ebi-pf-team/interproscan6 \
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile apptainer,lsf \
   --input /path/to/sequences.faa \
   --datadir /shared/interproscan/data
@@ -84,7 +84,7 @@ Example command:
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker,awsbatch \
   -c aws.config \
   -bucket-dir s3://<bucket>/interproscan/work \
@@ -118,7 +118,7 @@ Example command:
 ```bash
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/creds.json"
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker,googlebatch \
   -c gcp.config \
   -bucket-dir gs://<bucket>/interproscan/work \
@@ -167,7 +167,7 @@ Example command:
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -c your_cluster.config \
   -profile singularity,slurm \
   --input /path/to/sequences.faa \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,14 +6,14 @@ The typical command for running InterProScan is as follows:
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \ # (1)!
+  -r 6.0.1 \ # (1)!
   -profile docker \ # (2)!
   --input /path/to/sequences.faa \ # (3)!
   --datadir data \ # (4)!
   --interpro latest # (5)!
 ```
 
-1. Run InterProScan `v6.0.0`
+1. Run InterProScan `v6.0.1`
 2. Executes tasks in Docker containers
 3. Path to your input FASTA file of protein sequences
 4. Directory where to download and save the reference files
@@ -48,7 +48,7 @@ See [Analyses](analyses.md) for the full list of supported analyses.
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker \
   --datadir data \
   --input /path/to/sequences.faa \
@@ -59,7 +59,7 @@ nextflow run ebi-pf-team/interproscan6 \
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker \
   --datadir data \
   --input /path/to/sequences.faa \
@@ -84,7 +84,7 @@ By default, InterProScan expects protein sequences, but supports nucleotide sequ
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker \
   --datadir data \
   --input /path/to/contigs.fna \ # (1)!
@@ -108,7 +108,7 @@ When a match is integrated into an InterPro entry, InterProScan can add those an
 
 ```bash
 nextflow run ebi-pf-team/interproscan6 \
-  -r 6.0.0 \
+  -r 6.0.1 \
   -profile docker \
   --datadir data \
   --input /path/to/sequences.faa \

--- a/nextflow.config
+++ b/nextflow.config
@@ -82,7 +82,7 @@ manifest {
     license                = "Apache License 2.0"
     mainScript             = "main.nf" 
     name                   = "InterProScan6"
-    nextflowVersion        = "!>=25.04.6"
+    nextflowVersion        = "!>=25.10.4"
     organization           = "EMBL-EBI"
-    version                = "6.0.0"
+    version                = "6.0.1"
 }


### PR DESCRIPTION
- Add a citation for the InterProScan 6 paper that is now published
- Bump the minimum Nextflow version to `25.10`
- Bump the InterProScan version to `6.0.1`