### PR TITLE
Skip SFLD site annotations without descriptions

### DIFF
--- a/lib/uk/ac/ebi/interpro/SFLD.groovy
+++ b/lib/uk/ac/ebi/interpro/SFLD.groovy
@@ -89,9 +89,9 @@ class SFLD {
                 String description = fields.length == 3 ? fields[2] : null
 
                 Match match = domains.get(modelAccession)
-                if (match != null) {
+                if (match != null && description != null) {
                     Site site = new Site(description, residues)
-                    match.addSite(site)                        
+                    match.addSite(site)
                 }
             }
         }


### PR DESCRIPTION
Sometimes, SFLD site annotations lack a description. We currently report them, but they aren't useful. With this PR, they are now ignored.