### PR TITLE
Fix SMART handling for unmatched sequences during pre-filtering

### DIFF
--- a/modules/smart/main.nf
+++ b/modules/smart/main.nf
@@ -85,7 +85,10 @@ process SEARCH_SMART {
 
     tmpdir=\$(mktemp -d -p .)
 
-    unzip -q ${seqs_zip} -d \${tmpdir}
+    # When PREFILTER_SMART finds no matches, PREPARE_SMART emits an empty
+    # sequences.zip; unzip warns "zipfile is empty" and exits 1. 
+    # Tolerate that but fail on real errors (>= 2).
+    unzip -q ${seqs_zip} -d \${tmpdir} || [ \$? -eq 1 ]
     touch \${tmpdir}/hmmpfam.out
 
     for fasta in \${tmpdir}/*.faa; do


### PR DESCRIPTION
For SMART, we run first pre-filter input sequences with HMMER3 (fast) then annotate matched sequences with HMMER2 (slow). To avoid too many stage/unstage operations when using cloud computing, matched sequences are archived together in a zip file and unzipped before being annotated with HMMER2.

If no sequence is matched during the pre-filtering, the zip archive is empty and `unzip` shows a warning... and fails with exit code 1.

This PR handles the exit code 1 of `unzip` (other exit codes still lead to the task failing) so the pipeline doesn't crash when not a single sequence is matched by HMMER3.