### PR TITLE
Skip site annotations with empty descriptions

### DIFF
--- a/modules/pirsr/main.nf
+++ b/modules/pirsr/main.nf
@@ -78,9 +78,12 @@ process PARSE_PIRSR {
                                     }
                                 }
                             }
-                            if (residueStart != 0 && residueEnd != 0) {
+                            def label = (pos.label ?: '').trim()
+                            def desc = (pos.desc ?: '').trim().replaceAll(/\.$/, '')
+                            def siteDescription = desc ? "${label}: ${desc}" : label
+                            if (residueStart != 0 && residueEnd != 0 && siteDescription) {
                                 positionsParsed << [
-                                    pos.desc,
+                                    siteDescription,
                                     residue,
                                     residueStart,
                                     residueEnd

--- a/tests/modules/pirsr/main.nf.test.snap
+++ b/tests/modules/pirsr/main.nf.test.snap
@@ -5,15 +5,15 @@
                 "0": [
                     [
                         1,
-                        "pirsr.json:md5,46b01398aa2f603710c00c663ccce3d5"
+                        "pirsr.json:md5,f6e0f2ab7b2409442ccb49f96e77a0f3"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-01T00:30:07.157584923",
+        "timestamp": "2026-06-24T10:09:58.777338655",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.04.7"
+            "nextflow": "26.04.3"
         }
     }
 }


### PR DESCRIPTION
Similar to #327 but for PIRSR.

PIRSR site rules have a label and a description. For the latest version of PIRSR used in InterProScan 6, the label is never null or empty, while the description is empty ~900 times.

Currently, we only use the site rule descriptions to report site annotations, so there are case where we report a site annotation with an empty description. With this PR, we start using the label and the description, so even if the description is empty, we'll still report some information.