### PR TITLE
Fix working directory path for InterPro-N GPU process

### DIFF
--- a/modules/interpro_n/main.nf
+++ b/modules/interpro_n/main.nf
@@ -81,7 +81,7 @@ process RUN_INTERPRO_N_GPU {
     WORKDIR=\$(pwd)
     INPUT=\$(readlink -e ${tsv})
     CHECKPOINT=\$(readlink -e ${ck_dir})
-    cd /workdir
+    cd /opt/interpro_n
     python3 -m interpro_n.main \
         --input_dir \${INPUT} \
         --checkpoint \${CHECKPOINT} \


### PR DESCRIPTION
With the latest Docker/Singularity image, the working directory is no longer `/workdir`. The change was made for the CPU-based process of InterPro-N, but not the GPU-based process.