### PR TITLE
Get ML-based annotations from Matches API

### DIFF
--- a/lib/uk/ac/ebi/interpro/InterProN.groovy
+++ b/lib/uk/ac/ebi/interpro/InterProN.groovy
@@ -1,0 +1,35 @@
+package uk.ac.ebi.interpro
+
+class InterProN {
+    // appsConfig label -> library name as reported by InterPro
+    static final Map<String, String> SUPPORTED_DATABASES = [
+        cathgene3d     : "CATH-Gene3D",
+        cdd            : "CDD",
+        hamap          : "HAMAP",
+        ncbifam        : "NCBIFAM",
+        panther        : "PANTHER",
+        pfam           : "Pfam",
+        pirsf          : "PIRSF",
+        prints         : "PRINTS",
+        prositeprofiles: "PROSITE profiles",
+        prositepatterns: "PROSITE patterns",
+        sfld           : "SFLD",
+        smart          : "SMART",
+        superfamily    : "SUPERFAMILY",
+    ]
+
+    // Library names emitted by the InterPro-N model that differ from the appsConfig label
+    static final Map<String, String> LIBRARY_ALIASES = [ssf: "superfamily"]
+
+    // Normalise a library or application name to an appsConfig label
+    static String toLabel(String name) {
+        def key = InterProScan.normalizeName(name)
+        return LIBRARY_ALIASES.get(key, key)
+    }
+
+    // Supported databases to report, given the user's requested applications
+    static Set<String> selectDatabases(List<String> applications) {
+        def overlap = SUPPORTED_DATABASES.keySet().intersect(applications as Set)
+        return (overlap ?: SUPPORTED_DATABASES.keySet()) as Set
+    }
+}

--- a/lib/uk/ac/ebi/interpro/InterProScan.groovy
+++ b/lib/uk/ac/ebi/interpro/InterProScan.groovy
@@ -226,6 +226,10 @@ class InterProScan {
         return dirs ? dirs.last().fileName.toString() : null
     }
 
+    static String normalizeName(String name) {
+        return name.toLowerCase().replaceAll(/[-_\s]/, "")
+    }
+
     static List<String>validateApplications(String applications, String skipApplications, Map appsConfig, Boolean runML) {
         // Return: [appsToRun | null, errorMessage | null, warningMessage | null]
         if (applications && runML) {
@@ -238,11 +242,9 @@ class InterProScan {
         // Normalize "catalogue" of applications
         Map<String, String> aliases = [:]
         appsConfig.each { label, cfg ->
-            def std = cfg.name.toLowerCase().replaceAll(/[-_ ]/, "")
-            aliases[std] = label
+            aliases[this.normalizeName(cfg.name)] = label
             (cfg.aliases ?: []).each { alias ->
-                def stdAlias = alias.toLowerCase().replaceAll(/[-_ ]/, "")
-                aliases[stdAlias] = label
+                aliases[this.normalizeName(alias)] = label
             }
         }
 
@@ -274,7 +276,7 @@ class InterProScan {
         // Explicit --applications
         if (applications) {
             Set<String> req = applications.split(",")
-                                          .collect { it.trim().toLowerCase().replaceAll(/[-_ ]/, "") }
+                                          .collect { this.normalizeName(it.trim()) }
                                           .findAll { it }
                                           .toSet()
             Set<String> unrec = []
@@ -305,7 +307,7 @@ class InterProScan {
         // Explicit --skip--applications
         if (skipApplications) {
             Set<String> req = skipApplications.split(",")
-                                              .collect { it.trim().toLowerCase().replaceAll(/[-_ ]/, "") }
+                                              .collect { this.normalizeName(it.trim()) }
                                               .findAll { it }
                                               .toSet()
             Set<String> unrec = []

--- a/lib/uk/ac/ebi/interpro/ProcessOutputGFF3.groovy
+++ b/lib/uk/ac/ebi/interpro/ProcessOutputGFF3.groovy
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import uk.ac.ebi.interpro.Location
 import uk.ac.ebi.interpro.Match
 import uk.ac.ebi.interpro.SeqDB
+import uk.ac.ebi.interpro.SignalP
 
 
 class ProcessOutputGFF3 {
@@ -185,7 +186,7 @@ class ProcessOutputGFF3 {
             score = loc.score
         } else if (memberDb == "PRINTS") {
             score = match.evalue
-        } else if (memberDb == "SignalP" || ["HAMAP", "PROSITE profiles"].contains(memberDb)) {
+        } else if (memberDb == SignalP.LIBRARY || ["HAMAP", "PROSITE profiles"].contains(memberDb)) {
             score = loc.score
         } else {
             score = loc.evalue
@@ -202,10 +203,9 @@ class ProcessOutputGFF3 {
 
         def signalpMode = null
         def signalpOrganism = null
-        if (memberDb == "SignalP") {
-            def parts = match.modelAccession.split("_")
-            signalpMode = parts[1]
-            signalpOrganism = parts[2]
+        if (memberDb == SignalP.LIBRARY) {
+            signalpMode = SignalP.mode(match.modelAccession)
+            signalpOrganism = SignalP.organism(match.modelAccession)
         }
 
         String interproAccession = match.signature.entry?.accession

--- a/lib/uk/ac/ebi/interpro/SignalP.groovy
+++ b/lib/uk/ac/ebi/interpro/SignalP.groovy
@@ -1,0 +1,39 @@
+package uk.ac.ebi.interpro
+
+class SignalP {
+    // Library reported for both organism variants
+    static final String LIBRARY = "SignalP"
+
+    // The only mode the Matches API stores pre-calculated results for
+    static final String API_MODE = "fast"
+
+    // SignalP --organism option -> appsConfig label
+    static final Map<String, String> ORGANISMS = [
+        eukarya: "signalp_euk",
+        other  : "signalp_prok",
+    ]
+
+    static final List<String> APPLICATIONS = ORGANISMS.values() as List
+
+    // Model accessions encode the mode and organism, e.g. "SignalP_fast_eukarya"
+    static String modelAccession(String mode, String organism) {
+        return "SignalP_${mode}_${organism}".toString()
+    }
+
+    static String mode(String modelAccession) {
+        def parts = modelAccession.split("_")
+        assert parts.size() == 3
+        return parts[1]
+    }
+
+    static String organism(String modelAccession) {
+        def parts = modelAccession.split("_")
+        assert parts.size() == 3
+        return parts[2]
+    }
+
+    // "SignalP_fast_eukarya" -> "signalp_euk"; null when unrecognised
+    static String toLabel(String modelAccession) {
+        return ORGANISMS[organism(modelAccession)]
+    }
+}

--- a/modules/interpro_n/main.nf
+++ b/modules/interpro_n/main.nf
@@ -106,32 +106,8 @@ process PARSE_INTERPRO_N {
     tuple val(meta), path("interpro-n.json")
 
     exec:
-    def supported_databases = [
-        cathgene3d     : "CATH-Gene3D",
-        cdd            : "CDD",
-        hamap          : "HAMAP",
-        ncbifam        : "NCBIFAM",
-        panther        : "PANTHER",
-        pfam           : "Pfam",
-        pirsf          : "PIRSF",
-        prints         : "PRINTS",
-        prositeprofiles: "PROSITE profiles",
-        prositepatterns: "PROSITE patterns",
-        sfld           : "SFLD",
-        smart          : "SMART",
-        ssf            : "SUPERFAMILY",
-    ]
-
-    // User-requested applications
-    def requested = applications.collect { name ->
-        return name == "superfamily" ? "ssf" : name
-    } as Set
-
-    // Compute overlap
-    def overlappingApps = supported_databases.keySet().intersect(requested)
-
-    // If none overlap, fallback to all supported applications
-    def selectedApps = overlappingApps ?: supported_databases.keySet()
+    // Databases to report, given the user-requested applications
+    def selectedApps = uk.ac.ebi.interpro.InterProN.selectDatabases(applications)
 
     // Sequence lengths, used to discard positions past the end of a chunk
     def lengths = uk.ac.ebi.interpro.FastaFile.parse(fasta).collectEntries { id, seq ->
@@ -168,9 +144,9 @@ process PARSE_INTERPRO_N {
             def chunkEnd = Math.min(offset + max_length, seqLength)
             chunk.matches.each { match ->
                 def sigLib = match.signature.signatureLibraryRelease
-                def sigLibName = sigLib.library.toLowerCase().replaceAll(/[-\s]/, "")
-                if (sigLibName in selectedApps) {
-                    sigLib.library = supported_databases[sigLibName]
+                def label = uk.ac.ebi.interpro.InterProN.toLabel(sigLib.library)
+                if (label in selectedApps) {
+                    sigLib.library = uk.ac.ebi.interpro.InterProN.SUPPORTED_DATABASES[label]
                 } else {
                     return
                 }

--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -1,4 +1,16 @@
-def check_matches_api(applications, api_url, _version) {
+def is_appl_in_api(appl, api_appls, appl_config) {
+    if (uk.ac.ebi.interpro.SignalP.APPLICATIONS.contains(appl)) {
+        // A single "SignalP" analysis covers both organism variants, but the API
+        // only holds pre-calculated results for one mode
+        return api_appls.contains(
+                   uk.ac.ebi.interpro.InterProScan.normalizeName(uk.ac.ebi.interpro.SignalP.LIBRARY)
+               ) && appl_config[appl].mode == uk.ac.ebi.interpro.SignalP.API_MODE
+    }
+    return api_appls.contains(uk.ac.ebi.interpro.InterProScan.normalizeName(appl))
+}
+
+
+def check_matches_api(applications, appl_config, api_url, _version) {
     def appls_in_api     = []
     def appls_not_in_api = []
     def sanitized_url = uk.ac.ebi.interpro.HTTPRequest.sanitizeURL(api_url)
@@ -11,11 +23,11 @@ def check_matches_api(applications, api_url, _version) {
             log.warn "This version of InterProScan is not compatible with the Matches API at ${sanitized_url}; pre-calculated annotations will not be retrieved."
         } else {
             if (info.analyses) {
-                def all_appls_in_api = info.analyses*.name.collect { n -> 
-                    n.toLowerCase().replaceAll("[-\\s]", "") 
+                def all_appls_in_api = info.analyses*.name.collect { n ->
+                    uk.ac.ebi.interpro.InterProScan.normalizeName(n)
                 }
-                applications.each { appl -> 
-                    if (all_appls_in_api.contains(appl)) {
+                applications.each { appl ->
+                    if (is_appl_in_api(appl, all_appls_in_api, appl_config)) {
                         appls_in_api << appl
                     } else {
                         appls_not_in_api << appl
@@ -62,6 +74,10 @@ process GET_MATCHES {
     def request_chunk_size = chunk_size > 100 ? 100 : chunk_size // API set max to 100
     def chunks = md5s.collate(request_chunk_size)
     def base_url = uk.ac.ebi.interpro.HTTPRequest.sanitizeURL(api_url.toString())
+    // Databases to report InterPro-N matches for (null if InterPro-N was not requested)
+    def interpro_n_dbs = applications.contains("interpro_n")
+        ? uk.ac.ebi.interpro.InterProN.selectDatabases(applications)
+        : null
     def response = null
     def success = chunks.every { chunk ->
         def data = groovy.json.JsonOutput.toJson([md5: chunk])
@@ -76,11 +92,29 @@ process GET_MATCHES {
                 matches[seq_md5] = [:]
                 item.matches.each { match ->
                     def library = match.signature.signatureLibraryRelease.library
-                    def app_name = library.toLowerCase().replaceAll("[-\\s]", "")
-                    if (applications.contains(app_name)) {
-                        match = transformMatch(match, sequences[seq_md5])
-                        matches[seq_md5][match.modelAccession] = match
+                    def key
+                    if (match.source == "InterPro-N") {
+                        // InterPro-N matches report the member database as their library
+                        if (!interpro_n_dbs?.contains(uk.ac.ebi.interpro.InterProN.toLabel(library))) {
+                            return
+                        }
+                        // Use a namespaced key to avoid clashes with traditional applications
+                        key = "InterPro-N::${match.signature.accession}".toString()
+                    } else {
+                        def label
+                        if (library == uk.ac.ebi.interpro.SignalP.LIBRARY) {
+                            // One "SignalP" analysis covers both organism variants; the model
+                            // accession is what tells SignalP-Euk and SignalP-Prok apart
+                            label = uk.ac.ebi.interpro.SignalP.toLabel(match["model-ac"])
+                        } else {
+                            label = uk.ac.ebi.interpro.InterProScan.normalizeName(library)
+                        }
+                        if (!applications.contains(label)) {
+                            return
+                        }
+                        key = match["model-ac"]
                     }
+                    matches[seq_md5][key] = transformMatch(match, sequences[seq_md5])
                 }
             } else {
                 def seq = sequences[seq_md5]
@@ -113,7 +147,8 @@ process GET_MATCHES {
 
 def transformMatch(match, seq) {
     def transformedMatch = [:] + match
-    transformedMatch["modelAccession"] = match["model-ac"]
+    // InterPro-N matches have no model: fall back on the signature accession
+    transformedMatch["modelAccession"] = match["model-ac"] ?: match.signature?.accession
     transformedMatch["treegrafter"] = ["ancestralNodeID": match["ancestralNode"]]
     transformedMatch["locations"] = match["locations"].collect { loc ->
         def transformedLocation = [:] + loc

--- a/modules/lookup/main.nf
+++ b/modules/lookup/main.nf
@@ -1,7 +1,7 @@
 def is_appl_in_api(appl, api_appls, appl_config) {
     if (uk.ac.ebi.interpro.SignalP.APPLICATIONS.contains(appl)) {
-        // A single "SignalP" analysis covers both organism variants, but the API
-        // only holds pre-calculated results for one mode
+        // A single "SignalP" analysis covers both organism variants,
+        // but the API only holds pre-calculated results for one mode
         return api_appls.contains(
                    uk.ac.ebi.interpro.InterProScan.normalizeName(uk.ac.ebi.interpro.SignalP.LIBRARY)
                ) && appl_config[appl].mode == uk.ac.ebi.interpro.SignalP.API_MODE

--- a/modules/signalp/main.nf
+++ b/modules/signalp/main.nf
@@ -76,8 +76,8 @@ process PARSE_SIGNALP {
     def jsonPath = signalp_out.resolve("output.json")
     def jsonOutput = new groovy.json.JsonSlurper().parse(jsonPath)
 
-    def modelAcc = "SignalP_${mode}_${organism}"
-    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease("SignalP", "6.0i")
+    def modelAcc = uk.ac.ebi.interpro.SignalP.modelAccession(mode, organism)
+    def library = new uk.ac.ebi.interpro.SignatureLibraryRelease(uk.ac.ebi.interpro.SignalP.LIBRARY, "6.0i")
     def signatures = [
         "Sec/SPI"  : new uk.ac.ebi.interpro.Signature("SignalP-Sec-SPI", "Sec/SPI", "Sec signal peptide", "Region", library, null),
         "Sec/SPII" : new uk.ac.ebi.interpro.Signature("SignalP-Sec-SPII", "Sec/SPII", "Lipoprotein signal peptide", "Region", library, null),

--- a/subworkflows/lookup/main.nf
+++ b/subworkflows/lookup/main.nf
@@ -4,13 +4,14 @@ workflow LOOKUP {
     take:
     fasta                 // [meta, fasta]
     applications          // list[str]
+    appl_config           // map, contents of the conf/applications.config file
     matches_api_url       // str, url to matches api
     chunk_size            // int
     max_retries           // int
     interproscan_version  // str
 
     main:
-    def (in_api, not_in_api) = check_matches_api(applications, matches_api_url, interproscan_version)
+    def (in_api, not_in_api) = check_matches_api(applications, appl_config, matches_api_url, interproscan_version)
 
     GET_MATCHES(
         fasta,

--- a/workflows/interproscan.nf
+++ b/workflows/interproscan.nf
@@ -69,6 +69,7 @@ workflow INTERPROSCAN {
         LOOKUP(
             fasta,
             applications,
+            appl_config,
             matches_api_url,
             matches_api_chunk_size,
             matches_api_max_retries,


### PR DESCRIPTION
The staging Matches API (https://wwwdev.ebi.ac.uk/interpro/matches/api) now provides predicted matches from InterPro-N, TMbed, and SignalP (Euk + Prok).

Currently, InterPro-N, SignalP, and TMbed always run locally even in the input sequence is in the Matches API. With this PR, the matches, when available, are retrieved from the Matches API and the tools run locally on sequences not in UniParc (so not in the Matches API).

Example:

```bash
# Download and extract sequences from the human reference proteome (~20k sequences)
wget https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/reference_proteomes/Eukaryota/UP000005640/UP000005640_9606.fasta.gz
gzip -d UP000005640_9606.fasta.gz

nextflow run ebi-pf-team/interproscan6 \
  -r lookup-ml-hits \
  -profile singularity \
  -c <path-to-licensed-conf> \
  --input UP000005640_9606.fasta \
  --datadir <path-to-data-dir> \
  --interpro 110.0 \
  --skip-interpro-version-check \
  --matches-api-url https://wwwdev.ebi.ac.uk/interpro/matches/api \
  --applications signalp-euk,signalp-prok,tmbed,interpro-n
```

If using `-profile singularity,test` to use our small test FASTA file, most sequences will be skipped because their annotations are in the Matches API, but some aren't so they will be annotate locally.

> [!IMPORTANT]  
> `--interpro 110.0` is required as the staging Matches API has been built with InterPro 110.0 pre-release data. 
> `--skip-interpro-version-check` is required because InterPro 110.0 is not yet released. Additionally, you'll need the data files for InterPro 110.0, which aren't yet on the FTP. Let me know when you're ready to review this and I'll share the files with you.