### PR TITLE
Typed params

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -12,6 +12,21 @@ params {
     skipInterproVersionCheck: Boolean
     runMl: Boolean
     useGpu: Boolean
+    batchSize: Integer
+    subBatchSize: Integer
+    cpus: Integer
+    matchesApiChunkSize: Integer
+    matchesApiMaxRetries: Integer
+    maxWorkers: Integer
+    input: String
+    datadir: String
+    applications: String
+    formats: String
+    outdir: String
+    outprefix: String
+    skipApplications: String
+    interpro: String
+    matchesApiUrl: String
 }
 
 workflow {

--- a/main.nf
+++ b/main.nf
@@ -18,11 +18,11 @@ params {
     matchesApiChunkSize: Integer
     matchesApiMaxRetries: Integer
     maxWorkers: Integer
-    input: String
-    datadir: String
+    input: Path
+    datadir: Path
+    outdir: Path
     applications: String
     formats: String
-    outdir: String
     outprefix: String
     skipApplications: String
     interpro: String

--- a/main.nf
+++ b/main.nf
@@ -1,11 +1,15 @@
 include { INIT_PIPELINE } from './subworkflows/init/pipeline'
 include { INTERPROSCAN  } from './workflows/interproscan'
 
+params {
+    help: Boolean
+}
+
 workflow {
     println "# ${workflow.manifest.name} ${workflow.manifest.version}"
     println "# ${workflow.manifest.description}\n"
 
-    if (params.help.toBoolean()) {
+    if (params.help) {
         uk.ac.ebi.interpro.InterProScan.printHelp(params.appsConfig)
         exit 0
     }

--- a/main.nf
+++ b/main.nf
@@ -3,6 +3,15 @@ include { INTERPROSCAN  } from './workflows/interproscan'
 
 params {
     help: Boolean
+    globus: Boolean
+    noMatchesApi: Boolean
+    nucleic: Boolean
+    goterms: Boolean
+    pathways: Boolean
+    skipReprLocations: Boolean
+    skipInterproVersionCheck: Boolean
+    runMl: Boolean
+    useGpu: Boolean
 }
 
 workflow {

--- a/subworkflows/init/pipeline/main.nf
+++ b/subworkflows/init/pipeline/main.nf
@@ -1,8 +1,3 @@
-params {
-    run_ml: Boolean
-    use_gpu: Boolean
-}
-
 workflow INIT_PIPELINE {
     // Validate pipeline input parameters
     take:

--- a/subworkflows/init/pipeline/main.nf
+++ b/subworkflows/init/pipeline/main.nf
@@ -1,3 +1,8 @@
+params {
+    run_ml: Boolean
+    use_gpu: Boolean
+}
+
 workflow INIT_PIPELINE {
     // Validate pipeline input parameters
     take:
@@ -26,7 +31,7 @@ workflow INIT_PIPELINE {
     }
 
     // Applications validation
-    (apps, error, warn) = uk.ac.ebi.interpro.InterProScan.validateApplications(applications, skip_applications, applications_config, run_ml.toBoolean())
+    (apps, error, warn) = uk.ac.ebi.interpro.InterProScan.validateApplications(applications, skip_applications, applications_config, run_ml)
     if (!apps) {
         log.error error
         exit 1
@@ -35,7 +40,7 @@ workflow INIT_PIPELINE {
     }
 
     // Enable gpu acceleration if requested
-    (apps_config, warn) = uk.ac.ebi.interpro.InterProScan.enableGpuAcceleration(use_gpu.toBoolean(), apps, applications_config)
+    (apps_config, warn) = uk.ac.ebi.interpro.InterProScan.enableGpuAcceleration(use_gpu, apps, applications_config)
     if (warn) {
         log.warn warn
     }

--- a/workflows/interproscan.nf
+++ b/workflows/interproscan.nf
@@ -7,6 +7,17 @@ include { SCAN_SEQUENCES as SCAN_REMAINING;
 include { COMBINE              } from "../subworkflows/combine"
 include { OUTPUT               } from "../subworkflows/output"
 
+params {
+    no_matches_api: Boolean
+    globus: Boolean
+    enforce_compatibility: Boolean
+    nucleic: Boolean
+    goterms: Boolean
+    pathways: Boolean
+    skip_repr_locations: Boolean
+}
+
+
 workflow INTERPROSCAN {
     take:
     fasta_file              // channel.fromPath(input fasta file)
@@ -39,23 +50,23 @@ workflow INTERPROSCAN {
         data_dir,
         interpro_version,
         interproscan_version,
-        !no_matches_api.toBoolean(),
-        globus.toBoolean(),
-        enforce_compatibility.toBoolean()
+        !no_matches_api,
+        globus,
+        enforce_compatibility
     )
     appl_dirs        = INIT_DATABASES.out.directories
     interpro_version = INIT_DATABASES.out.interpro_version
 
     INIT_SEQUENCES(
         fasta_file,
-        nucleic.toBoolean(),
+        nucleic,
         batch_size
     )
     fasta = INIT_SEQUENCES.out.fasta
     seqdb = INIT_SEQUENCES.out.database
 
     scan_results = channel.empty()
-    if (no_matches_api.toBoolean()) {
+    if (no_matches_api) {
         SCAN_SEQUENCES(
             fasta,
             appl_config,
@@ -109,9 +120,9 @@ workflow INTERPROSCAN {
         scan_results,
         appl_config,
         appl_dirs,
-        goterms.toBoolean(),
-        pathways.toBoolean(),
-        skip_repr_locations.toBoolean()
+        goterms,
+        pathways,
+        skip_repr_locations
     )
 
     OUTPUT(
@@ -119,7 +130,7 @@ workflow INTERPROSCAN {
         seqdb,
         formats,
         outprefix,
-        nucleic.toBoolean(),
+        nucleic,
         interpro_version,
         interproscan_version
     )

--- a/workflows/interproscan.nf
+++ b/workflows/interproscan.nf
@@ -7,17 +7,6 @@ include { SCAN_SEQUENCES as SCAN_REMAINING;
 include { COMBINE              } from "../subworkflows/combine"
 include { OUTPUT               } from "../subworkflows/output"
 
-params {
-    no_matches_api: Boolean
-    globus: Boolean
-    enforce_compatibility: Boolean
-    nucleic: Boolean
-    goterms: Boolean
-    pathways: Boolean
-    skip_repr_locations: Boolean
-}
-
-
 workflow INTERPROSCAN {
     take:
     fasta_file              // channel.fromPath(input fasta file)


### PR DESCRIPTION
Related to [Jira task](https://embl.atlassian.net/browse/IBU-12497).

Adding params type only to the boolean to avoid Nextflow interpret as String (and removing the explicit cast to those cases).

PS: The other case we had the wrong Nextflow interpretation as String was in the float/double types, but still using the explicit cast because they occur inside a process.