### PR TITLE
Fix download DB

### DIFF
--- a/modules/download/main.nf
+++ b/modules/download/main.nf
@@ -70,7 +70,6 @@ process FIND_DATABASES {
     ready   = [] as Set
     missing = [] as Set
     seen    = [] as Set
-
     appls.each { appl_name ->
         if (appl_dirs.containsKey(appl_name)) {
             def normalised_name = appl_name.replaceAll(/[\s\-]+/, '').toLowerCase()

--- a/modules/download/main.nf
+++ b/modules/download/main.nf
@@ -78,7 +78,7 @@ process FIND_DATABASES {
             def appl_dir_parts = appl_dirs[normalised_name]
             def appl_dir = appl_dir_parts[0]
             def appl_subdir = appl_dir_parts[1]
-            def appl_fulldir = datadir.resolve("${appl_dir}/${appl_version}/${appl_subdir}")
+            def appl_fulldir = datadir.resolve("${appl_dir}/${appl_version}/${appl_subdir}".replaceAll(/\/+$/, ''))
             if (appl_fulldir.isDirectory()) {
                 log.info "[FIND_DATABASES] ${normalised_name}: READY -> ${appl_fulldir}"
                 ready.add( [ normalised_name, appl_fulldir ])

--- a/modules/download/main.nf
+++ b/modules/download/main.nf
@@ -21,13 +21,16 @@ process DOWNLOAD {
     } else {
         def base_url = use_globus ? uk.ac.ebi.interpro.InterProScan.GLOBUS_URL : uk.ac.ebi.interpro.InterProScan.FTP_URL
         """
-        curl -OJ ${base_url}/${iprscan_version}/${arcname}/${arcname}-${version}.tar.gz
-        curl -OJ ${base_url}/${iprscan_version}/${arcname}/${arcname}-${version}.tar.gz.md5
+        set -euo pipefail
+        curl -OJ ${base_url}/${iprscan_version}/${arcname}/${arcname}-${version}.tar.gz \
+            || { echo "Error: failed to download ${arcname}-${version}.tar.gz from ${base_url}" >&2; exit 1; }
+        curl -OJ ${base_url}/${iprscan_version}/${arcname}/${arcname}-${version}.tar.gz.md5 \
+            || { echo "Error: failed to download ${arcname}-${version}.tar.gz.md5 from ${base_url}" >&2; exit 1; }
         md5sum -c ${arcname}-${version}.tar.gz.md5 || { echo "Error: MD5 checksum failed" >&2; exit 1; }
         tar -C ${outdir} -zxf ${arcname}-${version}.tar.gz
         rm ${arcname}-${version}.tar.gz*
         chmod 777 -R ${outdir}/${arcname}
-        """        
+        """
     }
     
 }
@@ -68,6 +71,7 @@ process FIND_DATABASES {
     ready   = [] as Set
     missing = [] as Set
     seen    = [] as Set
+
     appls.each { appl_name ->
         if (appl_dirs.containsKey(appl_name)) {
             def normalised_name = appl_name.replaceAll(/[\s\-]+/, '').toLowerCase()
@@ -78,8 +82,10 @@ process FIND_DATABASES {
             def appl_subdir = appl_dir_parts[1]
             def appl_fulldir = datadir.resolve("${appl_dir}/${appl_version}/${appl_subdir}")
             if (appl_fulldir.isDirectory()) {
+                log.info "[FIND_DATABASES] ${normalised_name}: READY -> ${appl_fulldir}"
                 ready.add( [ normalised_name, appl_fulldir ])
             } else {
+                log.info "[FIND_DATABASES] ${normalised_name}: MISSING -> ${appl_fulldir} (will download)"
                 missing.add( [ 
                     normalised_name, 
                     appl_dir, 
@@ -89,6 +95,8 @@ process FIND_DATABASES {
                 ] )
                 seen.add( appl_dir )
             }
+        } else {
+            log.warn "[FIND_DATABASES] Application '${appl_name}' has no entry in appl_dirs, skipping."
         }
     }
 }

--- a/modules/download/main.nf
+++ b/modules/download/main.nf
@@ -2,7 +2,6 @@ process DOWNLOAD {
     maxForks  1
     label     'mem_min'
     label     'time_veryshort'
-    executor  'local'
     container 'interpro/download:1.0'
 
     input:

--- a/subworkflows/init/databases/main.nf
+++ b/subworkflows/init/databases/main.nf
@@ -44,7 +44,6 @@ workflow INIT_DATABASES {
     ch_ready = channel.empty()
     if (data_dir != null) {
         // At least one applications requires data files
-        
         // Handle applications with a common directory (cath -> CATH-Gene3 / CATH-FunFam, prosite -> PROSITE Patterns / PROSITE Profiles)
         appl_dirs = appl_configs
             .findAll { _k, v -> v.has_data == true }
@@ -107,7 +106,6 @@ workflow INIT_DATABASES {
     directories = ch_ready
     interpro_version
 }
-
 
 
 def extractMajorMinorVersion(String version) {

--- a/subworkflows/init/databases/main.nf
+++ b/subworkflows/init/databases/main.nf
@@ -25,17 +25,15 @@ workflow INIT_DATABASES {
         // }
 
         def versions = uk.ac.ebi.interpro.InterProScan.fetchCompatibleVersions(iprscan_maj_min_version, use_globus)
-        if (versions == null) {
-            if (!use_globus) {
+        if (versions == null && !use_globus) {
                 // Try again, but using Globus
                 versions = uk.ac.ebi.interpro.InterProScan.fetchCompatibleVersions(iprscan_maj_min_version, true)
             }
-
-            if (versions == null) {
-                log.error "InterProScan could not retrieve compatibility information for InterPro data versions. Try disabling the compatibility check with --skip-interpro-version-check."
-                exit 1
-            }
-        } else if (interpro_version == "latest") {
+        if (versions == null) {
+            log.error "InterProScan could not retrieve compatibility information for InterPro data versions. Try disabling the compatibility check with --skip-interpro-version-check."
+            exit 1
+        }
+        if (interpro_version == "latest") {
             interpro_version = versions[-1]
         } else if (!versions.contains(interpro_version)) {
             log.error "InterProScan ${iprscan_version} is not compatible with InterPro ${interpro_version} data. Compatible versions are: ${versions.join(', ')}."  // codenarc-disable-line JoinMismatchRule, JoinDuplicateRule
@@ -89,16 +87,15 @@ workflow INIT_DATABASES {
                 data_dir
             )
         }
-
         ch_ready = ch_ready.mix(ch_interpro)
         ch_ready = ch_ready.mix(FIND_DATABASES.out.ready.flatMap())
         ch_missing = FIND_DATABASES.out.missing.flatMap()
-    
+
         DOWNLOAD_DATABASE(
-            ch_missing,
-            iprscan_maj_min_version,
-            use_globus,
-            data_dir
+                ch_missing,
+                iprscan_maj_min_version,
+                use_globus,
+                data_dir
         )
 
         ch_ready = ch_ready.mix(DOWNLOAD_DATABASE.out)
@@ -110,6 +107,7 @@ workflow INIT_DATABASES {
     directories = ch_ready
     interpro_version
 }
+
 
 
 def extractMajorMinorVersion(String version) {


### PR DESCRIPTION
Relative to [Jira ticket](https://embl.atlassian.net/browse/IBU-12616).

The issue when running on cloud profiles was the `executor 'local'` on DOWNLOAD process, removing it already solve (because the executor is set in profile config). Plus a small fix was made in `appl_fulldir` (to remove a final '/') to avoid false positive READY when running on GCP.
Testing locally (docker), aws, gpc and slurm (singularity) it downloaded correctly the missing data.

IMPORTANT: I made another logic fix on subworkflow to make sure we will have the other verifications (in case of enter in `!use_globus` IF), check if you agree.

I remember we had some issue once because the folder was empty, what you think about to put an additional check to it?

Note: I kept some of the log infos that helped me to debug because I consider they useful.