### PR TITLE
Add dynamic label to DeepTMHMM

### DIFF
--- a/modules/deeptmhmm/main.nf
+++ b/modules/deeptmhmm/main.nf
@@ -1,6 +1,7 @@
 process RUN_DEEPTMHMM_CPU {
     label       'mem_high'
     label       'time_medium'
+    label       'dynamic'
     container   'interpro/deeptmhmm:1.0'
     stageInMode 'copy'
 
@@ -28,6 +29,7 @@ process RUN_DEEPTMHMM_GPU {
     label       'mem_high'
     label       'time_short'
     label       'use_gpu'
+    label       'dynamic'
     container   'interpro/deeptmhmm:1.0'
     stageInMode 'copy'
 


### PR DESCRIPTION
Currently, the `RUN_DEEPTMHMM_CPU` process always runs with one CPU, so using `--cpus XX` to assign more CPUs to individual tasks will not have any effect for DeepTMHMM. This PR adds the `dynamic` label to the process, improving DeepTMHMM performances.